### PR TITLE
fix(server/api/jellyfin.ts): use /Library/VirtualFolders Jellyfin API call to fetch Jellyfin libs

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -171,28 +171,25 @@ class JellyfinAPI {
 
   public async getLibraries(): Promise<JellyfinLibrary[]> {
     try {
-      const account = await this.axios.get<any>(
-        `/Users/${this.userId ?? 'Me'}/Views`
-      );
+      const libraries = await this.axios.get<any>('/Library/VirtualFolders');
 
-      const response: JellyfinLibrary[] = account.data.Items.filter(
-        (Item: any) => {
+      const response: JellyfinLibrary[] = libraries.data
+        .filter((Item: any) => {
           return (
-            Item.Type === 'CollectionFolder' &&
             Item.CollectionType !== 'music' &&
             Item.CollectionType !== 'books' &&
             Item.CollectionType !== 'musicvideos' &&
             Item.CollectionType !== 'homevideos'
           );
-        }
-      ).map((Item: any) => {
-        return <JellyfinLibrary>{
-          key: Item.Id,
-          title: Item.Name,
-          type: Item.CollectionType === 'movies' ? 'movie' : 'show',
-          agent: 'jellyfin',
-        };
-      });
+        })
+        .map((Item: any) => {
+          return <JellyfinLibrary>{
+            key: Item.ItemId,
+            title: Item.Name,
+            type: Item.CollectionType === 'movies' ? 'movie' : 'show',
+            agent: 'jellyfin',
+          };
+        });
 
       return response;
     } catch (e) {


### PR DESCRIPTION
#### Description
Use /Library/VirtualFolders Jellyfin API call to fetch Jellyfin libraries, instead of relying on user's view. This allows the admin user to use automatic grouping in Jellyfin
#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #256 
