### PR TITLE
Unify naming in Docs and Web-GUI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -19,7 +19,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: What version of Overseerr are you running? (You can find this in Settings → About → Version.)
+      description: What version of Jellyseerr are you running? (You can find this in Settings → About → Version.)
     validations:
       required: true
   - type: textarea
@@ -87,5 +87,5 @@ body:
       label: Code of Conduct
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/fallenbagel/jellyseerr/blob/develop/CODE_OF_CONDUCT.md)
       options:
-        - label: I agree to follow Overseerr's Code of Conduct
+        - label: I agree to follow Jellyseerr's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Support via Discord
-    url: https://discord.gg/ckbvBtDJgC
-    about: Chat with other users and the Overseerr dev team
+    url: https://discord.com/invite/ckbvBtDJgC
+    about: Chat with other users and the Jellyseerr dev team
   - name: 💬 Support via GitHub Discussions
     url: https://github.com/fallenbagel/jellyseerr/discussions
     about: Ask questions and discuss with other community members

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -33,5 +33,5 @@ body:
       label: Code of Conduct
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/fallenbagel/jellyseerr/blob/develop/CODE_OF_CONDUCT.md)
       options:
-        - label: I agree to follow Overseerr's Code of Conduct
+        - label: I agree to follow Jellyseer's Code of Conduct
           required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ All help is welcome and greatly appreciated! If you would like to contribute to 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) the repository to your own GitHub account and [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device:
 
    ```bash
-   git clone https://github.com/YOUR_USERNAME/overseerr.git
-   cd overseerr/
+   git clone https://github.com/YOUR_USERNAME/jellyseerr.git
+   cd jellyseerr/
    ```
 
 2. Add the remote `upstream`:

--- a/cypress/config/settings.cypress.json
+++ b/cypress/config/settings.cypress.json
@@ -4,7 +4,7 @@
   "vapidPublic": "BK_EpP8NDm9waor2zn6_S28o3ZYv4kCkJOfYpO3pt3W6jnPmxrgTLANUBNbbyaNatPnSQ12De9CeqSYQrqWzHTs",
   "main": {
    "apiKey": "testkey",
-   "applicationTitle": "Overseerr",
+   "applicationTitle": "Jellyseerr",
    "applicationUrl": "",
    "csrfProtection": false,
    "cacheImages": false,
@@ -55,7 +55,7 @@
       "ignoreTls": false,
       "requireTls": false,
       "allowSelfSigned": false,
-      "senderName": "Overseerr"
+      "senderName": "Jellyseerr"
      }
     },
     "discord": {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -6,7 +6,7 @@ Cypress.Commands.add('login', (email, password) => {
     [email, password],
     () => {
       cy.visit('/login');
-      cy.contains('Use your Overseerr account').click();
+      cy.contains('Use your Jellyseerr account').click();
 
       cy.get('[data-testid=email]').type(email);
       cy.get('[data-testid=password]').type(password);

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,11 @@
 # Introduction
 
-Welcome to the Overseerr Documentation.
+Welcome to the Jellyseerr Documentation.
 
 ## Features
 
 - **Full Plex integration**. Login and manage user access with Plex.
+- **Full Jellyfin/Emby integration**. Login and manage user access with Jellyfin/Emby.
 - **Syncs to your Plex library** to show what titles you already have.
 - **Integrates with Sonarr and Radarr**. With more services to come in the future.
 - **Easy to use request system** allowing users to request individual seasons or movies in a friendly, clean UI.
@@ -15,10 +16,10 @@ Welcome to the Overseerr Documentation.
 
 ## Motivation
 
-The primary motivation for starting this project was to have an incredibly performant and easy to use application. There is a heavy focus on the user experience for both the server owner and the users. We feel requesting should be **effortless for the user**. Find the media you want, click request, and branch off efficiently into other titles that interest you, all in one seamless flow. For the server owner, Overseerr takes all the hassle out of approving your users' requests.
+The primary motivation for starting this project was to have an incredibly performant and easy to use application. There is a heavy focus on the user experience for both the server owner and the users. We feel requesting should be **effortless for the user**. Find the media you want, click request, and branch off efficiently into other titles that interest you, all in one seamless flow. For the server owner, Jellyseerr takes all the hassle out of approving your users' requests.
 
 ## We need your help!
 
-Overseerr is an ambitious project. We have already poured a lot of work into this, and have a lot more to do. We need your valuable feedback and help to find and fix bugs. Also, with Overseerr being an open-source project, anyone is welcome to contribute. Contribution includes building new features, patching bugs, translating the application, or even just writing documentation.
+Jellyseerr is an ambitious project. We have already poured a lot of work into this, and have a lot more to do. We need your valuable feedback and help to find and fix bugs. Also, with Jellyseerr being an open-source project, anyone is welcome to contribute. Contribution includes building new features, patching bugs, translating the application, or even just writing documentation.
 
 If you would like to contribute, please be sure to review our [contribution guidelines](https://github.com/fallenbagel/jellyseerr/blob/develop/CONTRIBUTING.md).

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,7 +6,7 @@
 
 - [Installation](getting-started/installation.md)
 
-## Using Overseerr
+## Using Jellyseerr
 
 - [Settings](using-overseerr/settings/README.md)
 - [Users](using-overseerr/users/README.md)
@@ -27,7 +27,7 @@
 - [Frequently Asked Questions (FAQ)](support/faq.md)
 - [Need Help?](support/need-help.md)
 
-## Extending Overseerr
+## Extending Jellyseerr
 
 - [Reverse Proxy](extending-overseerr/reverse-proxy.md)
 - [Fail2ban](extending-overseerr/fail2ban.md)

--- a/docs/extending-overseerr/fail2ban.md
+++ b/docs/extending-overseerr/fail2ban.md
@@ -1,10 +1,10 @@
 # Fail2ban Filter
 
 {% hint style="warning" %}
-If you are running Overseerr behind a reverse proxy, make sure that the **Enable Proxy Support** setting is **enabled**.
+If you are running Jellyseerr behind a reverse proxy, make sure that the **Enable Proxy Support** setting is **enabled**.
 {% endhint %}
 
-To use Fail2ban with Overseerr, create a new file named `overseerr.local` in your Fail2ban `filter.d` directory with the following filter definition:
+To use Fail2ban with Jellyseerr, create a new file named `jellyseerr.local` in your Fail2ban `filter.d` directory with the following filter definition:
 
 ```
 [Definition]

--- a/docs/extending-overseerr/reverse-proxy.md
+++ b/docs/extending-overseerr/reverse-proxy.md
@@ -1,7 +1,7 @@
 # Reverse Proxy
 
 {% hint style="warning" %}
-Base URLs cannot be configured in Overseerr. With this limitation, only subdomain configurations are supported.
+Base URLs cannot be configured in Jellyseerr. With this limitation, only subdomain configurations are supported.
 
 A Nginx subfolder workaround configuration is provided below, but it is not officially supported.
 {% endhint %}
@@ -15,16 +15,16 @@ A sample proxy configuration is included in [SWAG (Secure Web Application Gatewa
 
 However, this page is still the only source of truth, so the SWAG sample configuration is not guaranteed to be up-to-date. If you find an inconsistency, please [report it to the LinuxServer team](https://github.com/linuxserver/reverse-proxy-confs/issues/new) or [submit a pull request to update it](https://github.com/linuxserver/reverse-proxy-confs/pulls).
 
-To use the bundled configuration file, simply rename `overseerr.subdomain.conf.sample` in the `proxy-confs` folder to `overseerr.subdomain.conf`.
+To use the bundled configuration file, simply rename `jellyseerr.subdomain.conf.sample` in the `proxy-confs` folder to `jellyseerr.subdomain.conf`.
 
-Alternatively, you can create a new file `overseerr.subdomain.conf` in `proxy-confs` with the following configuration:
+Alternatively, you can create a new file `jellyseerr.subdomain.conf` in `proxy-confs` with the following configuration:
 
 ```nginx
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    server_name overseerr.*;
+    server_name jellyseerr.*;
 
     include /config/nginx/ssl.conf;
 
@@ -33,7 +33,7 @@ server {
     location / {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
-        set $upstream_app overseerr;
+        set $upstream_app jellyseerr;
         set $upstream_port 5055;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -50,9 +50,9 @@ Add a new proxy host with the following settings:
 
 ### Details
 
-- **Domain Names:** Your desired external Overseerr hostname; e.g., `overseerr.example.com`
+- **Domain Names:** Your desired external Jellyseerr hostname; e.g., `jellyseerr.example.com`
 - **Scheme:** `http`
-- **Forward Hostname / IP:** Internal Overseerr hostname or IP
+- **Forward Hostname / IP:** Internal Jellyseerr hostname or IP
 - **Forward Port:** `5055`
 - **Cache Assets:** yes
 - **Block Common Exploits:** yes
@@ -67,21 +67,21 @@ Add a new proxy host with the following settings:
 
 {% tab title="Subdomain" %}
 
-Add the following configuration to a new file `/etc/nginx/sites-available/overseerr.example.com.conf`:
+Add the following configuration to a new file `/etc/nginx/sites-available/jellyseerr.example.com.conf`:
 
 ```nginx
 server {
     listen 80;
-    server_name overseerr.example.com;
+    server_name jellyseerr.example.com;
     return 301 https://$server_name$request_uri;
 }
 
 server {
     listen 443 ssl http2;
-    server_name overseerr.example.com;
+    server_name jellyseerr.example.com;
 
-    ssl_certificate /etc/letsencrypt/live/overseerr.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/overseerr.example.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/jellyseerr.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/jellyseerr.example.com/privkey.pem;
 
     proxy_set_header Referer $http_referer;
     proxy_set_header Host $host;
@@ -103,7 +103,7 @@ server {
 Then, create a symlink to `/etc/nginx/sites-enabled`:
 
 ```bash
-sudo ln -s /etc/nginx/sites-available/overseerr.example.com.conf /etc/nginx/sites-enabled/overseerr.example.com.conf
+sudo ln -s /etc/nginx/sites-available/jellyseerr.example.com.conf /etc/nginx/sites-enabled/jellyseerr.example.com.conf
 ```
 
 {% endtab %}
@@ -111,19 +111,19 @@ sudo ln -s /etc/nginx/sites-available/overseerr.example.com.conf /etc/nginx/site
 {% tab title="Subfolder" %}
 
 {% hint style="warning" %}
-This Nginx subfolder reverse proxy is an unsupported workaround, and only provided as an example. The filters may stop working when Overseerr is updated.
+This Nginx subfolder reverse proxy is an unsupported workaround, and only provided as an example. The filters may stop working when Jellyseerr is updated.
 
-If you encounter any issues with Overseerr while using this workaround, we may ask you to try to reproduce the problem without the Nginx proxy.
+If you encounter any issues with Jellyseerr while using this workaround, we may ask you to try to reproduce the problem without the Nginx proxy.
 {% endhint %}
 
 Add the following location block to your existing `nginx.conf` file.
 
 ```nginx
-location ^~ /overseerr {
-    set $app 'overseerr';
+location ^~ /jellyseerr {
+    set $app 'jellyseerr';
 
-    # Remove /overseerr path to pass to the app
-    rewrite ^/overseerr/?(.*)$ /$1 break;
+    # Remove /jellyseerr path to pass to the app
+    rewrite ^/jellyseerr/?(.*)$ /$1 break;
     proxy_pass http://127.0.0.1:5055; # NO TRAILING SLASH
 
     # Redirect location headers
@@ -156,18 +156,18 @@ location ^~ /overseerr {
 
 ## Traefik (v2)
 
-Add the following labels to the Overseerr service in your `docker-compose.yml` file:
+Add the following labels to the Jellyseerr service in your `docker-compose.yml` file:
 
 ```text
 labels:
   - "traefik.enable=true"
   ## HTTP Routers
-  - "traefik.http.routers.overseerr-rtr.entrypoints=https"
-  - "traefik.http.routers.overseerr-rtr.rule=Host(`overseerr.domain.com`)"
-  - "traefik.http.routers.overseerr-rtr.tls=true"
+  - "traefik.http.routers.jellyseerr-rtr.entrypoints=https"
+  - "traefik.http.routers.jellyseerr-rtr.rule=Host(`jellyseerr.domain.com`)"
+  - "traefik.http.routers.jellyseerr-rtr.tls=true"
   ## HTTP Services
-  - "traefik.http.routers.overseerr-rtr.service=overseerr-svc"
-  - "traefik.http.services.overseerr-svc.loadbalancer.server.port=5055"
+  - "traefik.http.routers.jellyseerr-rtr.service=jellyseerr-svc"
+  - "traefik.http.services.jellyseerr-svc.loadbalancer.server.port=5055"
 ```
 
 For more information, please refer to the [Traefik documentation](https://doc.traefik.io/traefik/user-guides/docker-compose/basic-example/).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,17 +1,17 @@
 # Installation
 
 {% hint style="danger" %}
-**Overseerr is currently in BETA.** If you would like to help test the bleeding edge, please use the image **`fallenbagel/jellyseerr:develop`**!
+**Jellyseerr is currently in BETA.** If you would like to help test the bleeding edge, please use the image **`fallenbagel/jellyseerr:develop`**!
 {% endhint %}
 
 {% hint style="info" %}
-After running Overseerr for the first time, configure it by visiting the web UI at `http://[address]:5055` and completing the setup steps.
+After running Jellyseerr for the first time, configure it by visiting the web UI at `http://[address]:5055` and completing the setup steps.
 {% endhint %}
 
 ## Docker
 
 {% hint style="warning" %}
-Be sure to replace `/path/to/appdata/config` in the below examples with a valid host directory path. If this volume mount is not configured correctly, your Overseerr settings/data will not be persisted when the container is recreated (e.g., when updating the image or rebooting your machine).
+Be sure to replace `/path/to/appdata/config` in the below examples with a valid host directory path. If this volume mount is not configured correctly, your Jellyseerr settings/data will not be persisted when the container is recreated (e.g., when updating the image or rebooting your machine).
 
 The `TZ` environment variable value should also be set to the [TZ database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) of your time zone!
 {% endhint %}
@@ -25,7 +25,7 @@ For details on the Docker CLI, please [review the official `docker run` document
 
 ```bash
 docker run -d \
-  --name overseerr \
+  --name jellyseerr \
   -e LOG_LEVEL=debug \
   -e TZ=Asia/Tokyo \
   -e PORT=5055 `#optional` \
@@ -42,7 +42,7 @@ To run the container as a specific user/group, you may optionally add `--user=[ 
 Stop and remove the existing container:
 
 ```bash
-docker stop overseerr && docker rm overseerr
+docker stop jellyseerr && docker rm jellyseerr
 ```
 
 Pull the latest image:
@@ -58,7 +58,7 @@ docker run -d ...
 ```
 
 {% hint style="info" %}
-You may alternatively use a third-party updating mechanism, such as [Watchtower](https://github.com/containrrr/watchtower) or [Ouroboros](https://github.com/pyouroboros/ouroboros), to keep Overseerr up-to-date automatically.
+You may alternatively use a third-party updating mechanism, such as [Watchtower](https://github.com/containrrr/watchtower) or [Ouroboros](https://github.com/pyouroboros/ouroboros), to keep Jellyseerr up-to-date automatically.
 {% endhint %}
 
 {% endtab %}
@@ -69,16 +69,16 @@ For details on how to use Docker Compose, please [review the official Compose do
 
 **Installation:**
 
-Define the `overseerr` service in your `docker-compose.yml` as follows:
+Define the `jellyseerr` service in your `docker-compose.yml` as follows:
 
 ```yaml
 ---
 version: '3'
 
 services:
-  overseerr:
+  jellyseerr:
     image: fallenbagel/jellyseerr:latest
-    container_name: overseerr
+    container_name: jellyseerr
     environment:
       - LOG_LEVEL=debug
       - TZ=Asia/Tokyo
@@ -101,7 +101,7 @@ docker-compose up -d
 Pull the latest image:
 
 ```bash
-docker-compose pull overseerr
+docker-compose pull jellyseerr
 ```
 
 Then, restart all services defined in the Compose file:
@@ -116,10 +116,10 @@ docker-compose up -d
 ## Unraid
 
 1. Ensure you have the **Community Applications** plugin installed.
-2. Inside the **Community Applications** app store, search for **Overseerr**.
+2. Inside the **Community Applications** app store, search for **Jellyseerr**.
 3. Click the **Install Button**.
 4. On the following **Add Container** screen, make changes to the **Host Port** and **Host Path 1**\(Appdata\) as needed.
-5. Click apply and access "Overseerr" at your `<ServerIP:HostPort>` in a web browser.
+5. Click apply and access "Jellyseerr" at your `<ServerIP:HostPort>` in a web browser.
 
 ## Windows
 
@@ -129,10 +129,10 @@ Please refer to the [Docker Desktop for Windows user manual](https://docs.docker
 **WSL2 will need to be installed to prevent DB corruption!** Please see the [Docker Desktop WSL 2 backend documentation](https://docs.docker.com/docker-for-windows/wsl/) for instructions on how to enable WSL2. The commands below will only work with WSL2 installed!
 {% endhint %}
 
-First, create a volume to store the configuration data for Overseerr using using either the Docker CLI:
+First, create a volume to store the configuration data for Jellyseerr using using either the Docker CLI:
 
 ```bash
-docker volume create overseerr-data
+docker volume create jellyseerr-data
 ```
 
 or the Docker Desktop app:
@@ -140,15 +140,15 @@ or the Docker Desktop app:
 1. Open the Docker Desktop app
 2. Head to the Volumes tab
 3. Click on the "New Volume" button near the top right
-4. Enter a name for the volume (example: `overseerr-data`) and hit "Create"
+4. Enter a name for the volume (example: `jellyseerr-data`) and hit "Create"
 
-Then, create and start the Overseerr container:
+Then, create and start the Jellyseerr container:
 
 ```bash
-docker run -d --name overseerr -e LOG_LEVEL=debug -e TZ=Asia/Tokyo -p 5055:5055 -v "overseerr-data:/app/config" --restart unless-stopped fallenbagel/jellyseerr:latest
+docker run -d --name jellyseerr -e LOG_LEVEL=debug -e TZ=Asia/Tokyo -p 5055:5055 -v "jellyseerr-data:/app/config" --restart unless-stopped fallenbagel/jellyseerr:latest
 ```
 
-To access the files inside the volume created above, navigate to `\\wsl$\docker-desktop-data\version-pack-data\community\docker\volumes\overseerr-data\_data` using File Explorer.
+To access the files inside the volume created above, navigate to `\\wsl$\docker-desktop-data\version-pack-data\community\docker\volumes\jellyseerr-data\_data` using File Explorer.
 
 {% hint style="info" %}
 Docker on Windows works differently than it does on Linux; it runs Docker inside of a stripped-down Linux VM. Volume mounts are exposed to Docker inside this VM via SMB mounts. While this is fine for media, it is unacceptable for the `/app/config` directory because SMB does not support file locking. This will eventually corrupt your database, which can lead to slow behavior and crashes.

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -8,37 +8,37 @@ _Please do not post questions or support requests on the GitHub issue tracker!_
 
 ## General
 
-### How do I keep Overseerr up-to-date?
+### How do I keep Jellyseerr up-to-date?
 
-Use a third-party update mechanism (such as [Watchtower](https://github.com/containrrr/watchtower), [Ouroboros](https://github.com/pyouroboros/ouroboros), or [Pullio](https://hotio.dev/pullio)) to keep Overseerr up-to-date automatically.
+Use a third-party update mechanism (such as [Watchtower](https://github.com/containrrr/watchtower), [Ouroboros](https://github.com/pyouroboros/ouroboros), or [Pullio](https://hotio.dev/pullio)) to keep Jellyseerr up-to-date automatically.
 
-### How can I access Overseerr outside of my home network?
+### How can I access Jellyseerr outside of my home network?
 
-The easiest but least secure method is to simply forward an external port (e.g., `5055`) on your router to the internal port used by Overseerr (default is TCP `5055`). Visit [Port Forward](http://portforward.com/) for instructions for your particular router. You would then be able to access Overseerr via `http://EXTERNAL-IP-ADDRESS:5055`.
+The easiest but least secure method is to simply forward an external port (e.g., `5055`) on your router to the internal port used by Jellyseerr (default is TCP `5055`). Visit [Port Forward](http://portforward.com/) for instructions for your particular router. You would then be able to access Jellyseerr via `http://EXTERNAL-IP-ADDRESS:5055`.
 
-A more advanced, user-friendly, and secure (if using SSL) method is to set up a web server and use a reverse proxy to access Overseerr. Please refer to our [reverse proxy examples](../extending-overseerr/reverse-proxy.md) for more information.
+A more advanced, user-friendly, and secure (if using SSL) method is to set up a web server and use a reverse proxy to access Jellyseerr. Please refer to our [reverse proxy examples](../extending-overseerr/reverse-proxy.md) for more information.
 
-The most secure method (but also the most inconvenient method) is to set up a VPN tunnel to your home server. You would then be able to access Overseerr as if you were on your local network, via `http://LOCAL-IP-ADDRESS:5055`.
+The most secure method (but also the most inconvenient method) is to set up a VPN tunnel to your home server. You would then be able to access Jellyseerr as if you were on your local network, via `http://LOCAL-IP-ADDRESS:5055`.
 
-### Are there mobile apps for Overseerr?
+### Are there mobile apps for Jellyseerr?
 
-Since Overseerr has an almost native app experience when installed as a Progressive Web App (PWA), there are no plans to develop mobile apps for Overseerr.
+Since Jellyseerr has an almost native app experience when installed as a Progressive Web App (PWA), there are no plans to develop mobile apps for Jellyseerr.
 
-Out of the box, Overseerr already fulfills most of the [PWA install criteria](https://web.dev/install-criteria/). You simply need to make sure that your Overseerr instance is being served over HTTPS (e.g., via a [reverse proxy](../extending-overseerr/reverse-proxy.md)).
+Out of the box, Jellyseerr already fulfills most of the [PWA install criteria](https://web.dev/install-criteria/). You simply need to make sure that your Jellyseerr instance is being served over HTTPS (e.g., via a [reverse proxy](../extending-overseerr/reverse-proxy.md)).
 
-### Overseerr is amazing! But it is not translated in my language yet! Can I help with translations?
+### Jellyseerr is amazing! But it is not translated in my language yet! Can I help with translations?
 
 You sure can! We are using [Weblate](https://hosted.weblate.org/engage/overseerr/) for translations. If your language is not listed, please [open a feature request on GitHub](https://github.com/sct/overseerr/issues/new/choose).
 
 ### Where can I find the changelog?
 
-You can find the changelog for your version (stable/`latest`,s or `develop`) in the **Settings &rarr; About** page in your Overseerr instance.
+You can find the changelog for your version (stable/`latest`,s or `develop`) in the **Settings &rarr; About** page in your Jellyseerr instance.
 
 You can alternatively review the [stable release history](https://github.com/fallenbagel/jellyseerr/releases) and [`develop` branch commit history](https://github.com/fallenbagel/jellyseerr/commits/develop) on GitHub.
 
-### Some media is missing from Overseerr that I know is in Plex!
+### Some media is missing from Jellyseerr that I know is in Plex!
 
-Overseerr currently supports the following agents:
+Jellyseerr currently supports the following agents:
 
 - New Plex Movie
 - Legacy Plex Movie
@@ -54,15 +54,15 @@ When changing agents, a full metadata refresh of your Plex library is required. 
 
 #### Troubleshooting Steps
 
-First, check the Overseerr logs for media items that are missing. The logs will contain an error as to why that item could not be matched.
+First, check the Jellyseerr logs for media items that are missing. The logs will contain an error as to why that item could not be matched.
 
 1. Verify that you are using one of the agents mentioned above.
 2. Refresh the metadata for just that item.
-3. Run a full scan in Overseerr to see if that item is now matched properly.
-4. If the item is now seen by Overseerr then repeat step 2 for each missing item. If you have a large amount of items missing then a full metadata refresh is recommended for that library.
-5. Run a full scan on Overseerr after refreshing all unmatched items.
+3. Run a full scan in Jellyseerr to see if that item is now matched properly.
+4. If the item is now seen by Jellyseerr then repeat step 2 for each missing item. If you have a large amount of items missing then a full metadata refresh is recommended for that library.
+5. Run a full scan on Jellyseerr after refreshing all unmatched items.
 
-You can also perform the following to verify the media item has a GUID Overseerr can match:
+You can also perform the following to verify the media item has a GUID Jellyseerr can match:
 
 1. Go to the media item in Plex and **"Get info"** and click on **"View XML"**.
 2. Verify that the media item's GUID follows one of the below formats:
@@ -82,11 +82,11 @@ Please see [these instructions on how to locate and share your logs](./need-help
 
 Please see the [documentation for importing users from Plex](../using-overseerr/users/README.md#importing-users-from-plex).
 
-### Can I create local users in Overseerr?
+### Can I create local users in Jellyseerr?
 
 Yes! Please see the [documentation for creating local users](../using-overseerr/users/README.md#creating-local-users).
 
-### Is is possible to set user roles in Overseerr?
+### Is is possible to set user roles in Jellyseerr?
 
 Permissions can be configured for each user via the **User List** or their **User Settings** page. The list of assignable permissions is still growing, so if you have any suggestions, [submit a feature request](https://github.com/fallenbagel/jellyseerr/issues/new/choose)!
 
@@ -94,7 +94,7 @@ Permissions can be configured for each user via the **User List** or their **Use
 
 ### I receive 409 or 400 errors when requesting a movie or TV series!
 
-Verify you are running v3 of both Radarr and Sonarr. Overseerr is not backwards-compatible with previous versions.
+Verify you are running v3 of both Radarr and Sonarr. Jellyseerr is not backwards-compatible with previous versions.
 
 ### Can I allow users to submit 4K requests?
 
@@ -110,7 +110,7 @@ Check the minimum availability setting in your Radarr server. If a movie does no
 
 ### Help! My request still shows "requested" even though it is in Plex!
 
-See "[Some media is missing from Overseerr that I know is in Plex!](#some-media-is-missing-from-overseerr-that-i-know-is-in-plex)" for troubleshooting steps.
+See "[Some media is missing from Jellyseerr that I know is in Plex!](#some-media-is-missing-from-overseerr-that-i-know-is-in-plex)" for troubleshooting steps.
 
 ### Series requests keep failing!
 
@@ -128,6 +128,6 @@ If you have 2-Step Verification enabled on your account, you will need to create
 
 ### The logo image in email notifications is broken!
 
-This may be an issue with how you are proxying your Overseerr instance. A good first troubleshooting step is to verify that the [`Content-Security-Policy` HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) being set by your proxy (if any) is configured appropriately to allow external embedding of the image.
+This may be an issue with how you are proxying your Jellyseerr instance. A good first troubleshooting step is to verify that the [`Content-Security-Policy` HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) being set by your proxy (if any) is configured appropriately to allow external embedding of the image.
 
 For Gmail users, another possible issue is that Google's image URL proxy is being blocked from fetching the image. If using Cloudflare, overzealous firewall rules could be the culprit.

--- a/docs/support/need-help.md
+++ b/docs/support/need-help.md
@@ -2,8 +2,8 @@
 
 Before seeking assistance, please make sure you have first tried these following:
 
-- **Updating** Overseerr to the latest version.
-- **Stopping and restarting** Overseerr.
+- **Updating** Jellyseerr to the latest version.
+- **Stopping and restarting** Jellyseerr.
 - **Restarting** your machine.
 - **Clearing** your browser cache.
 - **Analyzing** your logs, you just might find the solution yourself!
@@ -19,10 +19,10 @@ Please try to include as much information as possible. A vague statement like "i
 
 Try to answer the following questions:
 
-- What version of Overseerr are you running? (You can find this in Settings → About → Version.)
-- How did you install Overseerr? Are you using the official Docker or snap images, or images published by a third-party?
-- How are you accessing Overseerr?
-  - Are you accessing Overseerr through your reverse proxy or via a local IP address?
+- What version of Jellyseerr are you running? (You can find this in Settings → About → Version.)
+- How did you install Jellyseerr? Are you using the official Docker or snap images, or images published by a third-party?
+- How are you accessing Jellyseerr?
+  - Are you accessing Jellyseerr through your reverse proxy or via a local IP address?
   - What browser are you using? What browser extensions are enabled?
 - What were you trying to do, and how did you attempt it?
   - What command did you enter?
@@ -36,10 +36,10 @@ Try to answer the following questions:
   - Did something not happen?
   - Are there any error messages showing?
   - Provide screenshots to help us see what you are seeing.
-  - Share your Overseerr logs, which show exactly what happened and are often critical for identifying issues (see [How can I share my logs?](#how-can-i-share-my-logs) below).
+  - Share your Jellyseerr logs, which show exactly what happened and are often critical for identifying issues (see [How can I share my logs?](#how-can-i-share-my-logs) below).
 
 ## How can I share my logs?
 
-1. Locate the current log file at `<your Overseerr config directory>/logs/overseerr.log`.
+1. Locate the current log file at `<your Jellyseerr config directory>/logs/overseerr.log`.
 2. Open the log file and **copy its contents** into a [**secret gist** on GitHub](https://gist.github.com/). If you upload your logs elsewhere, we may ask you to share them again via GitHub Gist.
 3. **Share the link/URL to your secret gist** in the [`#support` channel in our Discord server](https://discord.gg/ckbvBtDJgC).

--- a/docs/using-overseerr/notifications/README.md
+++ b/docs/using-overseerr/notifications/README.md
@@ -2,7 +2,7 @@
 
 ## Supported Notification Agents
 
-Overseerr currently supports the following notification agents:
+Jellyseerr currently supports the following notification agents:
 
 - [Email](./email.md)
 - [Web Push](./webpush.md)
@@ -23,4 +23,4 @@ Users can customize their personal notification preferences in their own user no
 
 ## Requesting New Notification Agents
 
-If we do not currently support your preferred notification agent, feel free to [submit a feature request on GitHub](https://github.com/sct/overseerr/issues). However, please be sure to search first and confirm that there is not already an existing request for the agent!
+If we do not currently support your preferred notification agent, feel free to [submit a feature request on GitHub](https://github.com/Fallenbagel/jellyseerr/issues). However, please be sure to search first and confirm that there is not already an existing request for the agent!

--- a/docs/using-overseerr/notifications/email.md
+++ b/docs/using-overseerr/notifications/email.md
@@ -3,12 +3,12 @@
 ## Configuration
 
 {% hint style="info" %}
-If the [Application URL](../settings/README.md#application-url) setting is configured in **Settings &rarr; General**, Overseerr will explicitly set the origin server hostname when connecting to the SMTP host.
+If the [Application URL](../settings/README.md#application-url) setting is configured in **Settings &rarr; General**, Jellyseerr will explicitly set the origin server hostname when connecting to the SMTP host.
 {% endhint %}
 
 ### Sender Name (optional)
 
-Configure a friendly name for the email sender (e.g., "Overseerr").
+Configure a friendly name for the email sender (e.g., "Jellyseerr").
 
 ### Sender Address
 

--- a/docs/using-overseerr/notifications/pushbullet.md
+++ b/docs/using-overseerr/notifications/pushbullet.md
@@ -10,7 +10,7 @@ User notifications are separate from system notifications, and the available not
 
 ### Access Token
 
-[Create an access token](https://www.pushbullet.com/#settings) and set it here to grant Overseerr access to the Pushbullet API.
+[Create an access token](https://www.pushbullet.com/#settings) and set it here to grant Jellyseerr access to the Pushbullet API.
 
 ### Channel Tag (optional)
 

--- a/docs/using-overseerr/notifications/webhooks.md
+++ b/docs/using-overseerr/notifications/webhooks.md
@@ -18,7 +18,7 @@ This value will be sent as an `Authorization` HTTP header.
 
 ### JSON Payload
 
-Customize the JSON payload to suit your needs. Overseerr provides several [template variables](#template-variables) for use in the payload, which will be replaced with the relevant data when the notifications are triggered.
+Customize the JSON payload to suit your needs. Jellyseerr provides several [template variables](#template-variables) for use in the payload, which will be replaced with the relevant data when the notifications are triggered.
 
 ## Template Variables
 

--- a/docs/using-overseerr/notifications/webpush.md
+++ b/docs/using-overseerr/notifications/webpush.md
@@ -1,8 +1,8 @@
 # Web Push
 
-The web push notification agent enables you and your users to receive Overseerr notifications in a supported browser.
+The web push notification agent enables you and your users to receive Jellyseerr notifications in a supported browser.
 
-This notification agent does not require any configuration, but is not enabled in Overseerr by default.
+This notification agent does not require any configuration, but is not enabled in Jellyseerr by default.
 
 {% hint style="warning" %}
 **The web push agent only works via HTTPS.** Refer to our [reverse proxy examples](../../extending-overseerr/reverse-proxy.md) for help on proxying Overseerr traffic via HTTPS.

--- a/docs/using-overseerr/settings/README.md
+++ b/docs/using-overseerr/settings/README.md
@@ -4,23 +4,23 @@
 
 ### API Key
 
-This is your Overseerr API key, which can be used to integrate Overseerr with third-party applications. Do **not** share this key publicly, as it can be used to gain administrator access!
+This is your Jellyseerr API key, which can be used to integrate Jellyseerr with third-party applications. Do **not** share this key publicly, as it can be used to gain administrator access!
 
 If you need to generate a new API key for any reason, simply click the button to the right of the text box.
 
 ### Application Title
 
-If you aren't a huge fan of the name "Overseerr" and would like to display something different to your users, you can customize the application title!
+If you aren't a huge fan of the name "Jellyseerr" and would like to display something different to your users, you can customize the application title!
 
 ### Application URL
 
-Set this to the externally-accessible URL of your Overseerr instance.
+Set this to the externally-accessible URL of your Jellyseerr instance.
 
 You must configure this setting in order to enable password reset and [generation](../users/README.md#automatically-generate-password) emails.
 
 ### Enable Proxy Support
 
-If you have Overseerr behind a [reverse proxy](../../extending-overseerr/reverse-proxy.md), enable this setting to allow Overseerr to correctly register client IP addresses. For details, please see the [Express documentation](http://expressjs.com/en/guide/behind-proxies.html).
+If you have Jellyseerr behind a [reverse proxy](../../extending-overseerr/reverse-proxy.md), enable this setting to allow Jellyseerr to correctly register client IP addresses. For details, please see the [Express documentation](http://expressjs.com/en/guide/behind-proxies.html).
 
 This setting is **disabled** by default.
 
@@ -30,19 +30,19 @@ This setting is **disabled** by default.
 **This is an advanced setting.** We do not recommend enabling it unless you understand the implications of doing so.
 {% endhint %}
 
-CSRF stands for [cross-site request forgery](https://en.wikipedia.org/wiki/Cross-site_request_forgery). When this setting is enabled, all external API access that alters Overseerr application data is blocked.
+CSRF stands for [cross-site request forgery](https://en.wikipedia.org/wiki/Cross-site_request_forgery). When this setting is enabled, all external API access that alters Jellyseerr application data is blocked.
 
-If you do not use Overseerr integrations with third-party applications to add/modify/delete requests or users, you can consider enabling this setting to protect against malicious attacks.
+If you do not use Jellyseerr integrations with third-party applications to add/modify/delete requests or users, you can consider enabling this setting to protect against malicious attacks.
 
-One caveat, however, is that _HTTPS is required_, meaning that once this setting is enabled, you will no longer be able to access your Overseerr instance over HTTP (including using an IP address and port number).
+One caveat, however, is that _HTTPS is required_, meaning that once this setting is enabled, you will no longer be able to access your Jellyseerr instance over HTTP (including using an IP address and port number).
 
-If you enable this setting and find yourself unable to access Overseerr, you can disable the setting by modifying `settings.json` in `/app/config`.
+If you enable this setting and find yourself unable to access Jellyseerr, you can disable the setting by modifying `settings.json` in `/app/config`.
 
 This setting is **disabled** by default.
 
 ### Enable Image Caching
 
-When enabled, Overseerr will proxy and cache images from pre-configured sources (such as TMDB). This can use a significant amount of disk space.
+When enabled, Jellyseerr will proxy and cache images from pre-configured sources (such as TMDB). This can use a significant amount of disk space.
 
 Images are saved in the `config/cache/images` and stale images are cleared out every 24 hours.
 
@@ -50,7 +50,7 @@ You should enable this if you are having issues with loading images directly fro
 
 ### Display Language
 
-Set the default display language for Overseerr. Users can override this setting in their user settings.
+Set the default display language for Jellyseerr. Users can override this setting in their user settings.
 
 ### Discover Region & Discover Language
 
@@ -76,13 +76,13 @@ This setting is **enabled** by default.
 
 When enabled, users who have configured passwords will be allowed to sign in using their email address.
 
-When disabled, Plex OAuth becomes the only sign-in option, and any "local users" you have created will not be able to sign in to Overseerr.
+When disabled, Plex OAuth becomes the only sign-in option, and any "local users" you have created will not be able to sign in to Jellyseerr.
 
 This setting is **enabled** by default.
 
 ### Enable New Plex Sign-In
 
-When enabled, users with access to your Plex server will be able to sign in to Overseerr even if they have not yet been imported. Users will be automatically assigned the permissions configured in the [Default Permissions](#default-permissions) setting upon first sign-in.
+When enabled, users with access to your Plex server will be able to sign in to Jellyseerr even if they have not yet been imported. Users will be automatically assigned the permissions configured in the [Default Permissions](#default-permissions) setting upon first sign-in.
 
 This setting is **enabled** by default.
 
@@ -98,7 +98,7 @@ Note that users with the **Manage Users** permission are exempt from request lim
 
 Select the permissions you would like assigned to new users to have by default upon account creation.
 
-If [Enable New Plex Sign-In](#enable-new-plex-sign-in) is enabled, any user with access to your Plex server will be able to sign in to Overseerr, and they will be granted the permissions you select here upon first sign-in.
+If [Enable New Plex Sign-In](#enable-new-plex-sign-in) is enabled, any user with access to your Plex server will be able to sign in to Jellyseerr, and they will be granted the permissions you select here upon first sign-in.
 
 This setting only affects new users, and has no impact on existing users. In order to modify permissions for existing users, you will need to [edit the users](../users/README.md#editing-users).
 
@@ -109,12 +109,12 @@ This setting only affects new users, and has no impact on existing users. In ord
 {% hint style="info" %}
 To set up Plex, you can either enter your details manually or select a server retrieved from [plex.tv](https://plex.tv/). Press the button to the right of the "Server" dropdown to retrieve available servers.
 
-Depending on your setup/configuration, you may need to enter your Plex server details manually in order to establish a connection from Overseerr.
+Depending on your setup/configuration, you may need to enter your Plex server details manually in order to establish a connection from Jellyseerr.
 {% endhint %}
 
 #### Hostname or IP Address
 
-If you have Overseerr installed on the same network as Plex, you can set this to the local IP address of your Plex server. Otherwise, this should be set to a valid hostname (e.g., `plex.myawesomeserver.com`).
+If you have Jellyseerr installed on the same network as Plex, you can set this to the local IP address of your Plex server. Otherwise, this should be set to a valid hostname (e.g., `plex.myawesomeserver.com`).
 
 #### Port
 
@@ -132,20 +132,20 @@ Note that you will need to enter the full path to the web app (e.g., `https://pl
 
 ### Plex Libraries
 
-In this section, simply select the libraries you would like Overseerr to scan. Overseerr will periodically check the selected libraries for available content to update the media status that is displayed to users.
+In this section, simply select the libraries you would like Jellyseerr to scan. Jellyseerr will periodically check the selected libraries for available content to update the media status that is displayed to users.
 
 If you do not see your Plex libraries listed, verify your Plex settings are correct and click the **Sync Libraries** button.
 
 ### Manual Library Scan
 
-Overseerr will perform a full scan of your Plex libraries once every 24 hours (recently added items are fetched more frequently). If this is your first time configuring Plex, a one-time full manual library scan is recommended!
+Jellyseerr will perform a full scan of your Plex libraries once every 24 hours (recently added items are fetched more frequently). If this is your first time configuring Plex, a one-time full manual library scan is recommended!
 
 ## Services
 
 {% hint style="info" %}
-**If you keep separate copies of non-4K and 4K content in your media libraries, you will need to set up multiple Radarr/Sonarr instances and link each of them to Overseerr.**
+**If you keep separate copies of non-4K and 4K content in your media libraries, you will need to set up multiple Radarr/Sonarr instances and link each of them to Jellyseerr.**
 
-Overseerr checks these linked servers to determine whether or not media has already been requested or is available, so two servers of each type are required _if you keep separate non-4K and 4K copies of media_.
+Jellyseerr checks these linked servers to determine whether or not media has already been requested or is available, so two servers of each type are required _if you keep separate non-4K and 4K copies of media_.
 
 **If you only maintain one copy of media, you can instead simply set up one server and set the "Quality Profile" setting on a per-request basis.**
 {% endhint %}
@@ -153,7 +153,7 @@ Overseerr checks these linked servers to determine whether or not media has alre
 ### Radarr/Sonarr Settings
 
 {% hint style="warning" %}
-**Only v3 Radarr/Sonarr servers are supported!** If your Radarr/Sonarr server is still running v2, you will need to upgrade in order to add it to Overseerr.
+**Only v3 Radarr/Sonarr servers are supported!** If your Radarr/Sonarr server is still running v2, you will need to upgrade in order to add it to Jellyseerr.
 {% endhint %}
 
 #### Default Server
@@ -172,7 +172,7 @@ Enter a friendly name for the Radarr/Sonarr server.
 
 #### Hostname or IP Address
 
-If you have Overseerr installed on the same network as Radarr/Sonarr, you can set this to the local IP address of your Radarr/Sonarr server. Otherwise, this should be set to a valid hostname (e.g., `radarr.myawesomeserver.com`).
+If you have Jellyseerr installed on the same network as Radarr/Sonarr, you can set this to the local IP address of your Radarr/Sonarr server. Otherwise, this should be set to a valid hostname (e.g., `radarr.myawesomeserver.com`).
 
 #### Port
 
@@ -190,7 +190,7 @@ You can locate the required API keys in Radarr/Sonarr in **Settings &rarr; Gener
 
 #### URL Base
 
-If you have configured a URL base for your Radarr/Sonarr server, you _must_ enter it here in order for Overseerr to connect to those services!
+If you have configured a URL base for your Radarr/Sonarr server, you _must_ enter it here in order for Jellyseerr to connect to those services!
 
 You can verify whether or not you have a URL base configured in your Radarr/Sonarr server at **Settings &rarr; General &rarr; Host**. (Note that a restart of your Radarr/Sonarr server is required if you modify this setting!)
 
@@ -216,6 +216,6 @@ Please see [Notifications](../notifications/README.md) for details on configurin
 
 ## Jobs & Cache
 
-Overseerr performs certain maintenance tasks as regularly-scheduled jobs, but they can also be manually triggered on this page.
+Jellyseerr performs certain maintenance tasks as regularly-scheduled jobs, but they can also be manually triggered on this page.
 
-Overseerr also caches requests to external API endpoints to optimize performance and avoid making unnecessary API calls. If necessary, the cache for any particular endpoint can be cleared by clicking the "Flush Cache" button.
+OverseJellyseerrerr also caches requests to external API endpoints to optimize performance and avoid making unnecessary API calls. If necessary, the cache for any particular endpoint can be cleared by clicking the "Flush Cache" button.

--- a/docs/using-overseerr/users/README.md
+++ b/docs/using-overseerr/users/README.md
@@ -2,21 +2,21 @@
 
 ## Owner Account
 
-The user account created during Overseerr setup is the "Owner" account, which cannot be deleted or modified by other users. This account's credentials are used to authenticate with Plex.
+The user account created during Jellyseerr setup is the "Owner" account, which cannot be deleted or modified by other users. This account's credentials are used to authenticate with Plex.
 
 ## Adding Users
 
-There are currently two methods to add users to Overseerr: importing Plex users and creating "local users." All new users are created with the [default permissions](../settings/README.md#default-permissions) defined in **Settings &rarr; Users**.
+There are currently two methods to add users to Jellyseerr: importing Plex users and creating "local users." All new users are created with the [default permissions](../settings/README.md#default-permissions) defined in **Settings &rarr; Users**.
 
 ### Importing Plex Users
 
-Clicking the **Import Plex Users** button on the **User List** page will fetch the list of users with access to the Plex server from [plex.tv](https://www.plex.tv/), and add them to Overseerr automatically.
+Clicking the **Import Plex Users** button on the **User List** page will fetch the list of users with access to the Plex server from [plex.tv](https://www.plex.tv/), and add them to Jellyseerr automatically.
 
-Importing Plex users is not required, however. Any user with access to the Plex server can log in to Overseerr even if they have not been imported, and will be assigned the configured [default permissions](../settings/README.md#default-permissions) upon their first login.
+Importing Plex users is not required, however. Any user with access to the Plex server can log in to Jellyseerr even if they have not been imported, and will be assigned the configured [default permissions](../settings/README.md#default-permissions) upon their first login.
 
 ### Creating Local Users
 
-If you would like to grant Overseerr access to a user who doesn't have their own Plex account and/or access to the Plex server, you can manually add them by clicking the **Create Local User** button.
+If you would like to grant Jellyseerr access to a user who doesn't have their own Plex account and/or access to the Plex server, you can manually add them by clicking the **Create Local User** button.
 
 #### Email Address
 
@@ -24,7 +24,7 @@ Enter a valid email address at which the user can receive messages pertaining to
 
 #### Automatically Generate Password
 
-If an [application URL](../settings/README.md#application-url) is set and [email notifications](../notifications/email.md) have been configured and enabled, Overseerr can automatically generate a password for the new user.
+If an [application URL](../settings/README.md#application-url) is set and [email notifications](../notifications/email.md) have been configured and enabled, Jellyseerr can automatically generate a password for the new user.
 
 #### Password
 
@@ -44,7 +44,7 @@ You can optionally set a "friendly name" for any user. This name will be used in
 
 #### Display Language
 
-Users can override the [global display language](../settings/README.md#display-language) to use Overseerr in their preferred language.
+Users can override the [global display language](../settings/README.md#display-language) to use Jellyseerr in their preferred language.
 
 #### Discover Region & Discover Language
 

--- a/server/api/github.ts
+++ b/server/api/github.ts
@@ -94,7 +94,7 @@ class GithubAPI extends ExternalAPI {
       return data;
     } catch (e) {
       logger.warn(
-        "Failed to retrieve GitHub releases. This may be an issue on GitHub's end. Overseerr can't check if it's on the latest version.",
+        "Failed to retrieve GitHub releases. This may be an issue on GitHub's end. Jellyseerr can't check if it's on the latest version.",
         { label: 'GitHub API', errorMessage: e.message }
       );
       return [];
@@ -122,7 +122,7 @@ class GithubAPI extends ExternalAPI {
       return data;
     } catch (e) {
       logger.warn(
-        "Failed to retrieve GitHub commits. This may be an issue on GitHub's end. Overseerr can't check if it's on the latest version.",
+        "Failed to retrieve GitHub commits. This may be an issue on GitHub's end. Jellyseerr can't check if it's on the latest version.",
         { label: 'GitHub API', errorMessage: e.message }
       );
       return [];

--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -88,9 +88,9 @@ class JellyfinAPI {
 
     let authHeaderVal = '';
     if (this.authToken) {
-      authHeaderVal = `MediaBrowser Client="Overseerr", Device="Axios", DeviceId="${deviceId}", Version="10.8.0", Token="${authToken}"`;
+      authHeaderVal = `MediaBrowser Client="Jellyseerr", Device="Axios", DeviceId="${deviceId}", Version="10.8.0", Token="${authToken}"`;
     } else {
-      authHeaderVal = `MediaBrowser Client="Overseerr", Device="Axios", DeviceId="${deviceId}", Version="10.8.0"`;
+      authHeaderVal = `MediaBrowser Client="Jellyseerr", Device="Axios", DeviceId="${deviceId}", Version="10.8.0"`;
     }
 
     this.axios = axios.create({

--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -124,9 +124,9 @@ class PlexAPI {
       // },
       options: {
         identifier: settings.clientId,
-        product: 'Overseerr',
-        deviceName: 'Overseerr',
-        platform: 'Overseerr',
+        product: 'Jellyseerr',
+        deviceName: 'Jellyseerr',
+        platform: 'Jellyseerr',
       },
     });
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -37,7 +37,7 @@ import YAML from 'yamljs';
 
 const API_SPEC_PATH = path.join(__dirname, '../overseerr-api.yml');
 
-logger.info(`Starting Overseerr version ${getAppVersion()}`);
+logger.info(`Starting Jellyseerr version ${getAppVersion()}`);
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
 const handle = app.getRequestHandler();

--- a/server/lib/watchlistsync.ts
+++ b/server/lib/watchlistsync.ts
@@ -130,7 +130,7 @@ class WatchlistSync {
 
           switch (e.constructor) {
             // During watchlist sync, these errors aren't necessarily
-            // a problem with Overseerr. Since we are auto syncing these constantly, it's
+            // a problem with Jellyseer. Since we are auto syncing these constantly, it's
             // possible they are unexpectedly at their quota limit, for example. So we'll
             // instead log these as debug messages.
             case RequestPermissionError:

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -153,7 +153,7 @@ authRoutes.post('/plex', async (req, res, next) => {
           });
         } else {
           logger.info(
-            'Sign-in attempt from Plex user with access to the media server; creating new Overseerr user',
+            'Sign-in attempt from Plex user with access to the media server; creating new Jellyseerr user',
             {
               label: 'API',
               ip: req.ip,
@@ -313,7 +313,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       const totalUsers = await userRepository.count();
       if (totalUsers === 0) {
         logger.info(
-          'Sign-in attempt from Jellyfin user with access to the media server; creating initial admin user for Overseerr',
+          'Sign-in attempt from Jellyfin user with access to the media server; creating initial admin user for Jellyseerr',
           {
             label: 'API',
             ip: req.ip,
@@ -430,7 +430,7 @@ authRoutes.post('/local', async (req, res, next) => {
       .getOne();
 
     if (!user || !(await user.passwordMatch(body.password))) {
-      logger.warn('Failed sign-in attempt using invalid Overseerr password', {
+      logger.warn('Failed sign-in attempt using invalid Jellyseerr password', {
         label: 'API',
         ip: req.ip,
         email: body.email,
@@ -520,7 +520,7 @@ authRoutes.post('/local', async (req, res, next) => {
     return res.status(200).json(user?.filter() ?? {});
   } catch (e) {
     logger.error(
-      'Something went wrong authenticating with Overseerr password',
+      'Something went wrong authenticating with Jellyseerr password',
       {
         label: 'API',
         errorMessage: e.message,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -362,7 +362,7 @@ router.get('/watchproviders/tv', async (req, res, next) => {
 
 router.get('/', (_req, res) => {
   return res.status(200).json({
-    api: 'Overseerr API',
+    api: 'Jellyseerr API',
     version: '1.0',
   });
 });

--- a/src/components/Layout/VersionStatus/index.tsx
+++ b/src/components/Layout/VersionStatus/index.tsx
@@ -10,8 +10,8 @@ import { defineMessages, useIntl } from 'react-intl';
 import useSWR from 'swr';
 
 const messages = defineMessages({
-  streamdevelop: 'Overseerr Develop',
-  streamstable: 'Overseerr Stable',
+  streamdevelop: 'Jellyseerr Develop',
+  streamstable: 'Jellyseerr Stable',
   outofdate: 'Out of Date',
   commitsbehind:
     '{commitsBehind} {commitsBehind, plural, one {commit} other {commits}} behind',

--- a/src/components/PWAHeader/index.tsx
+++ b/src/components/PWAHeader/index.tsx
@@ -2,7 +2,7 @@ interface PWAHeaderProps {
   applicationTitle?: string;
 }
 
-const PWAHeader = ({ applicationTitle = 'Overseerr' }: PWAHeaderProps) => {
+const PWAHeader = ({ applicationTitle = 'Jellyseerr' }: PWAHeaderProps) => {
   return (
     <>
       <link

--- a/src/components/Settings/Notifications/NotificationsTelegram.tsx
+++ b/src/components/Settings/Notifications/NotificationsTelegram.tsx
@@ -19,7 +19,7 @@ const messages = defineMessages({
     'Allow users to also start a chat with your bot and configure their own notifications',
   botAPI: 'Bot Authorization Token',
   botApiTip:
-    '<CreateBotLink>Create a bot</CreateBotLink> for use with Overseerr',
+    '<CreateBotLink>Create a bot</CreateBotLink> for use with Jellyseerr',
   chatId: 'Chat ID',
   chatIdTip:
     'Start a chat with your bot, add <GetIdBotLink>@get_id_bot</GetIdBotLink>, and issue the <code>/my_id</code> command',

--- a/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
@@ -18,7 +18,7 @@ const messages = defineMessages({
   toastWebPushTestSuccess: 'Web push test notification sent!',
   toastWebPushTestFailed: 'Web push test notification failed to send.',
   httpsRequirement:
-    'In order to receive web push notifications, Overseerr must be served over HTTPS.',
+    'In order to receive web push notifications, Jellyseerr must be served over HTTPS.',
 });
 
 const NotificationsWebPush = () => {

--- a/src/components/Settings/SettingsAbout/index.tsx
+++ b/src/components/Settings/SettingsAbout/index.tsx
@@ -16,7 +16,7 @@ import useSWR from 'swr';
 
 const messages = defineMessages({
   about: 'About',
-  overseerrinformation: 'About Overseerr',
+  overseerrinformation: 'About Jellyseerr',
   version: 'Version',
   totalmedia: 'Total Media',
   totalrequests: 'Total Requests',
@@ -24,7 +24,7 @@ const messages = defineMessages({
   githubdiscussions: 'GitHub Discussions',
   timezone: 'Time Zone',
   appDataPath: 'Data Directory',
-  supportoverseerr: 'Support Overseerr',
+  supportoverseerr: 'Support Jellyseerr',
   helppaycoffee: 'Help Pay for Coffee',
   documentation: 'Documentation',
   preferredmethod: 'Preferred',
@@ -33,7 +33,7 @@ const messages = defineMessages({
   betawarning:
     'This is BETA software. Features may be broken and/or unstable. Please report any issues on GitHub!',
   runningDevelop:
-    'You are running the <code>develop</code> branch of Overseerr, which is only recommended for those contributing to development or assisting with bleeding-edge testing.',
+    'You are running the <code>develop</code> branch of Jellyseerr, which is only recommended for those contributing to development or assisting with bleeding-edge testing.',
 });
 
 const SettingsAbout = () => {

--- a/src/components/Settings/SettingsBadge.tsx
+++ b/src/components/Settings/SettingsBadge.tsx
@@ -9,7 +9,7 @@ const messages = defineMessages({
   experimentalTooltip:
     'Enabling this setting may result in unexpected application behavior',
   restartrequiredTooltip:
-    'Overseerr must be restarted for changes to this setting to take effect',
+    'Jellyseerr must be restarted for changes to this setting to take effect',
 });
 
 const SettingsBadge = ({

--- a/src/components/Settings/SettingsJobsCache/index.tsx
+++ b/src/components/Settings/SettingsJobsCache/index.tsx
@@ -30,7 +30,7 @@ const messages: { [messageName: string]: MessageDescriptor } = defineMessages({
   jobsandcache: 'Jobs & Cache',
   jobs: 'Jobs',
   jobsDescription:
-    'Overseerr performs certain maintenance tasks as regularly-scheduled jobs, but they can also be manually triggered below. Manually running a job will not alter its schedule.',
+    'Jellyseerr performs certain maintenance tasks as regularly-scheduled jobs, but they can also be manually triggered below. Manually running a job will not alter its schedule.',
   jobname: 'Job Name',
   jobtype: 'Type',
   nextexecution: 'Next Execution',
@@ -42,7 +42,7 @@ const messages: { [messageName: string]: MessageDescriptor } = defineMessages({
   command: 'Command',
   cache: 'Cache',
   cacheDescription:
-    'Overseerr caches requests to external API endpoints to optimize performance and avoid making unnecessary API calls.',
+    'Jellyseerr caches requests to external API endpoints to optimize performance and avoid making unnecessary API calls.',
   cacheflushed: '{cachename} cache flushed.',
   cachename: 'Cache Name',
   cachehits: 'Hits',
@@ -73,7 +73,7 @@ const messages: { [messageName: string]: MessageDescriptor } = defineMessages({
     'Every {jobScheduleMinutes, plural, one {minute} other {{jobScheduleMinutes} minutes}}',
   imagecache: 'Image Cache',
   imagecacheDescription:
-    'When enabled in settings, Overseerr will proxy and cache images from pre-configured external sources. Cached images are saved into your config folder. You can find the files in <code>{appDataPath}/cache/images</code>.',
+    'When enabled in settings, Jellyseerr will proxy and cache images from pre-configured external sources. Cached images are saved into your config folder. You can find the files in <code>{appDataPath}/cache/images</code>.',
   imagecachecount: 'Images Cached',
   imagecachesize: 'Total Cache Size',
 });

--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -27,7 +27,7 @@ const messages = defineMessages({
   general: 'General',
   generalsettings: 'General Settings',
   generalsettingsDescription:
-    'Configure global and default settings for Overseerr.',
+    'Configure global and default settings for Jellyseerr.',
   apikey: 'API Key',
   applicationTitle: 'Application Title',
   applicationurl: 'Application URL',
@@ -49,7 +49,7 @@ const messages = defineMessages({
     'Cache externally sourced images (requires a significant amount of disk space)',
   trustProxy: 'Enable Proxy Support',
   trustProxyTip:
-    'Allow Overseerr to correctly register client IP addresses behind a proxy',
+    'Allow Jellyseerr to correctly register client IP addresses behind a proxy',
   validationApplicationTitle: 'You must provide an application title',
   validationApplicationUrl: 'You must provide a valid URL',
   validationApplicationUrlTrailingSlash: 'URL must not end in a trailing slash',

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -28,7 +28,7 @@ const messages = defineMessages({
   plex: 'Plex',
   plexsettings: 'Plex Settings',
   plexsettingsDescription:
-    'Configure the settings for your Plex server. Overseerr scans your Plex libraries to determine content availability.',
+    'Configure the settings for your Plex server. Jellyseerr scans your Plex libraries to determine content availability.',
   serverpreset: 'Server',
   serverLocal: 'local',
   serverRemote: 'remote',
@@ -49,12 +49,12 @@ const messages = defineMessages({
   enablessl: 'Use SSL',
   plexlibraries: 'Plex Libraries',
   plexlibrariesDescription:
-    'The libraries Overseerr scans for titles. Set up and save your Plex connection settings, then click the button below if no libraries are listed.',
+    'The libraries Jellyseerr scans for titles. Set up and save your Plex connection settings, then click the button below if no libraries are listed.',
   scanning: 'Syncing…',
   scan: 'Sync Libraries',
   manualscan: 'Manual Library Scan',
   manualscanDescription:
-    "Normally, this will only be run once every 24 hours. Overseerr will check your Plex server's recently added more aggressively. If this is your first time configuring Plex, a one-time full manual library scan is recommended!",
+    "Normally, this will only be run once every 24 hours. Jellyseerr will check your Plex server's recently added more aggressively. If this is your first time configuring Plex, a one-time full manual library scan is recommended!",
   notrunning: 'Not Running',
   currentlibrary: 'Current Library: {name}',
   librariesRemaining: 'Libraries Remaining: {count}',
@@ -67,7 +67,7 @@ const messages = defineMessages({
     'Optionally direct users to the web app on your server instead of the "hosted" web app',
   tautulliSettings: 'Tautulli Settings',
   tautulliSettingsDescription:
-    'Optionally configure the settings for your Tautulli server. Overseerr fetches watch history data for your Plex media from Tautulli.',
+    'Optionally configure the settings for your Tautulli server. Jellyseerr fetches watch history data for your Plex media from Tautulli.',
   urlBase: 'URL Base',
   tautulliApiKey: 'API Key',
   externalUrl: 'External URL',

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -10,7 +10,7 @@ export interface SettingsContextProps {
 
 const defaultSettings = {
   initialized: false,
-  applicationTitle: 'Overseerr',
+  applicationTitle: 'Jellyseerr',
   applicationUrl: '',
   hideAvailable: false,
   localLogin: true,

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -58,14 +58,14 @@ class PlexOAuth {
     const browser = Bowser.getParser(window.navigator.userAgent);
     this.plexHeaders = {
       Accept: 'application/json',
-      'X-Plex-Product': 'Overseerr',
+      'X-Plex-Product': 'Jellyseerr',
       'X-Plex-Version': 'Plex OAuth',
       'X-Plex-Client-Identifier': clientId,
       'X-Plex-Model': 'Plex OAuth',
       'X-Plex-Platform': browser.getBrowserName(),
       'X-Plex-Platform-Version': browser.getBrowserVersion(),
       'X-Plex-Device': browser.getOSName(),
-      'X-Plex-Device-Name': `${browser.getBrowserName()} (Overseerr)`,
+      'X-Plex-Device-Name': `${browser.getBrowserName()} (Jellyseerr)`,
       'X-Plex-Device-Screen-Resolution':
         window.screen.width + 'x' + window.screen.height,
       'X-Plex-Language': 'en',


### PR DESCRIPTION
#### Description

This PR renames most uses of "Overseerr" to "Jellyseerr" in non critical places.
As this is already the case in some instances (a few settings/docs), but not all. This PR is meant to make the naming in the Docs and Web-UI consistent.

I also changed the Plex header infos at [src/utils/plex.ts](src/utils/plex.ts), this should only make a difference for new sessions. But this can be removed to be sure that it doesn't cause any problems.

Skipped were:
- Paths/Directory names
- Snap (as it is not available atm.)
- Filenames
- Functions and everything that could change the behavior of Jellyseerr
- Test cases
- Funding and similar things

If you don't want to merge theses changes, as to have better upstream compatibility for a future merge with Overseerr, you can just close this PR.
If i missed anything you can let me know and I will fix it.