### PR TITLE
fix: fix for the jellyseerr out of date even though it is up-to-date

### DIFF
--- a/src/components/Layout/VersionStatus/index.tsx
+++ b/src/components/Layout/VersionStatus/index.tsx
@@ -1,6 +1,6 @@
 import {
   ArrowCircleUpIcon,
-  // BeakerIcon,
+  BeakerIcon,
   CodeIcon,
   ServerIcon,
 } from '@heroicons/react/outline';
@@ -36,7 +36,7 @@ const VersionStatus: React.FC<VersionStatusProps> = ({ onClick }) => {
     data.commitTag === 'local'
       ? 'Keep it up! 👍'
       : data.version.startsWith('develop-')
-      ? intl.formatMessage(messages.streamstable)
+      ? intl.formatMessage(messages.streamdevelop)
       : intl.formatMessage(messages.streamstable);
 
   return (
@@ -52,16 +52,14 @@ const VersionStatus: React.FC<VersionStatusProps> = ({ onClick }) => {
         tabIndex={0}
         className={`flex items-center p-2 mx-2 text-xs transition duration-300 rounded-lg ring-1 ring-gray-700 ${
           data.updateAvailable
-            ? // ? 'bg-yellow-500 text-white hover:bg-yellow-400'
-              'bg-gray-900 text-gray-300 hover:bg-gray-800'
+            ? 'bg-yellow-500 text-white hover:bg-yellow-400'
             : 'bg-gray-900 text-gray-300 hover:bg-gray-800'
         }`}
       >
         {data.commitTag === 'local' ? (
           <CodeIcon className="w-6 h-6" />
         ) : data.version.startsWith('develop-') ? (
-          // <BeakerIcon className="w-6 h-6" />
-          <CodeIcon className="w-6 h-6" />
+          <BeakerIcon className="w-6 h-6" />
         ) : (
           <ServerIcon className="w-6 h-6" />
         )}
@@ -74,8 +72,7 @@ const VersionStatus: React.FC<VersionStatusProps> = ({ onClick }) => {
               intl.formatMessage(messages.commitsbehind, {
                 commitsBehind: data.commitsBehind,
               })
-            ) : // ) : data.commitsBehind === -1 ? (
-            data.commitsBehind === 0 ? (
+            ) : data.commitsBehind === -1 ? (
               intl.formatMessage(messages.outofdate)
             ) : (
               <code className="p-0 bg-transparent">

--- a/src/components/Settings/SettingsAbout/index.tsx
+++ b/src/components/Settings/SettingsAbout/index.tsx
@@ -85,10 +85,10 @@ const SettingsAbout: React.FC = () => {
             title={intl.formatMessage(messages.version)}
             className="truncate"
           >
-            {/* <code>{data.version.replace('develop-', '')}</code> */}
+            <code>{data.version.replace('develop-', '')}</code>
             {status?.updateAvailable ? (
-              <Badge badgeType="success" className="ml-2">
-                {intl.formatMessage(messages.uptodate)}
+              <Badge badgeType="warning" className="ml-2">
+                {intl.formatMessage(messages.outofdate)}
               </Badge>
             ) : (
               status?.commitTag !== 'local' && (
@@ -115,12 +115,12 @@ const SettingsAbout: React.FC = () => {
         <List title={intl.formatMessage(messages.gettingsupport)}>
           <List.Item title={intl.formatMessage(messages.documentation)}>
             <a
-              href="https://github.com/Fallenbagel/jellyseerr/blob/main/README.md"
+              href="https://github.com/Fallenbagel/jellyseerr#readme"
               target="_blank"
               rel="noreferrer"
               className="text-indigo-500 hover:underline"
             >
-              https://github.com/Fallenbagel/jellyseerr/blob/main/README.md
+              https://github.com/Fallenbagel/jellyseerr#readme
             </a>
           </List.Item>
           <List.Item title={intl.formatMessage(messages.githubdiscussions)}>


### PR DESCRIPTION
Fix for the jellyseerr version being out of date even though it is up-to-date

#### Screenshot (if UI-related)
**Before fix**
Side-bar
![image](https://user-images.githubusercontent.com/98979876/163552084-95b8905e-4890-4824-b039-c50cc1b39dc3.png)
Settings-about page
![image](https://user-images.githubusercontent.com/98979876/163552143-40874d25-714b-49d7-a5b5-4aa46742cffc.png)

**After fix**
Side-bar
![image](https://user-images.githubusercontent.com/98979876/163553043-9bc8b770-a41e-4acd-aef2-252fd7d18939.png)
Settings-about page
![image](https://user-images.githubusercontent.com/98979876/163553105-ccfb6846-98ca-41b2-be6d-58d1d5664cd7.png)

#### Issues Fixed or Closed
Fix for the jellyseerr version being out of date even though it is up-to-date