### PR TITLE
fix: disable availability sync temporarily

### DIFF
--- a/server/job/schedule.ts
+++ b/server/job/schedule.ts
@@ -1,5 +1,4 @@
 import { MediaServerType } from '@server/constants/server';
-import availabilitySync from '@server/lib/availabilitySync';
 import downloadTracker from '@server/lib/downloadtracker';
 import ImageProxy from '@server/lib/imageproxy';
 import { plexFullScanner, plexRecentScanner } from '@server/lib/scanners/plex';
@@ -154,7 +153,7 @@ export const startJobs = (): void => {
   });
 
   // Checks if media is still available in plex/sonarr/radarr libs
-  scheduledJobs.push({
+  /*  scheduledJobs.push({
     id: 'availability-sync',
     name: 'Media Availability Sync',
     type: 'process',
@@ -169,6 +168,7 @@ export const startJobs = (): void => {
     running: () => availabilitySync.running,
     cancelFn: () => availabilitySync.cancel(),
   });
+*/
 
   // Run download sync every minute
   scheduledJobs.push({


### PR DESCRIPTION
#### Description
This PR disables availability sync temporarily as the current one does not have jellyfin/emby sync ported into it. This would ensure that jellyseerr does not bug out and start removing availability from media despite it being available on jellyfin/emby/*arr as well as their requests.

#### To-Dos

- [x] Successful build `yarn build`
