### PR TITLE
feat(api): set tmdb query's default language based on locale setting

### DIFF
--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -1,5 +1,6 @@
 import ExternalAPI from '@server/api/externalapi';
 import cacheManager from '@server/lib/cache';
+import { getSettings } from '@server/lib/settings';
 import { sortBy } from 'lodash';
 import type {
   TmdbCollection,
@@ -98,6 +99,7 @@ interface DiscoverTvOptions {
 }
 
 class TheMovieDb extends ExternalAPI {
+  private locale: string;
   private region?: string;
   private originalLanguage?: string;
   constructor({
@@ -117,6 +119,7 @@ class TheMovieDb extends ExternalAPI {
         },
       }
     );
+    this.locale = getSettings().main?.locale || 'en';
     this.region = region;
     this.originalLanguage = originalLanguage;
   }
@@ -125,7 +128,7 @@ class TheMovieDb extends ExternalAPI {
     query,
     page = 1,
     includeAdult = false,
-    language = 'en',
+    language = this.locale,
   }: SearchOptions): Promise<TmdbSearchMultiResponse> => {
     try {
       const data = await this.get<TmdbSearchMultiResponse>('/search/multi', {
@@ -147,7 +150,7 @@ class TheMovieDb extends ExternalAPI {
     query,
     page = 1,
     includeAdult = false,
-    language = 'en',
+    language = this.locale,
     year,
   }: SingleSearchOptions): Promise<TmdbSearchMovieResponse> => {
     try {
@@ -176,7 +179,7 @@ class TheMovieDb extends ExternalAPI {
     query,
     page = 1,
     includeAdult = false,
-    language = 'en',
+    language = this.locale,
     year,
   }: SingleSearchOptions): Promise<TmdbSearchTvResponse> => {
     try {
@@ -203,7 +206,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getPerson = async ({
     personId,
-    language = 'en',
+    language = this.locale,
   }: {
     personId: number;
     language?: string;
@@ -221,7 +224,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getPersonCombinedCredits = async ({
     personId,
-    language = 'en',
+    language = this.locale,
   }: {
     personId: number;
     language?: string;
@@ -244,7 +247,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getMovie = async ({
     movieId,
-    language = 'en',
+    language = this.locale,
   }: {
     movieId: number;
     language?: string;
@@ -270,7 +273,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getTvShow = async ({
     tvId,
-    language = 'en',
+    language = this.locale,
   }: {
     tvId: number;
     language?: string;
@@ -323,7 +326,7 @@ class TheMovieDb extends ExternalAPI {
   public async getMovieRecommendations({
     movieId,
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     movieId: number;
     page?: number;
@@ -349,7 +352,7 @@ class TheMovieDb extends ExternalAPI {
   public async getMovieSimilar({
     movieId,
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     movieId: number;
     page?: number;
@@ -375,7 +378,7 @@ class TheMovieDb extends ExternalAPI {
   public async getMoviesByKeyword({
     keywordId,
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     keywordId: number;
     page?: number;
@@ -401,7 +404,7 @@ class TheMovieDb extends ExternalAPI {
   public async getTvRecommendations({
     tvId,
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     tvId: number;
     page?: number;
@@ -429,7 +432,7 @@ class TheMovieDb extends ExternalAPI {
   public async getTvSimilar({
     tvId,
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     tvId: number;
     page?: number;
@@ -453,7 +456,7 @@ class TheMovieDb extends ExternalAPI {
     sortBy = 'popularity.desc',
     page = 1,
     includeAdult = false,
-    language = 'en',
+    language = this.locale,
     primaryReleaseDateGte,
     primaryReleaseDateLte,
     originalLanguage,
@@ -526,7 +529,7 @@ class TheMovieDb extends ExternalAPI {
   public getDiscoverTv = async ({
     sortBy = 'popularity.desc',
     page = 1,
-    language = 'en',
+    language = this.locale,
     firstAirDateGte,
     firstAirDateLte,
     includeEmptyReleaseDate = false,
@@ -599,7 +602,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getUpcomingMovies = async ({
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     page: number;
     language: string;
@@ -626,7 +629,7 @@ class TheMovieDb extends ExternalAPI {
   public getAllTrending = async ({
     page = 1,
     timeWindow = 'day',
-    language = 'en',
+    language = this.locale,
   }: {
     page?: number;
     timeWindow?: 'day' | 'week';
@@ -699,7 +702,7 @@ class TheMovieDb extends ExternalAPI {
   public async getByExternalId({
     externalId,
     type,
-    language = 'en',
+    language = this.locale,
   }:
     | {
         externalId: string;
@@ -730,7 +733,7 @@ class TheMovieDb extends ExternalAPI {
 
   public async getMediaByImdbId({
     imdbId,
-    language = 'en',
+    language = this.locale,
   }: {
     imdbId: string;
     language?: string;
@@ -769,7 +772,7 @@ class TheMovieDb extends ExternalAPI {
 
   public async getShowByTvdbId({
     tvdbId,
-    language = 'en',
+    language = this.locale,
   }: {
     tvdbId: number;
     language?: string;
@@ -799,7 +802,7 @@ class TheMovieDb extends ExternalAPI {
 
   public async getCollection({
     collectionId,
-    language = 'en',
+    language = this.locale,
   }: {
     collectionId: number;
     language?: string;
@@ -875,7 +878,7 @@ class TheMovieDb extends ExternalAPI {
   }
 
   public async getMovieGenres({
-    language = 'en',
+    language = this.locale,
   }: {
     language?: string;
   } = {}): Promise<TmdbGenre[]> {
@@ -926,7 +929,7 @@ class TheMovieDb extends ExternalAPI {
   }
 
   public async getTvGenres({
-    language = 'en',
+    language = this.locale,
   }: {
     language?: string;
   } = {}): Promise<TmdbGenre[]> {


### PR DESCRIPTION
#### Description
From PR#627. Re-opening a PR with a cherrypick because not sure why cypress tests were failing, so to test.

> The tmdb api's default language is en, there's locale issue in notification payload. Since the locale is set from settings, just get the value there.
#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes ###
