### PR TITLE
fix: relax jellyfin url validation to allow local domains

### DIFF
--- a/src/components/Login/JellyfinLogin.tsx
+++ b/src/components/Login/JellyfinLogin.tsx
@@ -48,7 +48,10 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
   if (initial) {
     const LoginSchema = Yup.object().shape({
       host: Yup.string()
-        .url(intl.formatMessage(messages.validationhostformat))
+        .matches(
+          /^(?:(?:(?:https?):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/,
+          intl.formatMessage(messages.validationhostformat)
+        )
         .required(intl.formatMessage(messages.validationhostrequired)),
       email: Yup.string()
         .email(intl.formatMessage(messages.validationemailformat))


### PR DESCRIPTION
#### Description
Relaxes jellyfin url validation so that http://localhost:8096 and http://jellyfin:8096 urls are
accepted in addition to full urls like https://example.com

#### Issues Fixed or Closed
fix #31
