### PR TITLE
fix: use UTF8 encoding for webhook JSON

### DIFF
--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -141,7 +141,7 @@ class WebhookAgent
     const payloadString = Buffer.from(
       this.getSettings().options.jsonPayload,
       'base64'
-    ).toString('ascii');
+    ).toString('utf8');
 
     const parsedJSON = JSON.parse(JSON.parse(payloadString));
 

--- a/server/routes/settings/notifications.ts
+++ b/server/routes/settings/notifications.ts
@@ -275,7 +275,7 @@ notificationRoutes.get('/webhook', (_req, res) => {
       ...webhookSettings.options,
       jsonPayload: JSON.parse(
         Buffer.from(webhookSettings.options.jsonPayload, 'base64').toString(
-          'ascii'
+          'utf8'
         )
       ),
     },


### PR DESCRIPTION
#### Description

Switch to using UTF8 encoding instead of ASCII for Webhook bodies. With ASCII, extended characters like emojis will throw errors here, but UTF8 allows encoding anything in the JSON payload.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [x] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #713
