### PR TITLE
Fix non-square profile pictures being squished

### DIFF
--- a/src/components/IssueList/IssueItem/index.tsx
+++ b/src/components/IssueList/IssueItem/index.tsx
@@ -229,6 +229,7 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue }) => {
                             src={issue.createdBy.avatar}
                             alt=""
                             className="avatar-sm ml-1.5"
+                            style={{ objectFit: 'cover' }}
                           />
                           <span className="truncate text-sm font-semibold group-hover:text-white group-hover:underline">
                             {issue.createdBy.displayName}

--- a/src/components/Layout/UserDropdown/index.tsx
+++ b/src/components/Layout/UserDropdown/index.tsx
@@ -41,6 +41,7 @@ const UserDropdown: React.FC = () => {
         >
           <img
             className="h-8 w-8 rounded-full sm:h-10 sm:w-10"
+            style={{ objectFit: 'cover' }}
             src={user?.avatar}
             alt=""
           />

--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -232,6 +232,7 @@ const RequestCard: React.FC<RequestCardProps> = ({ request, onTitleData }) => {
                     src={requestData.requestedBy.avatar}
                     alt=""
                     className="avatar-sm"
+                    style={{ objectFit: 'cover' }}
                   />
                   <span className="truncate font-semibold group-hover:text-white group-hover:underline">
                     {requestData.requestedBy.displayName}

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -337,6 +337,7 @@ const RequestItem: React.FC<RequestItemProps> = ({
                               src={requestData.requestedBy.avatar}
                               alt=""
                               className="avatar-sm ml-1.5"
+                              style={{ objectFit: 'cover' }}
                             />
                             <span className="truncate text-sm font-semibold group-hover:text-white group-hover:underline">
                               {requestData.requestedBy.displayName}
@@ -391,6 +392,7 @@ const RequestItem: React.FC<RequestItemProps> = ({
                             src={requestData.modifiedBy.avatar}
                             alt=""
                             className="avatar-sm ml-1.5"
+                            style={{ objectFit: 'cover' }}
                           />
                           <span className="truncate text-sm font-semibold group-hover:text-white group-hover:underline">
                             {requestData.modifiedBy.displayName}


### PR DESCRIPTION
#### Description
Currently the aspect ratio of profile pictures in dropdown is not being preserved, resulting in pictures looking "squished". Adding `object-fit: cover;` to the image element fixes this ([caniuse.](https://caniuse.com/object-fit)). Please, help me find me another components where there is a profile picture so I can change it there too.

#### Screenshot (if UI-related)
Before:
![Before](https://user-images.githubusercontent.com/63553146/169824335-98d23250-de01-4ea4-91d7-c0aee618dbf1.png)

After:
![After](https://user-images.githubusercontent.com/63553146/169824432-2440f74b-e1ff-4b12-85c1-a444d8458d1c.png)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Find all other places where the profile picture is displayed and fix it there too

#### Issues Fixed or Closed

No prior issue
