### PR TITLE
ci: adds GITHUB_TOKEN as an env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
         run: yarn
       - name: Release
         env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: npx semantic-release


### PR DESCRIPTION
adds GITHUB_TOKEN as an env to fix the github_token missing error during release workflow
