### PR TITLE
fix: correct width issue in datepicker of filterSliderOver

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,6 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  important: true,
   mode: 'jit',
   content: [
     './node_modules/react-tailwindcss-datepicker-sct/dist/index.esm.js',


### PR DESCRIPTION
#### Description
This commit addresses a rendering issue with the date picker component. The problem was traced back to a misconfiguration in the tailwindcss settings, resulting in an incorrect width for the popup.

#### Screenshot (if UI-related)
**After:**
![image](https://github.com/Fallenbagel/jellyseerr/assets/98979876/e5e7fee1-626c-4c02-b65f-884f518f7133)

**Before:**
![image](https://github.com/Fallenbagel/jellyseerr/assets/98979876/85ba8672-2280-4b78-ba91-3b595f93a1a3)


#### To-Dos

- [ ] Successful build `yarn build`


#### Issues Fixed or Closed

- Fixes #415 
