### PR TITLE
feat: add emby detail url support

### DIFF
--- a/.github/workflows/fork_sync.yml
+++ b/.github/workflows/fork_sync.yml
@@ -1,0 +1,16 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: '*/30 * * * *' # every 30 minutes
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tgymnich/fork-sync@v1.4
+        with:
+          owner: Fallenbagel
+          base: master
+          head: master

--- a/.github/workflows/fork_sync.yml
+++ b/.github/workflows/fork_sync.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: tgymnich/fork-sync@v1.4
         with:
           owner: Fallenbagel
-          base: master
-          head: master
+          base: main
+          head: main

--- a/.github/workflows/fork_sync.yml
+++ b/.github/workflows/fork_sync.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: tgymnich/fork-sync@v1.4
         with:
+          token: ${{ secrets.PERSONAL_TOKEN }}
           owner: Fallenbagel
           base: main
           head: main

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -163,11 +163,12 @@ class Media {
         this.mediaUrl4k = `https://app.plex.tv/desktop#!/server/${settings.plex.machineId}/details?key=%2Flibrary%2Fmetadata%2F${this.ratingKey4k}`;
       }
     } else {
+      const pageName = process.env.JELLYFIN_TYPE === 'emby' ? 'item' : 'details';
       if (this.jellyfinMediaId) {
-        this.mediaUrl = `${settings.jellyfin.hostname}/web/index.html#!/details?id=${this.jellyfinMediaId}&context=home&serverId=${settings.jellyfin.serverId}`;
+        this.mediaUrl = `${settings.jellyfin.hostname}/web/index.html#!/${pageName}?id=${this.jellyfinMediaId}&context=home&serverId=${settings.jellyfin.serverId}`;
       }
       if (this.jellyfinMediaId4k) {
-        this.mediaUrl4k = `${settings.jellyfin.hostname}/web/index.html#!/details?id=${this.jellyfinMediaId4k}&context=home&serverId=${settings.jellyfin.serverId}`;
+        this.mediaUrl4k = `${settings.jellyfin.hostname}/web/index.html#!/${pageName}?id=${this.jellyfinMediaId4k}&context=home&serverId=${settings.jellyfin.serverId}`;
       }
     }
   }


### PR DESCRIPTION
#### Description
The emby format of media urls is <server_url>/web/index.html#!/item?id=xxx..., which is different from Jellyfin's <server_url>/web/index.html#!/details?id=xxx...

This PR add the support of media links for emby servers, via an enviroment variable JELLYFIN_TYPE=emby. It adds a alternative choice, and will not break anything of the current code base.