### PR TITLE
fix(jellyfinlogin): use externalHostname if set for forgetpassword link

### DIFF
--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -22,6 +22,7 @@ export interface SettingsAboutResponse {
 
 export interface PublicSettingsResponse {
   jellyfinHost?: string;
+  jellyfinExternalHost?: string;
   jellyfinServerName?: string;
   initialized: boolean;
   applicationTitle: string;

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -130,6 +130,7 @@ interface FullPublicSettings extends PublicSettings {
   originalLanguage: string;
   mediaServerType: number;
   jellyfinHost?: string;
+  jellyfinExternalHost?: string;
   jellyfinServerName?: string;
   partialRequestsEnabled: boolean;
   cacheImages: boolean;
@@ -543,6 +544,7 @@ class Settings {
       originalLanguage: this.data.main.originalLanguage,
       mediaServerType: this.main.mediaServerType,
       jellyfinHost: this.jellyfin.hostname,
+      jellyfinExternalHost: this.jellyfin.externalHostname,
       partialRequestsEnabled: this.data.main.partialRequestsEnabled,
       cacheImages: this.data.main.cacheImages,
       vapidPublic: this.vapidPublic,

--- a/src/components/Login/JellyfinLogin.tsx
+++ b/src/components/Login/JellyfinLogin.tsx
@@ -67,6 +67,7 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
       ),
       password: Yup.string(),
     });
+
     const mediaServerFormatValues = {
       mediaServerName:
         publicRuntimeConfig.JELLYFIN_TYPE == 'emby' ? 'Emby' : 'Jellyfin',
@@ -218,6 +219,9 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
       ),
       password: Yup.string(),
     });
+    const baseUrl = settings.currentSettings.jellyfinExternalHost
+      ? settings.currentSettings.jellyfinExternalHost
+      : settings.currentSettings.jellyfinHost;
     return (
       <div>
         <Formik
@@ -294,13 +298,11 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
                         <Button
                           as="a"
                           buttonType="ghost"
-                          href={
-                            process.env.JELLYFIN_TYPE == 'emby'
-                              ? settings.currentSettings.jellyfinHost +
-                                '/web/index.html#!/startup/forgotpassword.html'
-                              : settings.currentSettings.jellyfinHost +
-                                '/web/index.html#!/forgotpassword.html'
-                          }
+                          href={`${baseUrl}/web/index.html#!/${
+                            process.env.JELLYFIN_TYPE === 'emby'
+                              ? 'startup/'
+                              : ''
+                          }forgotpassword.html`}
                         >
                           {intl.formatMessage(messages.forgotpassword)}
                         </Button>


### PR DESCRIPTION

#### Description
Implemented dynamic URL generation for the 'Forgot Password' feature. If jellyfin external hostname is set, the URL is generated based on it; otherwise, jellyfin hostname is used as the base URL. The URL includes additional parameters to handle emby support.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #199 
- Fixes #424 
- Closes #212 
