### PR TITLE
fix: count combined episodes

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -38,6 +38,7 @@ export interface JellyfinLibraryItem {
   SeasonId?: string;
   SeasonName?: string;
   IndexNumber?: number;
+  IndexNumberEnd?: number;
   ParentIndexNumber?: number;
   MediaType: string;
 }

--- a/server/job/jellyfinsync/index.ts
+++ b/server/job/jellyfinsync/index.ts
@@ -257,8 +257,19 @@ class JobJellyfinSync {
               //use for loop to make sure this loop _completes_ in full
               //before the next section
               for (const episode of episodes) {
+                let episodeCount = 1;
+
+                // count number of combined episodes
+                if (
+                  episode.IndexNumber !== undefined &&
+                  episode.IndexNumberEnd !== undefined
+                ) {
+                  episodeCount =
+                    episode.IndexNumberEnd - episode.IndexNumber + 1;
+                }
+
                 if (!this.enable4kShow) {
-                  totalStandard++;
+                  totalStandard += episodeCount;
                 } else {
                   const ExtendedEpisodeData = await this.jfClient.getItemData(
                     episode.Id
@@ -268,10 +279,10 @@ class JobJellyfinSync {
                     return MediaSource.MediaStreams.some((MediaStream) => {
                       if (MediaStream.Type === 'Video') {
                         if (MediaStream.Width ?? 0 < 2000) {
-                          totalStandard++;
+                          totalStandard += episodeCount;
                         }
                       } else {
-                        total4k++;
+                        total4k += episodeCount;
                       }
                     });
                   });


### PR DESCRIPTION
### Description

Jellyfin allows combined episodes, like `S01E01-E02`, but seasons containing such episodes are only recognized as `Partially Available`. This PR should fix that by calculating the episode count using `IndexNumberEnd` and `IndexNumber`.

**Example File Name**: `Mr. Robot - S02E01-E02 - eps2.0unm4sk.tc.mkv`

### Screenshot (if UI-related)

**Before**
![image](https://user-images.githubusercontent.com/71837281/205466721-805fd725-2f9e-4745-a104-97c676e54735.png)

**After**
![image](https://user-images.githubusercontent.com/71837281/205466794-db33da03-473d-473b-bbd0-bf2dd0ff979c.png)

### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- ~Database migration (if required)~