### PR TITLE
change email sender name to Jellyseerr on initial setup

### DIFF
--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -345,7 +345,7 @@ class Settings {
               ignoreTls: false,
               requireTls: false,
               allowSelfSigned: false,
-              senderName: 'Overseerr',
+              senderName: 'Jellyseerr',
             },
           },
           discord: {


### PR DESCRIPTION
#### Description

change default email sender name to Jellyseerr on initial setup

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [x] Database migration (if required)

#### Issues Fixed or Closed
