### PR TITLE
revert(api): ip forwarding breaks windows docker desktop setups when externally accessed

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -123,24 +123,14 @@ class JellyfinAPI extends ExternalAPI {
 
   public async login(
     Username?: string,
-    Password?: string,
-    ClientIP?: string
+    Password?: string
   ): Promise<JellyfinLoginResponse> {
     try {
-      const headers = ClientIP
-        ? {
-            'X-Forwarded-For': ClientIP,
-          }
-        : {};
-
       const authResponse = await this.post<JellyfinLoginResponse>(
         '/Users/AuthenticateByName',
         {
           Username: Username,
           Pw: Password,
-        },
-        {
-          headers: headers,
         }
       );
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -271,13 +271,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       ? jellyfinHost.slice(0, -1)
       : jellyfinHost;
 
-    const ip = req.ip ? req.ip.split(':').reverse()[0] : undefined;
-    const account = await jellyfinserver.login(
-      body.username,
-      body.password,
-      ip
-    );
-
+    const account = await jellyfinserver.login(body.username, body.password);
     // Next let's see if the user already exists
     user = await userRepository.findOne({
       where: { jellyfinUserId: account.User.Id },


### PR DESCRIPTION
#### Description
IP forwarding is broken on windows docker desktop in bridge mode. Windows does not support `network_mode: host`, therefore, this feature breaks external access completely. Until a better method can be found, #470 has be reverted.

IP forwarding is not an issue when using windows baremetal installs, however, all docker desktop windows users would be unable to use jellyseerr externally unless #470 is reverted.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Reverts

- Reverts #470 
