### PR TITLE
feat: added the `audienceRating` and `audienceScore` fields back to rating response

### DIFF
--- a/server/api/rottentomatoes.ts
+++ b/server/api/rottentomatoes.ts
@@ -147,6 +147,9 @@ class RottenTomatoes extends ExternalAPI {
           ? 'Fresh'
           : 'Rotten',
         criticsScore: movie.rottenTomatoes.criticsScore,
+        audienceRating:
+          movie.rottenTomatoes.audienceScore >= 60 ? 'Upright' : 'Spilled',
+        audienceScore: movie.rottenTomatoes.audienceScore,
         year: Number(movie.releaseYear),
       };
     } catch (e) {


### PR DESCRIPTION
#### Description

Added the `audienceRating` and `audienceScore` fields back to rating response

#### Screenshots

|Before|After|
|---|---|
| ![image](https://github.com/Fallenbagel/jellyseerr/assets/71837281/a0729854-80b1-48b1-a883-f6819ac348cc) | ![image](https://github.com/Fallenbagel/jellyseerr/assets/71837281/133b470c-de7c-4a58-a919-47e0d3352ebd) |


#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [x] ~~Database migration (if required)~~
