### PR TITLE
Bump the base image version for the snap package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: >
   Jellyseerr is a free and open source software application for managing requests for your media library.
   It is a a fork of Overseerr built to bring support for & focusing mainly on Jellyfin & Emby media servers!
   It integrates with your existing services such as Sonarr, Radarr, and Jellyfin/Emby/Plex.
-base: core18
+base: core22
 confinement: strict
 
 architectures:


### PR DESCRIPTION
According to https://snapcraft.io/docs/base-snaps, "core22 is the currently recommended base for the majority of snaps."