### PR TITLE
fix(logs): jellyfin auth error now has the severity `warn` consistent with local login

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -380,7 +380,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
     return res.status(200).json(user?.filter() ?? {});
   } catch (e) {
     if (e.message === 'Unauthorized') {
-      logger.info(
+      logger.warn(
         'Failed login attempt from user with incorrect Jellyfin credentials',
         {
           label: 'Auth',


### PR DESCRIPTION
#### Description
This makes the jellyfin auth log severity consistent with the local login.

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #224 
