### PR TITLE
fix: empty email in user settings

### DIFF
--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -53,6 +53,8 @@ const messages = defineMessages({
   discordId: 'Discord User ID',
   discordIdTip:
     'The <FindDiscordIdLink>multi-digit ID number</FindDiscordIdLink> associated with your Discord user account',
+  validationemailrequired: 'Email required',
+  validationemailformat: 'Valid email required',
   validationDiscordId: 'You must provide a valid Discord user ID',
   plexwatchlistsyncmovies: 'Auto-Request Movies',
   plexwatchlistsyncmoviestip:
@@ -88,6 +90,9 @@ const UserGeneralSettings = () => {
   );
 
   const UserGeneralSettingsSchema = Yup.object().shape({
+    email: Yup.string()
+      .email(intl.formatMessage(messages.validationemailformat))
+      .required(intl.formatMessage(messages.validationemailrequired)),
     discordId: Yup.string()
       .nullable()
       .matches(/^\d{17,19}$/, intl.formatMessage(messages.validationDiscordId)),

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1177,6 +1177,8 @@
   "components.UserProfile.UserSettings.UserGeneralSettings.toastSettingsSuccess": "Settings saved successfully!",
   "components.UserProfile.UserSettings.UserGeneralSettings.user": "User",
   "components.UserProfile.UserSettings.UserGeneralSettings.validationDiscordId": "You must provide a valid Discord user ID",
+  "components.UserProfile.UserSettings.UserGeneralSettings.validationemailformat": "Valid email required",
+  "components.UserProfile.UserSettings.UserGeneralSettings.validationemailrequired": "Email required",
   "components.UserProfile.UserSettings.UserNotificationSettings.deviceDefault": "Device Default",
   "components.UserProfile.UserSettings.UserNotificationSettings.discordId": "User ID",
   "components.UserProfile.UserSettings.UserNotificationSettings.discordIdTip": "The <FindDiscordIdLink>multi-digit ID number</FindDiscordIdLink> associated with your user account",


### PR DESCRIPTION
#### Description

Email is mandatory for every user and required during the setup of Jellyseerr, but it is possible to set it empty afterwards in the user settings. When the email is empty, users are not able to connect to Jellyseer. This PR makes the email field mandatory in the user settings.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #803
