### PR TITLE
Update snapcraft.yaml - access to ~/.config directory

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,6 +96,7 @@ apps:
       - home
       - network
       - network-bind
+      - personal-files
     environment:
       PATH: '$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH'
       OVERSEERR_SNAP: 'True'


### PR DESCRIPTION
#### Description
The snap package cannot access the ~/.config directory, this allows it access.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [x] Database migration (if required)

#### Issues Fixed or Closed

N/A
