### PR TITLE
Add merge conflict labeler workflow

### DIFF
--- a/.github/workflows/conflict_labeler.yml
+++ b/.github/workflows/conflict_labeler.yml
@@ -1,0 +1,26 @@
+name: Merge Conflict Labeler
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request_target:
+    branches:
+      - develop
+    types: [synchronize]
+
+jobs:
+  label:
+    name: Labeling
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'Fallenbagel/jellyseerr' }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Apply label
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: 'merge conflict'
+          commentOnDirty: 'This pull request has merge conflicts. Please resolve the conflicts so the PR can be successfully reviewed and merged.'
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Before merging the PR you have to manually add the label `merge conflict` 

Put a label `merge conflict` on PR with merge conflict and comment also to say to the maintainer that PR as merge conflict.

Would be simpler to review PR for you (@Fallenbagel) and also gain time cause when merge conflict is detected the maintainer can solve it so you don't have to say to him manually to solve the merge conflict.