### PR TITLE
fix: fix mediaServerType not set for Plex which leads to Plex users s…

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -70,6 +70,9 @@ authRoutes.post('/plex', async (req, res, next) => {
         userType: UserType.PLEX,
       });
 
+      settings.main.mediaServerType = MediaServerType.PLEX;
+      settings.save();
+
       await userRepository.save(user);
     } else {
       const mainUser = await userRepository.findOneOrFail({


### PR DESCRIPTION
#### Description

Plex mediaserver type isn't being set when setting up Jellyseerr with a Plex server and is being left as NOT_CONFIGURED.

This is leading to Jellyfin options being shown for Plex users.

This PR sets the mediaserver type to PLEX when the initial Plex Jellyseerr admin is being created. 


#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)
