### PR TITLE
fix(jellyfinlogin.tsx): remove extra spaces from login info

### DIFF
--- a/src/components/Login/JellyfinLogin.tsx
+++ b/src/components/Login/JellyfinLogin.tsx
@@ -84,10 +84,10 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
         onSubmit={async (values) => {
           try {
             await axios.post('/api/v1/auth/jellyfin', {
-              username: values.username,
-              password: values.password,
-              hostname: values.host,
-              email: values.email,
+              username: values.username.trim(),
+              password: values.password.trim(),
+              hostname: values.host.trim(),
+              email: values.email.trim(),
             });
           } catch (e) {
             toasts.addToast(
@@ -235,9 +235,9 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
           onSubmit={async (values) => {
             try {
               await axios.post('/api/v1/auth/jellyfin', {
-                username: values.username,
-                password: values.password,
-                email: values.username,
+                username: values.username.trim(),
+                password: values.password.trim(),
+                email: values.username.trim(),
               });
             } catch (e) {
               toasts.addToast(


### PR DESCRIPTION
If a user accidentally adds a space to their username or password, they will not be able to login and they won't understand why. This change removes any spaces from the username, password and email when they submit their credentials.

#### Description

I was trying to log in and it kept saying my username/password were incorrect.  Turns out, tab completion or something had added a space at the end of my username.  The space is not visible of course, so it looked correct.  Re-typing the password several times didn't work until I realized the username had an extra space.

#### Screenshot (if UI-related)

#### To-Dos

- [X] Successful build `yarn build`
- [] Translation keys `yarn i18n:extract`
- [] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
