### PR TITLE
fix(ui): fix Avatar being broken when setup using internal ip

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -213,6 +213,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       settings.jellyfin.hostname !== ''
         ? settings.jellyfin.hostname
         : body.hostname;
+    const { externalHostname } = getSettings().jellyfin;
 
     // Try to find deviceId that corresponds to jellyfin user, else generate a new one
     let user = await userRepository.findOne({
@@ -229,6 +230,10 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
     }
     // First we need to attempt to log the user in to jellyfin
     const jellyfinserver = new JellyfinAPI(hostname ?? '', undefined, deviceId);
+    const jellyfinHost =
+      externalHostname && externalHostname.length > 0
+        ? externalHostname
+        : hostname;
 
     const account = await jellyfinserver.login(body.username, body.password);
     // Next let's see if the user already exists
@@ -244,7 +249,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
 
       // Update the users avatar with their jellyfin profile pic (incase it changed)
       if (account.User.PrimaryImageTag) {
-        user.avatar = `${hostname}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`;
+        user.avatar = `${jellyfinHost}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`;
       } else {
         user.avatar = '/os_logo_square.png';
       }
@@ -290,7 +295,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
           jellyfinAuthToken: account.AccessToken,
           permissions: Permission.ADMIN,
           avatar: account.User.PrimaryImageTag
-            ? `${hostname}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`
+            ? `${jellyfinHost}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`
             : '/os_logo_square.png',
           userType: UserType.JELLYFIN,
         });
@@ -319,7 +324,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
           jellyfinAuthToken: account.AccessToken,
           permissions: settings.main.defaultPermissions,
           avatar: account.User.PrimaryImageTag
-            ? `${hostname}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`
+            ? `${jellyfinHost}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`
             : '/os_logo_square.png',
           userType: UserType.JELLYFIN,
         });

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -303,6 +303,11 @@ settingsRoutes.get('/jellyfin/library', async (req, res) => {
 
 settingsRoutes.get('/jellyfin/users', async (req, res) => {
   const settings = getSettings();
+  const { hostname, externalHostname } = getSettings().jellyfin;
+  const jellyfinHost =
+    externalHostname && externalHostname.length > 0
+      ? externalHostname
+      : hostname;
 
   const userRepository = getRepository(User);
   const admin = await userRepository.findOneOrFail({
@@ -321,7 +326,7 @@ settingsRoutes.get('/jellyfin/users', async (req, res) => {
     username: user.Name,
     id: user.Id,
     thumb: user.PrimaryImageTag
-      ? `${settings.jellyfin.hostname}/Users/${user.Id}/Images/Primary/?tag=${user.PrimaryImageTag}&quality=90`
+      ? `${jellyfinHost}/Users/${user.Id}/Images/Primary/?tag=${user.PrimaryImageTag}&quality=90`
       : '/os_logo_square.png',
     email: user.Name,
   }));

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -494,6 +494,11 @@ router.post(
 
       const jellyfinUsersResponse = await jellyfinClient.getUsers();
       const createdUsers: User[] = [];
+      const { hostname, externalHostname } = getSettings().jellyfin;
+      const jellyfinHost =
+        externalHostname && externalHostname.length > 0
+          ? externalHostname
+          : hostname;
       for (const account of jellyfinUsersResponse.users) {
         if (account.Name) {
           const user = await userRepository
@@ -505,7 +510,7 @@ router.post(
             .getOne();
 
           const avatar = account.PrimaryImageTag
-            ? `${settings.jellyfin.hostname}/Users/${account.Id}/Images/Primary/?tag=${account.PrimaryImageTag}&quality=90`
+            ? `${jellyfinHost}/Users/${account.Id}/Images/Primary/?tag=${account.PrimaryImageTag}&quality=90`
             : '/os_logo_square.png';
 
           if (user) {


### PR DESCRIPTION
#### Description
allow avatar url to use externalHostname when setup using local ip
#### Screenshot (if UI-related)
Before
![170353173-19deb8ee-501a-42a8-ae38-d8f6d0636b66](https://user-images.githubusercontent.com/98979876/170371317-ecfb7355-3732-451a-8f3e-30a1c40a7fb6.png)
![170370927-6ec5df2e-3915-46c1-8436-db7d4245f848](https://user-images.githubusercontent.com/98979876/170371443-2a9a76c1-8ea2-4c50-bffb-d547570f92c4.png)

Now
![image](https://user-images.githubusercontent.com/98979876/170370999-785fcb11-9312-435e-8cdc-ac2719e5a25b.png)
![url](https://user-images.githubusercontent.com/98979876/170371160-ee2efed1-89dc-4fda-94fa-810fc67ab7c4.png)


#### Issues Fixed or Closed
- Fixes #110
