### PR TITLE
refactor: jellyfin authentication and add gravatar for missing avatars of jellyfin users

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -11,6 +11,7 @@ import logger from '@server/logger';
 import { isAuthenticated } from '@server/middleware/auth';
 import * as EmailValidator from 'email-validator';
 import { Router } from 'express';
+import gravatarUrl from 'gravatar-url';
 
 const authRoutes = Router();
 
@@ -296,7 +297,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
         permissions: Permission.ADMIN,
         avatar: account.User.PrimaryImageTag
           ? `${jellyfinHost}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`
-          : '/os_logo_square.png',
+          : gravatarUrl(body.email ?? '', { default: 'mm', size: 200 }),
         userType: UserType.JELLYFIN,
       });
 
@@ -333,7 +334,10 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       if (account.User.PrimaryImageTag) {
         user.avatar = `${jellyfinHost}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`;
       } else {
-        user.avatar = '/os_logo_square.png';
+        user.avatar = gravatarUrl(user.email, {
+          default: 'mm',
+          size: 200,
+        });
       }
       user.jellyfinUsername = account.User.Name;
 
@@ -385,7 +389,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
         permissions: settings.main.defaultPermissions,
         avatar: account.User.PrimaryImageTag
           ? `${jellyfinHost}/Users/${account.User.Id}/Images/Primary/?tag=${account.User.PrimaryImageTag}&quality=90`
-          : '/os_logo_square.png',
+          : gravatarUrl(body.email, { default: 'mm', size: 200 }),
         userType: UserType.JELLYFIN,
       });
       //initialize Jellyfin/Emby users with local login

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -29,6 +29,7 @@ import { getAppVersion } from '@server/utils/appVersion';
 import { Router } from 'express';
 import rateLimit from 'express-rate-limit';
 import fs from 'fs';
+import gravatarUrl from 'gravatar-url';
 import { escapeRegExp, merge, omit, set, sortBy } from 'lodash';
 import { rescheduleJob } from 'node-schedule';
 import path from 'path';
@@ -337,7 +338,7 @@ settingsRoutes.get('/jellyfin/users', async (req, res) => {
     id: user.Id,
     thumb: user.PrimaryImageTag
       ? `${jellyfinHost}/Users/${user.Id}/Images/Primary/?tag=${user.PrimaryImageTag}&quality=90`
-      : '/os_logo_square.png',
+      : gravatarUrl(user.Name, { default: 'mm', size: 200 }),
     email: user.Name,
   }));
 

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -537,7 +537,10 @@ router.post(
             permissions: settings.main.defaultPermissions,
             avatar: jellyfinUser?.PrimaryImageTag
               ? `${jellyfinHost}/Users/${jellyfinUser.Id}/Images/Primary/?tag=${jellyfinUser.PrimaryImageTag}&quality=90`
-              : '/os_logo_square.png',
+              : gravatarUrl(jellyfinUser?.Name ?? '', {
+                  default: 'mm',
+                  size: 200,
+                }),
             userType: UserType.JELLYFIN,
           });
 


### PR DESCRIPTION
#### Description
This refactor standardizes the authentication approach in Jellyfin to mirror the method employed in
Plex authentication for consistency. This also adds gravatar support for jellyfin users that are missing jellyfin avatars similar to plex users.

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

