### PR TITLE
fix(ui): fix translation errors for all locales in the import plex user button

### DIFF
--- a/src/i18n/locale/ca.json
+++ b/src/i18n/locale/ca.json
@@ -686,7 +686,7 @@
   "components.UserList.nouserstoimport": "No hi ha usuaris nous de Plex a importar.",
   "components.UserList.localuser": "Usuari local",
   "components.UserList.importfromplexerror": "S'ha produït un error en importar usuaris de Plex.",
-  "components.UserList.importfromplex": "Importeu usuaris de {mediaServerName}",
+  "components.UserList.importfromplex": "Importeu usuaris de Plex",
   "components.UserList.importedfromplex": "<strong>{userCount}</strong> {userCount, plural, one {usuari} other {usuaris}} de Plex importat correctament!",
   "components.TvDetails.watchtrailer": "Veure el tràiler",
   "components.TvDetails.viewfullcrew": "Mostreu equip complet",

--- a/src/i18n/locale/da.json
+++ b/src/i18n/locale/da.json
@@ -850,7 +850,7 @@
   "components.UserList.nouserstoimport": "Ingen nye brugere som kan importeres fra Plex.",
   "components.UserList.edituser": "Redigér Brugertilladelser",
   "components.UserList.email": "Email Adresse",
-  "components.UserList.importfromplex": "Importér Brugere fra {mediaServerName}",
+  "components.UserList.importfromplex": "Importér Brugere fra Plex",
   "components.UserList.owner": "Ejer",
   "components.UserList.password": "Kodeord",
   "components.UserList.passwordinfodescription": "Konfigurér en applikations-URL og aktivér emailnotifikationer for at tillade automatisk kodeordsgenerering.",

--- a/src/i18n/locale/de.json
+++ b/src/i18n/locale/de.json
@@ -223,7 +223,7 @@
   "components.Settings.SettingsAbout.Releases.latestversion": "Neuste",
   "components.Settings.SettingsAbout.Releases.currentversion": "Aktuell",
   "components.UserList.importfromplexerror": "Beim Importieren von Plex-Benutzern ist etwas schief gelaufen.",
-  "components.UserList.importfromplex": "{mediaServerName}-Benutzer importieren",
+  "components.UserList.importfromplex": "Plex-Benutzer importieren",
   "components.TvDetails.viewfullcrew": "Komplette Crew anzeigen",
   "components.TvDetails.TvCrew.fullseriescrew": "Komplette Serien-Crew",
   "components.PersonDetails.crewmember": "Crew",

--- a/src/i18n/locale/el.json
+++ b/src/i18n/locale/el.json
@@ -602,7 +602,7 @@
   "components.UserList.localuser": "Τοπικός χρήστης",
   "components.UserList.localLoginDisabled": "Η ρύθμιση <strong>Ενεργοποίηση τοπικής σύνδεσης</strong> είναι προς το παρόν απενεργοποιημένη.",
   "components.UserList.importfromplexerror": "Κάτι πήγε στραβά κατά την εισαγωγή χρηστών από το Plex.",
-  "components.UserList.importfromplex": "Εισαγωγή χρηστών από το {mediaServerName}",
+  "components.UserList.importfromplex": "Εισαγωγή χρηστών από το Plex",
   "components.UserList.importedfromplex": "{userCount, plural, one {# νέου χρήστη} other {#νέοι χρήστες}} εισήχθησαν απο το Plex επιτυχώς!",
   "components.UserList.email": "Διεύθυνση ηλεκτρονικού ταχυδρομείου",
   "components.UserList.edituser": "Επεξεργασία δικαιωμάτων χρήστη",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -861,7 +861,7 @@
   "components.UserList.edituser": "Edit User Permissions",
   "components.UserList.email": "Email Address",
   "components.UserList.importedfromplex": "<strong>{userCount}</strong> Plex {userCount, plural, one {user} other {users}} imported successfully!",
-  "components.UserList.importfromplex": "Import {mediaServerName} Users",
+  "components.UserList.importfromplex": "Import Plex Users",
   "components.UserList.importfromplexerror": "Something went wrong while importing Plex users.",
   "components.UserList.localLoginDisabled": "The <strong>Enable Local Sign-In</strong> setting is currently disabled.",
   "components.UserList.localuser": "Local User",

