### PR TITLE
fix(jellyfin sync): temporary workaround fix for jellyfin scan when display specials within season

### DIFF
--- a/server/job/jellyfinsync/index.ts
+++ b/server/job/jellyfinsync/index.ts
@@ -311,13 +311,13 @@ class JobJellyfinSync {
                 // setting the status to AVAILABLE if all of a type is there, partially if some,
                 // and then not modifying the status if there are 0 items
                 existingSeason.status =
-                  totalStandard === season.episode_count
+                  totalStandard >= season.episode_count
                     ? MediaStatus.AVAILABLE
                     : totalStandard > 0
                     ? MediaStatus.PARTIALLY_AVAILABLE
                     : existingSeason.status;
                 existingSeason.status4k =
-                  this.enable4kShow && total4k === season.episode_count
+                  this.enable4kShow && total4k >= season.episode_count
                     ? MediaStatus.AVAILABLE
                     : this.enable4kShow && total4k > 0
                     ? MediaStatus.PARTIALLY_AVAILABLE
@@ -329,13 +329,13 @@ class JobJellyfinSync {
                     // This ternary is the same as the ones above, but it just falls back to "UNKNOWN"
                     // if we dont have any items for the season
                     status:
-                      totalStandard === season.episode_count
+                      totalStandard >= season.episode_count
                         ? MediaStatus.AVAILABLE
                         : totalStandard > 0
                         ? MediaStatus.PARTIALLY_AVAILABLE
                         : MediaStatus.UNKNOWN,
                     status4k:
-                      this.enable4kShow && total4k === season.episode_count
+                      this.enable4kShow && total4k >= season.episode_count
                         ? MediaStatus.AVAILABLE
                         : this.enable4kShow && total4k > 0
                         ? MediaStatus.PARTIALLY_AVAILABLE


### PR DESCRIPTION
#### Description
Currently when display specials within season is enabled, it increases the indexed episode count of the season. This is a problem due to the way our jellyfin sync works as it requires total standard episodes to be equal to season episode count for the `AVAILABLE` badge for that season. However, when the display specials within season is enabled, the scan sets that season as `PARTIALLY AVAILABLE`. This workaround fixes this behaviour. 

In addition, this fix **might** also fix the recurring availability notifications (recurring notifications might be occurring due to the scan initially setting the season as available, thus the series is set as available and sends the notification, but then it sets the season as partially available due to the aforementioned sync flow until next scan and repeats).

I have tested this fix locally and it has fixed the issue for me.

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #215 
- Fixes #176
- Fixes #246
