### PR TITLE
fix(jellyfinscanner): conditionally assign the jellyfinMediaId and jellyfinMediaId4k

### DIFF
--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -461,8 +461,9 @@ class JellyfinScanner {
               tmdbId: tvShow.id,
               tvdbId: tvShow.external_ids.tvdb_id,
               mediaAddedAt: new Date(metadata.DateCreated ?? ''),
-              jellyfinMediaId: Id,
-              jellyfinMediaId4k: Id,
+              jellyfinMediaId: isAllStandardSeasons ? Id : undefined,
+              jellyfinMediaId4k:
+                isAll4kSeasons && this.enable4kShow ? Id : undefined,
               status: isAllStandardSeasons
                 ? MediaStatus.AVAILABLE
                 : newSeasons.some(


### PR DESCRIPTION
#### Description
Previously `jellyfinMediaId4k` was being assigned even if 4k server was not setup or even if 4k content were not present. This fixes it by conditionally assigning the jellyfinMediaId and JellyfinMediaId4k

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #681 
