### PR TITLE
chore(prettier): ignore CHANGELOG by prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 .next/
 dist/
 config/
+CHANGELOG.md
 
 # assets
 src/assets/


### PR DESCRIPTION
#### Description
When changelog is generated by semantic bot, it keeps failing the prettier format check. So this ignores it