--- a/src/i18n/locale/es.json
+++ b/src/i18n/locale/es.json
@@ -223,7 +223,7 @@
   "components.Settings.SettingsAbout.Releases.currentversion": "Actual",
   "components.MovieDetails.studio": "{studioCount, plural, one {Estudio} other {Estudios}}",
   "components.UserList.importfromplexerror": "Algo salió mal importando usuarios de Plex.",
-  "components.UserList.importfromplex": "Importar Usuarios de {mediaServerName}",
+  "components.UserList.importfromplex": "Importar Usuarios de Plex",
   "components.UserList.importedfromplex": "¡{userCount, plural, one {# nuevo usuario} other {# nuevos usuarios}} importado/s de Plex con éxito!",
   "components.TvDetails.viewfullcrew": "Ver Equipo Completo",
   "components.TvDetails.firstAirDate": "Primera fecha de emisión",

--- a/src/i18n/locale/fr.json
+++ b/src/i18n/locale/fr.json
@@ -223,7 +223,7 @@
   "components.Settings.SettingsAbout.Releases.latestversion": "Dernière version",
   "components.Settings.SettingsAbout.Releases.currentversion": "Actuelle",
   "components.UserList.importfromplexerror": "Une erreur s'est produite durant l'importation des utilisateurs de Plex.",
-  "components.UserList.importfromplex": "Importer les utilisateurs de {mediaServerName}",
+  "components.UserList.importfromplex": "Importer les utilisateurs de Plex",
   "components.UserList.importedfromplex": "<strong>{userCount}</strong> {userCount, plural, one {utilisateur} other {utilisateurs}} importé(s) depuis Plex avec succès !",
   "components.TvDetails.viewfullcrew": "Voir l'équipe complète de la série",
   "components.TvDetails.TvCrew.fullseriescrew": "Équipe complète de la série",

--- a/src/i18n/locale/hu.json
+++ b/src/i18n/locale/hu.json
@@ -165,7 +165,7 @@
   "components.UserList.password": "Jelszó",
   "components.UserList.localuser": "Helyi felhasználó",
   "components.UserList.importfromplexerror": "Hiba történt a felhasználók Plex-ről történő importálása közben.",
-  "components.UserList.importfromplex": "Felhasználók importálása {mediaServerName}-ről",
+  "components.UserList.importfromplex": "Felhasználók importálása Plex-ről",
   "components.UserList.importedfromplex": "{userCount, plural, =0 {Nem lett új} one {# új} other {# új}} felhasználó importálva Plex-ről!",
   "components.UserList.email": "E-mail-cím",
   "components.UserList.deleteuser": "Felhasználó törlése",

--- a/src/i18n/locale/it.json
+++ b/src/i18n/locale/it.json
@@ -223,7 +223,7 @@
   "components.Settings.SettingsAbout.Releases.latestversion": "Versione più recente",
   "components.Settings.SettingsAbout.Releases.currentversion": "Versione attuale",
   "components.UserList.importfromplexerror": "Qualcosa è andato storto nell'importare gli utenti Plex.",
-  "components.UserList.importfromplex": "Importa utenti {mediaServerName}",
+  "components.UserList.importfromplex": "Importa utenti Plex",
   "components.UserList.importedfromplex": "<strong>{userCount}</strong> {userCount, plural, one {utente} other {utenti}} Plex {userCount, plural, one {importato} other {importati}} correttamente!",
   "components.TvDetails.viewfullcrew": "Vedi troupe completa",
   "components.TvDetails.TvCrew.fullseriescrew": "Troupe completa serie",

--- a/src/i18n/locale/ja.json
+++ b/src/i18n/locale/ja.json
@@ -231,7 +231,7 @@
   "components.TvDetails.watchtrailer": "予告編を見る",
   "components.MovieDetails.watchtrailer": "予告編を見る",
   "components.UserList.importfromplexerror": "Plexからユーザーをインポート中に問題が発生しました。",
-  "components.UserList.importfromplex": "{mediaServerName}からユーザーをインポート",
+  "components.UserList.importfromplex": "Plexからユーザーをインポート",
   "components.UserList.importedfromplex": "Plex から新ユーザー {userCount} 名をインポートしました。",
   "components.TvDetails.viewfullcrew": "フルクルーを表示",
   "components.TvDetails.firstAirDate": "初放送日",

--- a/src/i18n/locale/nb_NO.json
+++ b/src/i18n/locale/nb_NO.json
@@ -194,7 +194,7 @@
   "components.UserList.userssaved": "Brukertillatelsene ble lagret!",
   "components.UserList.users": "Brukere",
   "components.UserList.importfromplexerror": "Noe gikk galt ved importering av brukere fra Plex.",
