### PR TITLE
fix(watchlist): added missing prop for watchlist item removal button in watchlist page

### DIFF
--- a/src/components/Common/ListView/index.tsx
+++ b/src/components/Common/ListView/index.tsx
@@ -46,6 +46,7 @@ const ListView = ({
                 id={title.tmdbId}
                 tmdbId={title.tmdbId}
                 type={title.mediaType}
+                isAddedToWatchlist={true}
                 canExpand
               />
             </li>


### PR DESCRIPTION
#### Description
This fix addresses a bug on the Watchlist page where `isAddedToWatchlist` prop was missing. This caused the removal button for watchlist items to be absent. With this fix, `isAddedToWatchlist` prop is re-added and set to `true` so users can now remove items from their local watchlist directly on the Watchlist page.

#### Screenshot (if UI-related)
![image](https://github.com/Fallenbagel/jellyseerr/assets/98979876/51d94d0a-6cf9-42b4-aac3-23fc84c8f1cd)

#### To-Dos

- [x] Successful build `yarn build`

