### PR TITLE
feat: check if first jellyfin user is admin

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -9,6 +9,9 @@ export interface JellyfinUserResponse {
   ServerId: string;
   ServerName: string;
   Id: string;
+  Policy: {
+    IsAdministrator: boolean;
+  };
   PrimaryImageTag?: string;
 }
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -276,6 +276,11 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
     });
 
     if (!user && !(await userRepository.count())) {
+      // Check if user is admin on jellyfin
+      if (account.User.Policy.IsAdministrator === false) {
+        throw new Error('not_admin');
+      }
+
       logger.info(
         'Sign-in attempt from Jellyfin user with access to the media server; creating initial admin user for Overseerr',
         {
@@ -422,6 +427,11 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       return next({
         status: 401,
         message: 'Unauthorized',
+      });
+    } else if (e.message === 'not_admin') {
+      return next({
+        status: 403,
+        message: 'CREDENTIAL_ERROR_NOT_ADMIN',
       });
     } else if (e.message === 'add_email') {
       return next({

--- a/src/components/Login/JellyfinLogin.tsx
+++ b/src/components/Login/JellyfinLogin.tsx
@@ -24,6 +24,7 @@ const messages = defineMessages({
   validationusernamerequired: 'Username required',
   validationpasswordrequired: 'Password required',
   loginerror: 'Something went wrong while trying to sign in.',
+  adminerror: 'You must use an admin account to sign in.',
   credentialerror: 'The username or password is incorrect.',
   signingin: 'Signing in…',
   signin: 'Sign In',
@@ -94,6 +95,8 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
               intl.formatMessage(
                 e.message == 'Request failed with status code 401'
                   ? messages.credentialerror
+                  : e.message == 'Request failed with status code 403'
+                  ? messages.adminerror
                   : messages.loginerror
               ),
               {

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -220,6 +220,7 @@
   "components.Layout.VersionStatus.streamdevelop": "Overseerr Develop",
   "components.Layout.VersionStatus.streamstable": "Overseerr Stable",
   "components.Login.credentialerror": "The username or password is incorrect.",
+  "components.Login.adminerror": "You must use an admin account to sign in.",
   "components.Login.description": "Since this is your first time logging into {applicationName}, you are required to add a valid email address.",
   "components.Login.email": "Email Address",
   "components.Login.emailtooltip": "Address does not need to be associated with your {mediaServerName} instance.",


### PR DESCRIPTION
Solves issue #610 by checking if the first Jellyfin user (at initial set-up) is an admin on Jellyfin or not, as required for set-up.

#### Description

When logging in with Jellyfin credentials for the initial set-up, this feature additionally checks if the user is an administrator on Jellyfin. If not, it gives an appropriate error. Changes include adding `Policy.IsAdministrator` to the interface `JellyfinUserResponse`, a separate check in authentication for (first user only), and addition of a separate error message in the frontend.

Please note that this is my first ever PR! I am really new to this stuff but am trying to learn, so I sincerely apologize if I made any mistakes or did anything not in accordance to the contribution rules.

#### Screenshot (if UI-related)

![image](https://github.com/Fallenbagel/jellyseerr/assets/121830048/3417098c-f6f5-40e4-90a3-a553cc98bb39)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #610