### PR TITLE
fix: fixes jellyfin forgot password and adds emby support to the forgort password link

### DIFF
--- a/src/components/Login/JellyfinLogin.tsx
+++ b/src/components/Login/JellyfinLogin.tsx
@@ -266,8 +266,11 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
                           as="a"
                           buttonType="ghost"
                           href={
-                            settings.currentSettings.jellyfinHost +
-                            '/web/#!/forgotpassword.html'
+                            process.env.JELLYFIN_TYPE == 'emby'
+                              ? settings.currentSettings.jellyfinHost +
+                                '/web/index.html#!/startup/forgotpassword.html'
+                              : settings.currentSettings.jellyfinHost +
+                                '/web/index.html#!/forgotpassword.html'
                           }
                         >
                           {intl.formatMessage(messages.forgotpassword)}


### PR DESCRIPTION

#### Description
Fixes jellyfin forgot password as it had a wrong url that lead to an empty page and also adds in
emby forgot password link if the environmental variable is set

#### Issues Fixed or Closed
- Fixes #99 
