### PR TITLE
fix: nullable type for jellyfinMediaId(4k)

### DIFF
--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -151,11 +151,11 @@ class Media {
   @Column({ nullable: true, type: 'varchar' })
   public ratingKey4k?: string | null;
 
-  @Column({ nullable: true })
-  public jellyfinMediaId?: string;
+  @Column({ nullable: true, type: 'varchar' })
+  public jellyfinMediaId?: string | null;
 
-  @Column({ nullable: true })
-  public jellyfinMediaId4k?: string;
+  @Column({ nullable: true, type: 'varchar' })
+  public jellyfinMediaId4k?: string | null;
 
   public serviceUrl?: string;
   public serviceUrl4k?: string;

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -548,7 +548,7 @@ class AvailabilitySync {
         media[is4k ? 'ratingKey4k' : 'ratingKey'] =
           mediaStatus === MediaStatus.PROCESSING
             ? media[is4k ? 'ratingKey4k' : 'ratingKey']
-            : undefined;
+            : null;
       } else if (
         mediaServerType === MediaServerType.JELLYFIN ||
         mediaServerType === MediaServerType.EMBY
@@ -556,7 +556,7 @@ class AvailabilitySync {
         media[is4k ? 'jellyfinMediaId4k' : 'jellyfinMediaId'] =
           mediaStatus === MediaStatus.PROCESSING
             ? media[is4k ? 'jellyfinMediaId4k' : 'jellyfinMediaId']
-            : undefined;
+            : null;
       }
       logger.info(
         `The ${is4k ? '4K' : 'non-4K'} ${

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -168,9 +168,9 @@ class JellyfinScanner {
           newMedia.jellyfinMediaId =
             hasOtherResolution || (!this.enable4kMovie && has4k)
               ? metadata.Id
-              : undefined;
+              : null;
           newMedia.jellyfinMediaId4k =
-            has4k && this.enable4kMovie ? metadata.Id : undefined;
+            has4k && this.enable4kMovie ? metadata.Id : null;
           await mediaRepository.save(newMedia);
           this.log(`Saved ${metadata.Name}`);
         }
@@ -461,9 +461,9 @@ class JellyfinScanner {
               tmdbId: tvShow.id,
               tvdbId: tvShow.external_ids.tvdb_id,
               mediaAddedAt: new Date(metadata.DateCreated ?? ''),
-              jellyfinMediaId: isAllStandardSeasons ? Id : undefined,
+              jellyfinMediaId: isAllStandardSeasons ? Id : null,
               jellyfinMediaId4k:
-                isAll4kSeasons && this.enable4kShow ? Id : undefined,
+                isAll4kSeasons && this.enable4kShow ? Id : null,
               status: isAllStandardSeasons
                 ? MediaStatus.AVAILABLE
                 : newSeasons.some(


### PR DESCRIPTION
#### Description
The jellyfinMediaId(4k) properties were inferred as string | undefined, causing them to be set to undefined when assigning null. This prevented the media from being saved correctly to the SQLite database, as it doesn't accept undefined values. This also resolves the availabilitySync job issue where the "play on" button wasn't being removed for all media server types.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #668 