-  "components.UserList.importfromplex": "Importer brukere fra {mediaServerName}",
+  "components.UserList.importfromplex": "Importer brukere fra Plex",
   "components.UserList.importedfromplex": "<strong>{userCount}</strong> {userCount, plural, one {ny bruker} other {nye brukere}} ble importert fra Plex!",
   "components.Settings.menuUsers": "Brukere",
   "components.Settings.SettingsUsers.users": "Brukere",

--- a/src/i18n/locale/nl.json
+++ b/src/i18n/locale/nl.json
@@ -214,7 +214,7 @@
   "components.UserList.userdeleteerror": "Er ging iets mis bij het verwijderen van de gebruiker.",
   "components.UserList.userdeleted": "Gebruiker succesvol verwijderd!",
   "components.UserList.importfromplexerror": "Er is iets misgegaan bij het importeren van Plex-gebruikers.",
-  "components.UserList.importfromplex": "{mediaServerName}-gebruikers importeren",
+  "components.UserList.importfromplex": "Plex-gebruikers importeren",
   "components.UserList.deleteuser": "Gebruiker verwijderen",
   "components.UserList.deleteconfirm": "Weet je zeker dat je deze gebruiker wilt verwijderen? Al hun bestaande aanvraaggegevens zullen worden verwijderd.",
   "components.TvDetails.watchtrailer": "Trailer bekijken",

--- a/src/i18n/locale/pl.json
+++ b/src/i18n/locale/pl.json
@@ -962,7 +962,7 @@
   "components.UserProfile.UserSettings.UserNotificationSettings.sendSilently": "Wyślij po cichu",
   "components.UserProfile.UserSettings.UserNotificationSettings.telegramsettingsfailed": "Nie udało się zapisać ustawień powiadomień telegram.",
   "components.UserProfile.UserSettings.UserNotificationSettings.discordIdTip": "<FindDiscordIdLink>Wielocyfrowy numer ID</FindDiscordIdLink> powiązany z Twoim kontem użytkownika",
-  "components.UserList.importfromplex": "Importuj użytkowników {mediaServerName}",
+  "components.UserList.importfromplex": "Importuj użytkowników Plex",
   "i18n.available": "Dostępny",
   "components.UserList.sortDisplayName": "Wyświetlana nazwa",
   "components.UserList.totalrequests": "Prośby",

--- a/src/i18n/locale/pt_BR.json
+++ b/src/i18n/locale/pt_BR.json
@@ -228,7 +228,7 @@
   "components.MovieDetails.viewfullcrew": "Ver Equipe Técnica Completa",
   "components.MovieDetails.MovieCrew.fullcrew": "Equipe Técnica Completa",
   "components.UserList.importfromplexerror": "Algo deu errado ao importar usuários do Plex.",
-  "components.UserList.importfromplex": "Importar Usuários do {mediaServerName}",
+  "components.UserList.importfromplex": "Importar Usuários do Plex",
   "components.UserList.importedfromplex": "<strong>{userCount}</strong> {userCount, plural, one {usuário Plex importado} other {usuários Plex importados}} com sucesso!",
   "components.Settings.Notifications.NotificationsSlack.agentenabled": "Habilitar Agente",
   "components.RequestList.RequestItem.failedretry": "Algo deu errado ao retentar fazer a solicitação.",

--- a/src/i18n/locale/pt_PT.json
+++ b/src/i18n/locale/pt_PT.json
@@ -199,7 +199,7 @@
   "components.UserList.passwordinfodescription": "Configurar um URL de aplicação e ativar as notificações por e-mail para permitir a geração automática de palavra-passe.",
   "components.UserList.localuser": "Utilizador Local",
   "components.UserList.importfromplexerror": "Ocorreu um erro ao importar utilizadores do Plex.",
-  "components.UserList.importfromplex": "Importar Utilizadores do {mediaServerName}",
+  "components.UserList.importfromplex": "Importar Utilizadores do Plex",
   "components.UserList.importedfromplex": "{userCount, plural, one {# novo utilizador} other {# novos utilizadores}} importados do Plex com sucesso!",
   "components.UserList.email": "Endereço de E-mail",
   "components.UserList.deleteuser": "Apagar Utilizador",

--- a/src/i18n/locale/ru.json
+++ b/src/i18n/locale/ru.json
@@ -793,7 +793,7 @@
   "components.UserList.usercreatedfailed": "Что-то пошло не так при создании пользователя.",
   "components.UserList.passwordinfodescription": "Настройте URL-адрес приложения и включите уведомления по электронной почте, чтобы обеспечить возможность автоматической генерации пароля.",
   "components.UserList.importfromplexerror": "Что-то пошло не так при импорте пользователей из Plex.",
