### PR TITLE
fix(embyauth): remove the accidentally added mediaServerType 

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -345,11 +345,11 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
         user.username = '';
       }
 
-      // If JELLYFIN_TYPE is set to 'emby' then set mediaServerType to EMBY
-      if (process.env.JELLYFIN_TYPE === 'emby') {
-        settings.main.mediaServerType = MediaServerType.EMBY;
-        settings.save();
-      }
+      // TODO: If JELLYFIN_TYPE is set to 'emby' then set mediaServerType to EMBY
+      // if (process.env.JELLYFIN_TYPE === 'emby') {
+      //   settings.main.mediaServerType = MediaServerType.EMBY;
+      //   settings.save();
+      // }
 
       await userRepository.save(user);
     } else if (!settings.main.newPlexLogin) {


### PR DESCRIPTION
#### Description
Removes the accidentally added the mediaServerType change code from another feature branch/PR during the auth logic refactor that broke emby logins.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
