### PR TITLE
fix: fix usertype from local user to mediaServerType

### DIFF
--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -58,6 +58,7 @@ const messages = defineMessages({
   deleteconfirm:
     'Are you sure you want to delete this user? All of their request data will be permanently removed.',
   localuser: 'Local User',
+  mediaServerUser: '{mediaServerName} User',
   createlocaluser: 'Create Local User',
   creating: 'Creating…',
   create: 'Create',
@@ -636,7 +637,13 @@ const UserList: React.FC = () => {
                   </Badge>
                 ) : (
                   <Badge badgeType="default">
-                    {intl.formatMessage(messages.localuser)}
+                    {intl.formatMessage(messages.mediaServerUser, {
+                      mediaServerName:
+                        settings.currentSettings.mediaServerType ===
+                        MediaServerType.PLEX
+                          ? 'Plex'
+                          : 'Jellyfin',
+                    })}
                   </Badge>
                 )}
               </Table.TD>


### PR DESCRIPTION
#### Description
Fixes usertype from appearing as local user even if the mediaServerType is jellyfin

#### Screenshot (if UI-related)
Before
![1](https://user-images.githubusercontent.com/98979876/164120048-0009ae6a-7399-4522-bee4-c0f022cf5e82.png)

After
![unknown](https://user-images.githubusercontent.com/98979876/164120063-668ca924-858c-4a7a-b13b-01f532361422.png)