### PR TITLE
feat: Add Job to Remove old Requests

### DIFF
--- a/server/job/schedule.ts
+++ b/server/job/schedule.ts
@@ -1,6 +1,7 @@
 import schedule from 'node-schedule';
 import { MediaServerType } from '../constants/server';
 import downloadTracker from '../lib/downloadtracker';
+import requestCleanup from '../lib/requestCleanup';
 import { plexFullScanner, plexRecentScanner } from '../lib/scanners/plex';
 import { radarrScanner } from '../lib/scanners/radarr';
 import { sonarrScanner } from '../lib/scanners/sonarr';
@@ -152,6 +153,20 @@ export const startJobs = (): void => {
         label: 'Jobs',
       });
       downloadTracker.resetDownloadTracker();
+    }),
+  });
+
+  // Check for Available Requests to clear Every Minute
+  scheduledJobs.push({
+    id: 'request-cleanup',
+    name: 'Request Cleanup',
+    type: 'command',
+    interval: 'fixed',
+    job: schedule.scheduleJob(jobs['request-cleanup'].schedule, () => {
+      logger.debug('Starting scheduled job: Request Cleanup', {
+        label: 'Jobs',
+      });
+      requestCleanup.removeAvailable();
     }),
   });
 

--- a/server/lib/requestCleanup.ts
+++ b/server/lib/requestCleanup.ts
@@ -1,0 +1,63 @@
+import { getRepository } from 'typeorm';
+import { MediaRequestStatus, MediaStatus } from '../constants/media';
+import { MediaRequest } from '../entity/MediaRequest';
+import logger from '../logger';
+
+class requestCleanup {
+  public removeAvailable() {
+    this.removeAvailableRequests();
+  }
+
+  private async deleteRequest(requestId: any) {
+    const requestRepository = getRepository(MediaRequest);
+
+    try {
+      const request = await requestRepository.findOneOrFail({
+        where: { id: Number(requestId) },
+      });
+
+      await requestRepository.remove(request);
+    } catch (e) {
+      logger.error('Something went wrong deleting a request.', {
+        label: 'Jobs',
+        errorMessage: e.message,
+      });
+    }
+  }
+
+  private async removeAvailableRequests() {
+    const requestRepository = getRepository(MediaRequest);
+
+    try {
+      const query = requestRepository
+        .createQueryBuilder('request')
+        .leftJoinAndSelect('request.media', 'media');
+
+      const Requests = await query
+        .where('request.status = :requestStatus', {
+          requestStatus: MediaRequestStatus.APPROVED,
+        })
+        .andWhere(
+          '((request.is4k = false AND media.status = :availableStatus) OR (request.is4k = true AND media.status4k = :availableStatus))',
+          {
+            availableStatus: MediaStatus.AVAILABLE,
+          }
+        )
+        .andWhere("date(request.updatedAt,'+2 day') <= datetime('now')")
+        .getMany();
+
+      for (const request of Requests) {
+        this.deleteRequest(request.id);
+      }
+    } catch (error) {
+      logger.error('Something went wrong retrieving request counts', {
+        label: 'requestCleanup',
+        errorMessage: error.message,
+      });
+    }
+  }
+}
+
+const requestCleanupJob = new requestCleanup();
+
+export default requestCleanupJob;

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -259,6 +259,7 @@ export type JobId =
   | 'sonarr-scan'
   | 'download-sync'
   | 'download-sync-reset'
+  | 'request-cleanup'
   | 'jellyfin-recently-added-sync'
   | 'jellyfin-full-sync';
 
@@ -432,6 +433,9 @@ class Settings {
         },
         'download-sync-reset': {
           schedule: '0 0 1 * * *',
+        },
+        'request-cleanup': {
+          schedule: '0 * * * * *',
         },
         'jellyfin-recently-added-sync': {
           schedule: '0 */5 * * * *',

--- a/src/components/Settings/SettingsJobsCache/index.tsx
+++ b/src/components/Settings/SettingsJobsCache/index.tsx
@@ -57,6 +57,7 @@ const messages: { [messageName: string]: MessageDescriptor } = defineMessages({
   'sonarr-scan': 'Sonarr Scan',
   'download-sync': 'Download Sync',
   'download-sync-reset': 'Download Sync Reset',
+  'request-cleanup': 'Request Cleanup',
   editJobSchedule: 'Modify Job',
   jobScheduleEditSaved: 'Job edited successfully!',
   jobScheduleEditFailed: 'Something went wrong while saving the job.',


### PR DESCRIPTION
This Job Will run every minute to check for Requests marked as available that are older than 48 hours and then automatically remove them. This is kind of similar to the feature already present on Ombi.
 
#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
