### PR TITLE
Fix jellyfin external url basepath being ignored 

### DIFF
--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -200,10 +200,11 @@ class Media {
       const pageName =
         process.env.JELLYFIN_TYPE === 'emby' ? 'item' : 'details';
       const { serverId, hostname, externalHostname } = getSettings().jellyfin;
-      const jellyfinHost =
+      let jellyfinHost =
         externalHostname && externalHostname.length > 0
           ? externalHostname
           : hostname;
+      jellyfinHost = jellyfinHost.endsWith("/") ? jellyfinHost.slice(0, -1) : jellyfinHost;
       if (this.jellyfinMediaId) {
         this.mediaUrl = `${jellyfinHost}/web/index.html#!/${pageName}?id=${this.jellyfinMediaId}&context=home&serverId=${serverId}`;
       }

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -205,16 +205,10 @@ class Media {
           ? externalHostname
           : hostname;
       if (this.jellyfinMediaId) {
-        this.mediaUrl = new URL(
-          `/web/index.html#!/${pageName}?id=${this.jellyfinMediaId}&context=home&serverId=${serverId}`,
-          jellyfinHost
-        ).href;
+        this.mediaUrl = `${jellyfinHost}/web/index.html#!/${pageName}?id=${this.jellyfinMediaId}&context=home&serverId=${serverId}`;
       }
       if (this.jellyfinMediaId4k) {
-        this.mediaUrl4k = new URL(
-          `/web/index.html#!/${pageName}?id=${this.jellyfinMediaId4k}&context=home&serverId=${serverId}`,
-          jellyfinHost
-        ).href;
+        this.mediaUrl4k = `${jellyfinHost}/web/index.html#!/${pageName}?id=${this.jellyfinMediaId4k}&context=home&serverId=${serverId}`;
       }
     }
   }

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -204,12 +204,16 @@ class Media {
         externalHostname && externalHostname.length > 0
           ? externalHostname
           : hostname;
-      jellyfinHost = jellyfinHost.endsWith("/") ? jellyfinHost.slice(0, -1) : jellyfinHost;
+
+      jellyfinHost = jellyfinHost!.endsWith('/')
+        ? jellyfinHost!.slice(0, -1)
+        : jellyfinHost;
+
       if (this.jellyfinMediaId) {
         this.mediaUrl = `${jellyfinHost}/web/index.html#!/${pageName}?id=${this.jellyfinMediaId}&context=home&serverId=${serverId}`;
       }
       if (this.jellyfinMediaId4k) {
-        this.mediaUrl4k = `${jellyfinHost}/web/index.html#!/${pageName}?id=${this.jellyfinMediaId4k}&context=home&serverId=${serverId}`;
+        this.mediaUrl4k = `${jellyfinHost}/web/index.html#!/${pageName}?id=${this.jellyfinMediaId}&context=home&serverId=${serverId}`;
       }
     }
   }

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -245,10 +245,13 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
     // First we need to attempt to log the user in to jellyfin
     const jellyfinserver = new JellyfinAPI(hostname ?? '', undefined, deviceId);
     let jellyfinHost =
-    externalHostname && externalHostname.length > 0
-      ? externalHostname
-      : hostname;
-    jellyfinHost = jellyfinHost.endsWith("/") ? jellyfinHost.slice(0, -1) : jellyfinHost;
+      externalHostname && externalHostname.length > 0
+        ? externalHostname
+        : hostname;
+
+    jellyfinHost = jellyfinHost!.endsWith('/')
+      ? jellyfinHost!.slice(0, -1)
+      : jellyfinHost;
 
     const account = await jellyfinserver.login(body.username, body.password);
     // Next let's see if the user already exists

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -244,10 +244,11 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
     }
     // First we need to attempt to log the user in to jellyfin
     const jellyfinserver = new JellyfinAPI(hostname ?? '', undefined, deviceId);
-    const jellyfinHost =
-      externalHostname && externalHostname.length > 0
-        ? externalHostname
-        : hostname;
+    let jellyfinHost =
+    externalHostname && externalHostname.length > 0
+      ? externalHostname
+      : hostname;
+    jellyfinHost = jellyfinHost.endsWith("/") ? jellyfinHost.slice(0, -1) : jellyfinHost;
 
     const account = await jellyfinserver.login(body.username, body.password);
     // Next let's see if the user already exists

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -263,10 +263,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
 
       // Update the users avatar with their jellyfin profile pic (incase it changed)
       if (account.User.PrimaryImageTag) {
-        user.avatar = new URL(
-          `/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`,
-          jellyfinHost
-        ).href;
+        user.avatar = `${jellyfinHost}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`;
       } else {
         user.avatar = '/os_logo_square.png';
       }
@@ -312,10 +309,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
           jellyfinAuthToken: account.AccessToken,
           permissions: Permission.ADMIN,
           avatar: account.User.PrimaryImageTag
