### PR TITLE
revert(jellyfinapi): reverts #450 as it broke library sync support for local accounts using LDAP

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -171,25 +171,31 @@ class JellyfinAPI {
 
   public async getLibraries(): Promise<JellyfinLibrary[]> {
     try {
-      const libraries = await this.axios.get<any>('/Library/VirtualFolders');
+      // TODO: Try to fix automatic grouping without fucking up LDAP users
+      // const libraries = await this.axios.get<any>('/Library/VirtualFolders');
 
-      const response: JellyfinLibrary[] = libraries.data
-        .filter((Item: any) => {
+      const account = await this.axios.get<any>(
+        `/Users/${this.userId ?? 'Me'}/Views`
+      );
+
+      const response: JellyfinLibrary[] = account.data.Items.filter(
+        (Item: any) => {
           return (
+            Item.Type === 'CollectionFolder' &&
             Item.CollectionType !== 'music' &&
             Item.CollectionType !== 'books' &&
             Item.CollectionType !== 'musicvideos' &&
             Item.CollectionType !== 'homevideos'
           );
-        })
-        .map((Item: any) => {
-          return <JellyfinLibrary>{
-            key: Item.ItemId,
-            title: Item.Name,
-            type: Item.CollectionType === 'movies' ? 'movie' : 'show',
-            agent: 'jellyfin',
-          };
-        });
+        }
+      ).map((Item: any) => {
+        return <JellyfinLibrary>{
+          key: Item.Id,
+          title: Item.Name,
+          type: Item.CollectionType === 'movies' ? 'movie' : 'show',
+          agent: 'jellyfin',
+        };
+      });
 
       return response;
     } catch (e) {


### PR DESCRIPTION
#### Description
Reverted #450 which addressed the issue where the automatic grouping enabled libraries were not functioning correctly. The previous fix inadvertently caused a bug for Jellyfin LDAP users, preventing library syncing with a 401 error. Reverting this change temporarily until support for automatic library grouping can be re-implemented

This PR can be tested using the tag `preview-pr524`

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #489
