### PR TITLE
fix: change SeriesSearch to MissingEpisodeSearch for season requests

### DIFF
--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -303,10 +303,10 @@ class SonarrAPI extends ServarrBase<{
     });
 
     try {
-      await this.runCommand('SeriesSearch', { seriesId });
+      await this.runCommand('MissingEpisodeSearch', { seriesId });
     } catch (e) {
       logger.error(
-        'Something went wrong while executing Sonarr series search.',
+        'Something went wrong while executing Sonarr missing episode search.',
         {
           label: 'Sonarr API',
           errorMessage: e.message,


### PR DESCRIPTION
#### Description

This fix changes the behavior of how Overseerr requests series data from Sonarr. Previously, when adding new seasons to a partially available series, Overseerr would initiate a SeriesSearch, causing Sonarr to search for all monitored seasons of the series, including those already available. This behavior is now corrected by executing a MissingEpisodeSearch for the specific seriesId, which results in Sonarr only searching for the seasons that are not already available (including the newly requested seasons).

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
~~-Translation keys `yarn i18n:extract`~~
~~-Database migration (if required)~~

#### Issues Fixed or Closed

- Fixes: https://github.com/Fallenbagel/jellyseerr/issues/710
