### PR TITLE
fix(auth): validation of ipv6/ipv4

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -14,6 +14,7 @@ import { ApiError } from '@server/types/error';
 import * as EmailValidator from 'email-validator';
 import { Router } from 'express';
 import gravatarUrl from 'gravatar-url';
+import net from 'net';
 
 const authRoutes = Router();
 
@@ -271,11 +272,21 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       ? jellyfinHost.slice(0, -1)
       : jellyfinHost;
 
-    const ip = req.ip ? req.ip.split(':').reverse()[0] : undefined;
+    const ip = req.ip;
+    let clientIp;
+
+    if (ip) {
+      if (net.isIPv4(ip)) {
+        clientIp = ip;
+      } else if (net.isIPv6(ip)) {
+        clientIp = ip.startsWith('::ffff:') ? ip.substring(7) : ip;
+      }
+    }
+
     const account = await jellyfinserver.login(
       body.username,
       body.password,
-      ip
+      clientIp
     );
 
     // Next let's see if the user already exists


### PR DESCRIPTION
#### Description
From #470, validation for ipv6 was sort of broken where for example `::1` was being sent as `1`, therefore, logins were broken. This PR fixes it by using nodejs `net.isIPv4()` & `net.isIPv6` for ipv4 and ipv6 validation.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #795 (possibly related)
