### PR TITLE
feat(auth): send real information on login

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -105,14 +105,23 @@ class JellyfinAPI {
 
   public async login(
     Username?: string,
-    Password?: string
+    Password?: string,
+    ClientIP?: string
   ): Promise<JellyfinLoginResponse> {
     try {
+      const headers = ClientIP
+        ? {
+            'X-Forwarded-For': ClientIP,
+          }
+        : {};
       const account = await this.axios.post<JellyfinLoginResponse>(
         '/Users/AuthenticateByName',
         {
           Username: Username,
           Pw: Password,
+        },
+        {
+          headers: headers,
         }
       );
       return account.data;

--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -88,9 +88,9 @@ class JellyfinAPI {
 
     let authHeaderVal = '';
     if (this.authToken) {
-      authHeaderVal = `MediaBrowser Client="Overseerr", Device="Axios", DeviceId="${deviceId}", Version="10.8.0", Token="${authToken}"`;
+      authHeaderVal = `MediaBrowser Client="Jellyseerr", Device="Jellyseerr", DeviceId="${deviceId}", Version="10.8.0", Token="${authToken}"`;
     } else {
-      authHeaderVal = `MediaBrowser Client="Overseerr", Device="Axios", DeviceId="${deviceId}", Version="10.8.0"`;
+      authHeaderVal = `MediaBrowser Client="Jellyseerr", Device="Jellyseerr", DeviceId="${deviceId}", Version="10.8.0"`;
     }
 
     this.axios = axios.create({

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -268,7 +268,13 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       ? jellyfinHost.slice(0, -1)
       : jellyfinHost;
 
-    const account = await jellyfinserver.login(body.username, body.password);
+    const ip = req.ip ? req.ip.split(':').reverse()[0] : undefined;
+    const account = await jellyfinserver.login(
+      body.username,
+      body.password,
+      ip
+    );
+
     // Next let's see if the user already exists
     user = await userRepository.findOne({
       where: { jellyfinUserId: account.User.Id },


### PR DESCRIPTION
#### Description

When a person logs in, their real ip is not sent and the application specified is Axios.
So I added the correct application name and added the X-Forwarded-For header in the axios request headers during login.

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