-  "components.UserList.importfromplex": "Импортировать пользователей из {mediaServerName}",
+  "components.UserList.importfromplex": "Импортировать пользователей из Plex",
   "components.UserList.importedfromplex": "{userCount, plural, one {# новый пользователь} other {# новых пользователя(ей)}} успешно импортированы из Plex!",
   "components.UserList.edituser": "Изменить разрешения пользователя",
   "components.UserList.displayName": "Отображаемое имя",

--- a/src/i18n/locale/sq.json
+++ b/src/i18n/locale/sq.json
@@ -1006,7 +1006,7 @@
   "components.UserProfile.UserSettings.UserPermissions.toastSettingsFailure": "Diçka shkoi keq duke ruajtur cilësimet.",
   "components.Settings.webAppUrlTip": "Në mënyrë opsionale drejto përdoruesit në aplikacionin web në serverin tënd në vend të atij web",
   "components.TvDetails.episodeRuntimeMinutes": "{runtime} minuta",
-  "components.UserList.importfromplex": "Importoni përdoruesit {mediaServerName}",
+  "components.UserList.importfromplex": "Importoni përdoruesit Plex",
   "components.UserList.importfromplexerror": "Diçka shkoi keq duke importuar përdoruesit Plex.",
   "components.TvDetails.firstAirDate": "Data e parë e transmetimit",
   "components.UserList.email": "Adresa email",

--- a/src/i18n/locale/sv.json
+++ b/src/i18n/locale/sv.json
@@ -222,7 +222,7 @@
   "components.Settings.SettingsAbout.Releases.releasedataMissing": "Versionsdata är för närvarande inte tillgänglig.",
   "components.Settings.SettingsAbout.Releases.latestversion": "Senaste Versionen",
   "components.Settings.SettingsAbout.Releases.currentversion": "Aktuell",
-  "components.UserList.importfromplex": "Importera  {mediaServerName}användare",
+  "components.UserList.importfromplex": "Importera Plexanvändare",
   "components.UserList.importfromplexerror": "Något gick fel när Plexanvändare importerades.",
   "components.TvDetails.watchtrailer": "Kolla Trailer",
   "components.Settings.Notifications.allowselfsigned": "Tillåt Självsignerade Certifikat",

--- a/src/i18n/locale/zh_Hans.json
+++ b/src/i18n/locale/zh_Hans.json
@@ -24,7 +24,7 @@
   "components.UserList.localuser": "本地用户",
   "components.UserList.localLoginDisabled": "<strong>允许本地登录</strong>的设置目前被禁用。",
   "components.UserList.importfromplexerror": "导入 Plex 用户时出错。",
-  "components.UserList.importfromplex": "导入 {mediaServerName} 用户",
+  "components.UserList.importfromplex": "导入 Plex 用户",
   "components.UserList.importedfromplex": "<strong>{userCount}</strong> Plex {userCount, plural, one {user} other {users}} 成功导入！",
   "components.UserList.email": "电子邮件地址",
   "components.UserList.edituser": "编辑用户权限",

--- a/src/i18n/locale/zh_Hant.json
+++ b/src/i18n/locale/zh_Hant.json
@@ -52,7 +52,7 @@
   "components.Settings.radarrsettings": "Radarr 設定",
   "components.Settings.menuPlexSettings": "Plex",
   "components.UserList.importfromplexerror": "匯入 Plex 使用者時出了點問題。",
-  "components.UserList.importfromplex": "匯入 {mediaServerName} 使用者",
+  "components.UserList.importfromplex": "匯入 Plex 使用者",
   "components.UserList.importedfromplex": "匯入 <strong>{userCount}</strong> 個 Plex 使用者成功！",
   "components.UserList.localuser": "本地使用者",
   "components.UserList.creating": "創建中…",


### PR DESCRIPTION
#### Description
fix translation errors for all locales in the import plex user button as it currently shows as
{mediaServerName}

#### Screenshot (if UI-related)
After
![image](https://user-images.githubusercontent.com/98979876/172838508-3598b2b5-cf08-413b-a0a8-67262db95be1.png)
Before
![image](https://user-images.githubusercontent.com/98979876/172838668-0bdd0428-76c0-455d-92a3-ea913b985e7b.png)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)