-            ? new URL(
-                `/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`,
-                jellyfinHost
-              ).href
+            ? `${jellyfinHost}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`
             : '/os_logo_square.png',
           userType: UserType.JELLYFIN,
         });
@@ -345,10 +339,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
           jellyfinAuthToken: account.AccessToken,
           permissions: settings.main.defaultPermissions,
           avatar: account.User.PrimaryImageTag
-            ? new URL(
-                `/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`,
-                jellyfinHost
-              ).href
+            ? `${jellyfinHost}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`
             : '/os_logo_square.png',
           userType: UserType.JELLYFIN,
         });

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -307,10 +307,11 @@ settingsRoutes.get('/jellyfin/library', async (req, res) => {
 settingsRoutes.get('/jellyfin/users', async (req, res) => {
   const settings = getSettings();
   const { hostname, externalHostname } = getSettings().jellyfin;
-  const jellyfinHost =
-    externalHostname && externalHostname.length > 0
-      ? externalHostname
-      : hostname;
+  let jellyfinHost =
+  externalHostname && externalHostname.length > 0
+    ? externalHostname
+    : hostname;
+  jellyfinHost = jellyfinHost.endsWith("/") ? jellyfinHost.slice(0, -1) : jellyfinHost;
 
   const userRepository = getRepository(User);
   const admin = await userRepository.findOneOrFail({

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -330,10 +330,7 @@ settingsRoutes.get('/jellyfin/users', async (req, res) => {
     username: user.Name,
     id: user.Id,
     thumb: user.PrimaryImageTag
-      ? new URL(
-          `/Users/${user.Id}/Images/Primary/?tag=${user.PrimaryImageTag}&quality=90`,
-          jellyfinHost
-        ).href
+      ? `${jellyfinHost}/Users/${user.Id}/Images/Primary/?tag=${user.PrimaryImageTag}&quality=90`
       : '/os_logo_square.png',
     email: user.Name,
   }));

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -308,11 +308,13 @@ settingsRoutes.get('/jellyfin/users', async (req, res) => {
   const settings = getSettings();
   const { hostname, externalHostname } = getSettings().jellyfin;
   let jellyfinHost =
-  externalHostname && externalHostname.length > 0
-    ? externalHostname
-    : hostname;
-  jellyfinHost = jellyfinHost.endsWith("/") ? jellyfinHost.slice(0, -1) : jellyfinHost;
+    externalHostname && externalHostname.length > 0
+      ? externalHostname
+      : hostname;
 
+  jellyfinHost = jellyfinHost!.endsWith('/')
+    ? jellyfinHost!.slice(0, -1)
+    : jellyfinHost;
   const userRepository = getRepository(User);
   const admin = await userRepository.findOneOrFail({
     select: ['id', 'jellyfinAuthToken', 'jellyfinDeviceId', 'jellyfinUserId'],

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -497,10 +497,11 @@ router.post(
       //const jellyfinUsersResponse = await jellyfinClient.getUsers();
       const createdUsers: User[] = [];
       const { hostname, externalHostname } = getSettings().jellyfin;
-      const jellyfinHost =
+      let jellyfinHost =
         externalHostname && externalHostname.length > 0
           ? externalHostname
           : hostname;
+      jellyfinHost = jellyfinHost.endsWith("/") ? jellyfinHost.slice(0, -1) : jellyfinHost;
 
       jellyfinClient.setUserId(admin.jellyfinUserId ?? '');
       const jellyfinUsers = await jellyfinClient.getUsers();

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -525,10 +525,7 @@ router.post(
             email: jellyfinUser?.Name,
             permissions: settings.main.defaultPermissions,
             avatar: jellyfinUser?.PrimaryImageTag
-              ? new URL(
-                  `/Users/${jellyfinUser.Id}/Images/Primary/?tag=${jellyfinUser.PrimaryImageTag}&quality=90`,
-                  jellyfinHost
-                ).href
+              ? `${jellyfinHost}/Users/${jellyfinUser.Id}/Images/Primary/?tag=${jellyfinUser.PrimaryImageTag}&quality=90`
               : '/os_logo_square.png',
             userType: UserType.JELLYFIN,
           });

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -501,8 +501,10 @@ router.post(
         externalHostname && externalHostname.length > 0
           ? externalHostname
           : hostname;
-      jellyfinHost = jellyfinHost.endsWith("/") ? jellyfinHost.slice(0, -1) : jellyfinHost;
 
+      jellyfinHost = jellyfinHost!.endsWith('/')
+        ? jellyfinHost!.slice(0, -1)
+        : jellyfinHost;
       jellyfinClient.setUserId(admin.jellyfinUserId ?? '');
       const jellyfinUsers = await jellyfinClient.getUsers();
 


### PR DESCRIPTION
#### Description
The previous PR introduced a new syntax which ignores external jellyfin base path's. I. e. http://localhost:4124/jellyfin.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #237
