### PR TITLE
fix(scan): process virtual seasons if they have non virtual episodes

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -261,9 +261,7 @@ class JellyfinAPI {
     try {
       const contents = await this.axios.get<any>(`/Shows/${seriesID}/Seasons`);
 
-      return contents.data.Items.filter(
-        (item: JellyfinLibraryItem) => item.LocationType !== 'Virtual'
-      );
+      return contents.data.Items;
     } catch (e) {
       logger.error(
         `Something went wrong while getting the list of seasons from the Jellyfin server: ${e.message}`,


### PR DESCRIPTION
All seasons are processed now, but those without any episodes are filtered out again as unavailable. This fixes an issue when jellyfin reports all seasons as virtual.

#### Description

I've had trouble setting up jellyseerr for my jellyfin instance.
Movies worked fine, but non of my shows were listed as available, even though jellyfin displays them normally.
After digging through the code I found out that jellyfin does indeed report ALL seasons for all my shows as "virtual".
Currently, these seasons are ignored because of this [commit 6574e18](https://github.com/Fallenbagel/jellyseerr/commit/6574e18516201bc11b5f0c422bf6b432c722e067) and this issue #119
How ever, the actual issue seems to not exist anymore as with my changes, virtual seasons get processed, but seasons without any episodes in them are correctly marked as missing.
Partial & full seasons also seem to work as expected now.

I am not sure why my Jellyfin instance acts this way, but it's just a normal docker install so I think this behaviour should be supported.

Example: I have 3 seasons of this show (with the fix):
![grafik](https://github.com/Fallenbagel/jellyseerr/assets/150857901/866c3ef4-71e0-4d15-a9dd-f36caa8f3f79)

This is what the jellyfin API endpoint "/Shows/${seriesID}/Seasons" reports:

> IndexNumber=1 Type=Season LocationType=Virtual SeriesName=Navy CIS: New Orleans
IndexNumber=2 Type=Season LocationType=Virtual SeriesName=Navy CIS: New Orleans
IndexNumber=3 Type=Season LocationType=Virtual SeriesName=Navy CIS: New Orleans
IndexNumber=4 Type=Season LocationType=Virtual SeriesName=Navy CIS: New Orleans
IndexNumber=5 Type=Season LocationType=Virtual SeriesName=Navy CIS: New Orleans
IndexNumber=6 Type=Season LocationType=Virtual SeriesName=Navy CIS: New Orleans
IndexNumber=7 Type=Season LocationType=Virtual SeriesName=Navy CIS: New Orleans

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

