### PR TITLE
feat: store jellyfin/emby servername

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -308,6 +308,9 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
         userType: UserType.JELLYFIN,
       });
 
+      const serverName = await jellyfinserver.getServerName();
+
+      settings.jellyfin.name = serverName;
       settings.jellyfin.hostname = body.hostname ?? '';
       settings.jellyfin.serverId = account.User.ServerId;
       settings.save();


### PR DESCRIPTION
#### Description
Stores jellyfin/emby(?) server name in the settings file. This might come in handy in the future once simultaneous multi-server sync is implemented.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
