### PR TITLE
fix(ui): permission to delete media file match API

### DIFF
--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -382,7 +382,7 @@ const ManageSlideOver = ({
                   </a>
                 )}
 
-                {hasPermission(Permission.ADMIN) &&
+                {hasPermission(Permission.MANAGE_REQUESTS) &&
                   data?.mediaInfo?.serviceUrl &&
                   isDefaultService() && (
                     <div>


### PR DESCRIPTION
#### Description

UI needs to have ADMIN permission to display delete file link, but [API only needs to have MANAGE_REQUESTS](https://github.com/Fallenbagel/jellyseerr/blob/b7282ce9908759975f426b442bd3ca96953399d8/server/routes/media.ts#L176).

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
