### PR TITLE
Fix permissions on ManageSliderOver

### DIFF
--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -103,10 +103,14 @@ const ManageSlideOver = ({
       : null
   );
   const { data: radarrData } = useSWR<RadarrSettings[]>(
-    '/api/v1/settings/radarr'
+    hasPermission(Permission.ADMIN) ?
+      '/api/v1/settings/radarr'
+      : null
   );
   const { data: sonarrData } = useSWR<SonarrSettings[]>(
-    '/api/v1/settings/sonarr'
+    hasPermission(Permission.ADMIN) ?
+      '/api/v1/settings/sonarr'
+      : null
   );
 
   const deleteMedia = async () => {

--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -103,14 +103,10 @@ const ManageSlideOver = ({
       : null
   );
   const { data: radarrData } = useSWR<RadarrSettings[]>(
-    hasPermission(Permission.ADMIN) ?
-      '/api/v1/settings/radarr'
-      : null
+    hasPermission(Permission.ADMIN) ? '/api/v1/settings/radarr' : null
   );
   const { data: sonarrData } = useSWR<SonarrSettings[]>(
-    hasPermission(Permission.ADMIN) ?
-      '/api/v1/settings/sonarr'
-      : null
+    hasPermission(Permission.ADMIN) ? '/api/v1/settings/sonarr' : null
   );
 
   const deleteMedia = async () => {


### PR DESCRIPTION
Previously, would cause a 403 error when a non-admin user opened a movie/series page

#### Description

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #482 
