### PR TITLE
fix(auth): case-sensitive logins not updating authtokens

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -325,7 +325,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       await userRepository.save(user);
     }
     // User already exists, let's update their information
-    else if (body.username === user?.jellyfinUsername) {
+    else if (account.User.Id === user?.jellyfinUserId) {
       logger.info(
         `Found matching ${
           settings.main.mediaServerType === MediaServerType.JELLYFIN


### PR DESCRIPTION
#### Description
Having a Jellyfin username with capital letters and logging into Jellyseerr with the username in lower case would prevent the auth token to be updated with a new one.

So, instead of comparing the usernames from the input field and the Jellyfin's auth response, we are now comparing the user ID stored in our DB and the one from Jellyfin's auth response.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
