### PR TITLE
ci: update format check command to ignore .prettierignore files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Lint
         run: yarn lint
       - name: Formatting
-        run: yarn format:check
+        run: yarn format:check --ignore-path .prettierignore
       - name: Build
         run: yarn build
 


### PR DESCRIPTION
#### Description
This is to try and fix formatting issues on #773 on a file that should be ignored.
The reason why the file was ignored was because locally when `yarn format:check` was run, it shows as follows:
![image](https://github.com/Fallenbagel/jellyseerr/assets/98979876/a069a0b9-93d6-4de2-ab40-6be5619af865)

However, the format check action is failing saying that the `settings.cypress.json` needs prettier run on it.
![image](https://github.com/Fallenbagel/jellyseerr/assets/98979876/291acc35-b4f7-4b89-bf7e-da4c2ba2a2da)

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
