### PR TITLE
feat: set movie status to unknown if unmonitored from radarr during scan #695

### DIFF
--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -618,6 +618,21 @@ class BaseScanner<T> {
   get protectedBundleSize(): number {
     return this.bundleSize;
   }
+
+  protected async processUnmonitoredMovie(tmdbId: number): Promise<void> {
+    const mediaRepository = getRepository(Media);
+    await this.asyncLock.dispatch(tmdbId, async () => {
+      const existing = await this.getExisting(tmdbId, MediaType.MOVIE);
+      if (existing) {
+        existing.status = MediaStatus.UNKNOWN;
+        await mediaRepository.save(existing);
+        this.log(
+          `Movie TMDB ID ${tmdbId} unmonitored from Radarr. Media status set to UNKNOWN.`,
+          'info'
+        );
+      }
+    });
+  }
 }
 
 export default BaseScanner;

--- a/server/lib/scanners/radarr/index.ts
+++ b/server/lib/scanners/radarr/index.ts
@@ -80,13 +80,7 @@ class RadarrScanner
 
   private async processRadarrMovie(radarrMovie: RadarrMovie): Promise<void> {
     if (!radarrMovie.monitored && !radarrMovie.hasFile) {
-      this.log(
-        'Title is unmonitored and has not been downloaded. Skipping item.',
-        'debug',
-        {
-          title: radarrMovie.title,
-        }
-      );
+      this.processUnmonitoredMovie(radarrMovie.tmdbId);
       return;
     }
 


### PR DESCRIPTION
#### Description
Quick & easy first implementation of Monitoring status support in Radarr:
When a movie - which was monitored before - is unmonitored, it won't appear as "requested" in Jellyseerr anymore

#### To-Dos

- [x] Successful build `yarn build`

#### Issues Fixed or Closed

- https://github.com/Fallenbagel/jellyseerr/issues/695