### PR TITLE
feat(api): adds support for Mixed Libraries

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -177,7 +177,13 @@ class JellyfinAPI {
 
       const response: JellyfinLibrary[] = account.data.Items.filter(
         (Item: any) => {
-          return Item.Type === 'CollectionFolder';
+          return (
+            Item.Type === 'CollectionFolder' &&
+            Item.CollectionType !== 'music' &&
+            Item.CollectionType !== 'books' &&
+            Item.CollectionType !== 'musicvideos' &&
+            Item.CollectionType !== 'homevideos'
+          );
         }
       ).map((Item: any) => {
         return <JellyfinLibrary>{

--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -177,11 +177,7 @@ class JellyfinAPI {
 
       const response: JellyfinLibrary[] = account.data.Items.filter(
         (Item: any) => {
-          return (
-            Item.Type === 'CollectionFolder' &&
-            (Item.CollectionType === 'tvshows' ||
-              Item.CollectionType === 'movies')
-          );
+          return Item.Type === 'CollectionFolder';
         }
       ).map((Item: any) => {
         return <JellyfinLibrary>{
@@ -205,7 +201,7 @@ class JellyfinAPI {
   public async getLibraryContents(id: string): Promise<JellyfinLibraryItem[]> {
     try {
       const contents = await this.axios.get<any>(
-        `/Users/${this.userId}/Items?SortBy=SortName&SortOrder=Ascending&IncludeItemTypes=Series,Movie&Recursive=true&StartIndex=0&ParentId=${id}`
+        `/Users/${this.userId}/Items?SortBy=SortName&SortOrder=Ascending&IncludeItemTypes=Series,Movie,Others&Recursive=true&StartIndex=0&ParentId=${id}`
       );
 
       return contents.data.Items.filter(


### PR DESCRIPTION
#### Description
Adds support for mixed libraries with movies and show types which enables syncing from mixed libraries. This also fixes the bug (for some user) where if you have manually (and/or using automatic collections option within library) created `Collections` library, jellyfin not syncing. Now it syncs whether you have manual/automatic/tmdb box set plugin created Collections.

#### Screenshot (if UI-related)
_Jellyfin > Dashboard > Libraries_
<img src="https://user-images.githubusercontent.com/98979876/208090204-9e14b981-7791-422a-904e-a995f2cf2bd0.png" width="300" />

_Jellyseerr > Settings > Jellyfin_
<img src="https://user-images.githubusercontent.com/98979876/208090250-987d6299-ce13-4efd-9c88-f9f1f0a9c80d.png" width="300" />

_Both Movies & Series from the mixed library synced and available_
<img src="https://user-images.githubusercontent.com/98979876/208090268-209b1ebe-944d-4d93-93ef-163546587459.png" width="300" />
#### To-Dos

- [x] Successful build `yarn build`
~- [ ] Translation keys `yarn i18n:extract`~
~- [ ] Database migration (if required)~

#### Issues Fixed or Closed

- Fixes #95 
