### PR TITLE
ci: temporarily disable snap release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,60 +35,60 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: npx semantic-release
 
-  build-snap:
-    name: Build Snap Package (${{ matrix.architecture }})
-    needs: semantic-release
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        architecture:
-          - amd64
-          - arm64
-          - armhf
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Switch to main branch
-        run: git checkout main
-      - name: Pull latest changes
-        run: git pull
-      - name: Prepare
-        id: prepare
-        run: |
-          git fetch --prune --tags
-          if [[ $GITHUB_REF == refs/tags/* || $GITHUB_REF == refs/heads/master ]]; then
-            echo "RELEASE=stable" >> $GITHUB_OUTPUT
-          else
-            echo "RELEASE=edge" >> $GITHUB_OUTPUT
-          fi
-      - name: Set Up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt@sha256:df15403e06a03c2f461c1f7938b171fda34a5849eb63a70e2a2109ed5a778bde
-      - name: Build Snap Package
-        uses: diddlesnaps/snapcraft-multiarch-action@v1
-        id: build
-        with:
-          architecture: ${{ matrix.architecture }}
-      - name: Upload Snap Package
-        uses: actions/upload-artifact@v4
-        with:
-          name: jellyseerr-snap-package-${{ matrix.architecture }}
-          path: ${{ steps.build.outputs.snap }}
-      - name: Review Snap Package
-        uses: diddlesnaps/snapcraft-review-tools-action@v1
-        with:
-          snap: ${{ steps.build.outputs.snap }}
-      - name: Publish Snap Package
-        uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_LOGIN }}
-        with:
-          snap: ${{ steps.build.outputs.snap }}
-          release: ${{ steps.prepare.outputs.RELEASE }}
+  # build-snap:
+  #   name: Build Snap Package (${{ matrix.architecture }})
+  #   needs: semantic-release
+  #   runs-on: ubuntu-22.04
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       architecture:
+  #         - amd64
+  #         - arm64
+  #         - armhf
+  #   steps:
+  #     - name: Checkout Code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Switch to main branch
+  #       run: git checkout main
+  #     - name: Pull latest changes
+  #       run: git pull
+  #     - name: Prepare
+  #       id: prepare
+  #       run: |
+  #         git fetch --prune --tags
+  #         if [[ $GITHUB_REF == refs/tags/* || $GITHUB_REF == refs/heads/master ]]; then
+  #           echo "RELEASE=stable" >> $GITHUB_OUTPUT
+  #         else
+  #           echo "RELEASE=edge" >> $GITHUB_OUTPUT
+  #         fi
+  #     - name: Set Up QEMU
+  #       uses: docker/setup-qemu-action@v3
+  #       with:
+  #         image: tonistiigi/binfmt@sha256:df15403e06a03c2f461c1f7938b171fda34a5849eb63a70e2a2109ed5a778bde
+  #     - name: Build Snap Package
+  #       uses: diddlesnaps/snapcraft-multiarch-action@v1
+  #       id: build
+  #       with:
+  #         architecture: ${{ matrix.architecture }}
+  #     - name: Upload Snap Package
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: jellyseerr-snap-package-${{ matrix.architecture }}
+  #         path: ${{ steps.build.outputs.snap }}
+  #     - name: Review Snap Package
+  #       uses: diddlesnaps/snapcraft-review-tools-action@v1
+  #       with:
+  #         snap: ${{ steps.build.outputs.snap }}
+  #     - name: Publish Snap Package
+  #       uses: snapcore/action-publish@v1
+  #       env:
+  #         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_LOGIN }}
+  #       with:
+  #         snap: ${{ steps.build.outputs.snap }}
+  #         release: ${{ steps.prepare.outputs.RELEASE }}
 
   discord:
     name: Send Discord Notification


### PR DESCRIPTION
#### Description
Disables snap release builds temporarily until we can fix it.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
