### PR TITLE
fix: bypass cache-able lookups when resolving localhost

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -59,15 +59,12 @@ app
     const originalLookup = cacheable.lookup;
 
     // if hostname is localhost use dns.lookup instead of cacheable-lookup
-    cacheable.lookup = (
-      hostname: string,
-      options: any,
-      callback?: any
-    ): void => {
+    cacheable.lookup = (...args: any) => {
+      const [hostname] = args;
       if (hostname === 'localhost') {
-        return lookup(hostname, options);
+        lookup(...(args as Parameters<typeof lookup>));
       } else {
-        return originalLookup(hostname, options, callback);
+        originalLookup(...(args as Parameters<typeof originalLookup>));
       }
     };
 


### PR DESCRIPTION
#### Description
This PR aims to address an issue where DNS lookups for 'localhost' were timing out when using `cacheable-lookup` . 'localhost' lookups are now bypassing the cacheable DNS resolution.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
