### PR TITLE
fix(setup&login): fix a description error in the manual scan in setup and add emby to login page

### DIFF
--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -15,12 +15,13 @@ import PlexLoginButton from '../PlexLoginButton';
 import Transition from '../Transition';
 import JellyfinLogin from './JellyfinLogin';
 import LocalLogin from './LocalLogin';
+import getConfig from 'next/config';
 
 const messages = defineMessages({
   signin: 'Sign In',
   signinheader: 'Sign in to continue',
   signinwithplex: 'Use your Plex account',
-  signinwithjellyfin: 'Use your Jellyfin account',
+  signinwithjellyfin: 'Use your {mediaServerName} account',
   signinwithoverseerr: 'Use your {applicationTitle} account',
 });
 
@@ -32,6 +33,7 @@ const Login: React.FC = () => {
   const { user, revalidate } = useUser();
   const router = useRouter();
   const settings = useSettings();
+  const { publicRuntimeConfig } = getConfig();
 
   // Effect that is triggered when the `authToken` comes back from the Plex OAuth
   // We take the token and attempt to sign in. If we get a success message, we will
@@ -133,7 +135,12 @@ const Login: React.FC = () => {
                     {settings.currentSettings.mediaServerType ==
                     MediaServerType.PLEX
                       ? intl.formatMessage(messages.signinwithplex)
-                      : intl.formatMessage(messages.signinwithjellyfin)}
+                      : intl.formatMessage(messages.signinwithjellyfin, {
+                          mediaServerName:
+                            publicRuntimeConfig.JELLYFIN_TYPE == 'emby'
+                              ? 'Emby'
+                              : 'Jellyfin',
+                        })}
                   </button>
                   <AccordionContent isOpen={openIndexes.includes(0)}>
                     <div className="px-10 py-8">

--- a/src/components/Settings/SettingsJellyfin.tsx
+++ b/src/components/Settings/SettingsJellyfin.tsx
@@ -36,7 +36,7 @@ const messages = defineMessages({
   syncJellyfin: 'Sync Libraries',
   manualscanJellyfin: 'Manual Library Scan',
   manualscanDescriptionJellyfin:
-    "Normally, this will only be run once every 24 hours. {mediaServerName} will check your {mediaServerName} server's recently added more aggressively. If this is your first time configuring {mediaServerName}, a one-time full manual library scan is recommended!",
+    "Normally, this will only be run once every 24 hours. Jellyseerr will check your {mediaServerName} server's recently added more aggressively. If this is your first time configuring {mediaServerName}, a one-time full manual library scan is recommended!",
   notrunning: 'Not Running',
   currentlibrary: 'Current Library: {name}',
   librariesRemaining: 'Libraries Remaining: {count}',


### PR DESCRIPTION
#### Description
Manual scan in setup used to say "Jellyfin will scan your Jellyfin's server" and same with emby, so
replaced first jellyfin with jellyseerr. And also added emby to login page

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

