### PR TITLE
prevent Email Update on Jellyfin Import

### DIFF
--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -516,7 +516,7 @@ router.post(
           if (user) {
             // Update the user's avatar with their Jellyfin thumbnail, in case it changed
             user.avatar = avatar;
-            user.email = account.Name;
+            // user.email = account.Name;
             user.jellyfinUsername = account.Name;
 
             // In case the user was previously a local account


### PR DESCRIPTION
#### Description
With the implementation of the new Email Field, if an admin runs the Jellyfin Import and selects all users, the import overwrites the existing email fields for the users. This change removes the code to update the email field on any existing users. New users will still have the email field set to account.Name

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)
