### PR TITLE
Revert "ci: update format check command to ignore .prettierignore files"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Lint
         run: yarn lint
       - name: Formatting
-        run: yarn format:check --ignore-path .prettierignore
+        run: yarn format:check
       - name: Build
         run: yarn build
 


### PR DESCRIPTION
Reverts Fallenbagel/jellyseerr#787

#787 was an attempt to figure out why format check was failing on github actions only  for #773 (it passes locally on any machine). It is no longer required as #773 format check is now passing without the need for this.