### PR TITLE
fix: multiple notifications for available media

### DIFF
--- a/server/job/jellyfinsync/index.ts
+++ b/server/job/jellyfinsync/index.ts
@@ -311,13 +311,15 @@ class JobJellyfinSync {
                 // setting the status to AVAILABLE if all of a type is there, partially if some,
                 // and then not modifying the status if there are 0 items
                 existingSeason.status =
-                  totalStandard >= season.episode_count
+                  totalStandard >= season.episode_count ||
+                  existingSeason.status === MediaStatus.AVAILABLE
                     ? MediaStatus.AVAILABLE
                     : totalStandard > 0
                     ? MediaStatus.PARTIALLY_AVAILABLE
                     : existingSeason.status;
                 existingSeason.status4k =
-                  this.enable4kShow && total4k >= season.episode_count
+                  (this.enable4kShow && total4k >= season.episode_count) ||
+                  existingSeason.status === MediaStatus.AVAILABLE
                     ? MediaStatus.AVAILABLE
                     : this.enable4kShow && total4k > 0
                     ? MediaStatus.PARTIALLY_AVAILABLE


### PR DESCRIPTION
Multiple repeat notifications being sent for available TV shows everyday at 4.30. Overseerr had [this same issue](https://github.com/sct/overseerr/issues/872) and was fixed in [this commit](https://github.com/sct/overseerr/commit/9b73423d49e1e799cd82764a9ade8c75d92a28a2).

This PR introduces the same changes.