### PR TITLE
fix: disable seasonfolder option in sonarr for jellyfin/Emby users

### DIFF
--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -1,8 +1,10 @@
 import Modal from '@app/components/Common/Modal';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
+import useSettings from '@app/hooks/useSettings';
 import globalMessages from '@app/i18n/globalMessages';
 import { Transition } from '@headlessui/react';
-import type { SonarrSettings } from '@server/lib/settings';
+import { MediaServerType } from '@server/constants/server';
+import { type SonarrSettings } from '@server/lib/settings';
 import axios from 'axios';
 import { Field, Formik } from 'formik';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -109,6 +111,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
   const { addToast } = useToasts();
   const [isValidated, setIsValidated] = useState(sonarr ? true : false);
   const [isTesting, setIsTesting] = useState(false);
+  const settings = useSettings();
   const [testResponse, setTestResponse] = useState<TestResponse>({
     profiles: [],
     rootFolders: [],
@@ -255,7 +258,9 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
           animeTags: sonarr?.animeTags ?? [],
           isDefault: sonarr?.isDefault ?? false,
           is4k: sonarr?.is4k ?? false,
-          enableSeasonFolders: sonarr?.enableSeasonFolders ?? false,
+          enableSeasonFolders:
+            sonarr?.enableSeasonFolders ??
+            settings.currentSettings.mediaServerType !== MediaServerType.PLEX,
           externalUrl: sonarr?.externalUrl,
           syncEnabled: sonarr?.syncEnabled ?? false,
           enableSearch: !sonarr?.preventSearch,
@@ -961,11 +966,25 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                   >
                     {intl.formatMessage(messages.seasonfolders)}
                   </label>
-                  <div className="form-input-area">
+                  <div
+                    className={`form-input-area ${
+                      settings.currentSettings.mediaServerType ===
+                        MediaServerType.JELLYFIN ||
+                      settings.currentSettings.mediaServerType ===
+                        MediaServerType.EMBY
+                        ? 'opacity-50'
+                        : 'opacity-100'
+                    }`}
+                  >
                     <Field
                       type="checkbox"
                       id="enableSeasonFolders"
                       name="enableSeasonFolders"
+                      // checked={true}
+                      disabled={
+                        settings.currentSettings.mediaServerType !==
+                        MediaServerType.PLEX
+                      }
                     />
                   </div>
                 </div>


### PR DESCRIPTION
#### Description
This disables seasonfolder option in sonarr for jellyfin/emby users as physical seasonFolders are necessary as virtualFolders are ignored since #126 

#### To-Dos

- [ ] Successful build `yarn build`

#### Issues Fixed or Closed

- Fixes #575
