### PR TITLE
fix: start scheduled jobs on initial admin account setup

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -87,8 +87,18 @@ app
       new WebPushAgent(),
     ]);
 
-    // Start Jobs
-    startJobs();
+    const userRepository = getRepository(User);
+    const totalUsers = await userRepository.count();
+    if (totalUsers > 0) {
+      startJobs();
+    } else {
+      logger.info(
+        `Skipping starting the scheduled jobs as we have no Plex/Jellyfin/Emby servers setup yet`,
+        {
+          label: 'Server',
+        }
+      );
+    }
 
     const server = express();
     if (settings.main.trustProxy) {

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -5,6 +5,7 @@ import PlexTvAPI from '../api/plextv';
 import { MediaServerType } from '../constants/server';
 import { UserType } from '../constants/user';
 import { User } from '../entity/User';
+import { startJobs } from '../job/schedule';
 import { Permission } from '../lib/permissions';
 import { getSettings } from '../lib/settings';
 import logger from '../logger';
@@ -83,6 +84,7 @@ authRoutes.post('/plex', async (req, res, next) => {
 
       settings.main.mediaServerType = MediaServerType.PLEX;
       settings.save();
+      startJobs();
 
       await userRepository.save(user);
     } else {
@@ -320,6 +322,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
           settings.jellyfin.hostname = body.hostname ?? '';
           settings.jellyfin.serverId = account.User.ServerId;
           settings.save();
+          startJobs();
         }
       }
 


### PR DESCRIPTION
#### Description
Ensures scheduled jobs are started the first time the server setup.
Also delays starting scheduled jobs until a media server is setup.


#### Screenshot (if UI-related)
N/A

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #170
