### PR TITLE
feat: remove "requested" status of unmonitored movies during scan

### DIFF
--- a/cypress/config/settings.cypress.json
+++ b/cypress/config/settings.cypress.json
@@ -22,6 +22,7 @@
     "blocklistedTagsLimit": 50,
     "trustProxy": false,
     "mediaServerType": 1,
+    "removeUnmonitoredEnabled": false,
     "partialRequestsEnabled": true,
     "enableSpecialEpisodes": false,
     "locale": "en"

--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -239,6 +239,9 @@ components:
         partialRequestsEnabled:
           type: boolean
           example: false
+        removeUnmonitoredEnabled:
+          type: boolean
+          example: false
         localLogin:
           type: boolean
           example: true

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -41,6 +41,7 @@ export interface PublicSettingsResponse {
   mediaServerType: number;
   partialRequestsEnabled: boolean;
   enableSpecialEpisodes: boolean;
+  removeUnmonitoredEnabled: boolean;
   cacheImages: boolean;
   vapidPublic: string;
   enablePushRegistration: boolean;

--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -240,7 +240,7 @@ class BaseScanner<T> {
 
   /**
    * processShow takes a TMDB ID and an array of ProcessableSeasons, which
-   * should include the total episodes a sesaon has + the total available
+   * should include the total episodes a season has + the total available
    * episodes that each season currently has. Unlike processMovie, this method
    * does not take an `is4k` option. We handle both the 4k _and_ non 4k status
    * in one method.
@@ -702,6 +702,21 @@ class BaseScanner<T> {
 
   get protectedBundleSize(): number {
     return this.bundleSize;
+  }
+
+  protected async processUnmonitoredMovie(tmdbId: number): Promise<void> {
+    const mediaRepository = getRepository(Media);
+    await this.asyncLock.dispatch(tmdbId, async () => {
+      const existing = await this.getExisting(tmdbId, MediaType.MOVIE);
+      if (existing && existing.status === MediaStatus.PROCESSING) {
+        existing.status = MediaStatus.UNKNOWN;
+        await mediaRepository.save(existing);
+        this.log(
+          `Movie TMDB ID ${tmdbId} unmonitored from Radarr. Media status set to UNKNOWN.`,
+          'info'
+        );
+      }
+    });
   }
 }
 

--- a/server/lib/scanners/radarr/index.ts
+++ b/server/lib/scanners/radarr/index.ts
@@ -79,14 +79,13 @@ class RadarrScanner
   }
 
   private async processRadarrMovie(radarrMovie: RadarrMovie): Promise<void> {
-    if (!radarrMovie.monitored && !radarrMovie.hasFile) {
-      this.log(
-        'Title is unmonitored and has not been downloaded. Skipping item.',
-        'debug',
-        {
-          title: radarrMovie.title,
-        }
-      );
+    const settings = getSettings();
+    if (
+      settings.main.removeUnmonitoredEnabled &&
+      !radarrMovie.monitored &&
+      !radarrMovie.hasFile
+    ) {
+      this.processUnmonitoredMovie(radarrMovie.tmdbId);
       return;
     }
 

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -144,6 +144,7 @@ export interface MainSettings {
   mediaServerType: number;
   partialRequestsEnabled: boolean;
   enableSpecialEpisodes: boolean;
+  removeUnmonitoredEnabled: boolean;
   locale: string;
   youtubeUrl: string;
 }
@@ -196,6 +197,7 @@ interface FullPublicSettings extends PublicSettings {
   jellyfinServerName?: string;
   partialRequestsEnabled: boolean;
   enableSpecialEpisodes: boolean;
+  removeUnmonitoredEnabled: boolean;
   cacheImages: boolean;
   vapidPublic: string;
   enablePushRegistration: boolean;
@@ -402,6 +404,7 @@ class Settings {
         mediaServerType: MediaServerType.NOT_CONFIGURED,
         partialRequestsEnabled: true,
         enableSpecialEpisodes: false,
+        removeUnmonitoredEnabled: false,
         locale: 'en',
         youtubeUrl: '',
       },
@@ -690,6 +693,7 @@ class Settings {
       mediaServerType: this.main.mediaServerType,
       partialRequestsEnabled: this.data.main.partialRequestsEnabled,
       enableSpecialEpisodes: this.data.main.enableSpecialEpisodes,
+      removeUnmonitoredEnabled: this.data.main.removeUnmonitoredEnabled,
       cacheImages: this.data.main.cacheImages,
       vapidPublic: this.vapidPublic,
       enablePushRegistration: this.data.notifications.agents.webpush.enabled,

--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -64,6 +64,9 @@ const messages = defineMessages('components.Settings.SettingsMain', {
   validationApplicationUrlTrailingSlash: 'URL must not end in a trailing slash',
   partialRequestsEnabled: 'Allow Partial Series Requests',
   enableSpecialEpisodes: 'Allow Special Episodes Requests',
+  removeUnmonitoredEnabled: 'Remove Unmonitored Media',
+  removeUnmonitoredExplanation:
+    'Remove Movies from Jellyseerr that are not available and have been un-monitored since',
   locale: 'Display Language',
   youtubeUrl: 'YouTube URL',
   youtubeUrlTip:
@@ -175,6 +178,7 @@ const SettingsMain = () => {
             enableSpecialEpisodes: data?.enableSpecialEpisodes,
             cacheImages: data?.cacheImages,
             youtubeUrl: data?.youtubeUrl,
+            removeUnmonitoredEnabled: data?.removeUnmonitoredEnabled,
           }}
           enableReinitialize
           validationSchema={MainSettingsSchema}
@@ -195,6 +199,7 @@ const SettingsMain = () => {
                 enableSpecialEpisodes: values.enableSpecialEpisodes,
                 cacheImages: values.cacheImages,
                 youtubeUrl: values.youtubeUrl,
+                removeUnmonitoredEnabled: values.removeUnmonitoredEnabled,
               });
               mutate('/api/v1/settings/public');
               mutate('/api/v1/status');
@@ -530,6 +535,35 @@ const SettingsMain = () => {
                         setFieldValue(
                           'enableSpecialEpisodes',
                           !values.enableSpecialEpisodes
+                        );
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label
+                    htmlFor="removeUnmonitoredEnabled"
+                    className="checkbox-label"
+                  >
+                    <span className="mr-2">
+                      {intl.formatMessage(messages.removeUnmonitoredEnabled)}
+                    </span>
+                    <SettingsBadge badgeType="experimental" />
+                    <span className="label-tip">
+                      {intl.formatMessage(
+                        messages.removeUnmonitoredExplanation
+                      )}
+                    </span>
+                  </label>
+                  <div className="form-input-area">
+                    <Field
+                      type="checkbox"
+                      id="removeUnmonitoredEnabled"
+                      name="removeUnmonitoredEnabled"
+                      onChange={() => {
+                        setFieldValue(
+                          'removeUnmonitoredEnabled',
+                          !values.removeUnmonitoredEnabled
                         );
                       }}
                     />

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -24,6 +24,7 @@ const defaultSettings = {
   mediaServerType: MediaServerType.NOT_CONFIGURED,
   partialRequestsEnabled: true,
   enableSpecialEpisodes: false,
+  removeUnmonitoredEnabled: false,
   cacheImages: false,
   vapidPublic: '',
   enablePushRegistration: false,

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -986,6 +986,7 @@
   "components.Settings.SettingsMain.partialRequestsEnabled": "Allow Partial Series Requests",
   "components.Settings.SettingsMain.streamingRegion": "Streaming Region",
   "components.Settings.SettingsMain.streamingRegionTip": "Show streaming sites by regional availability",
+  "components.Settings.SettingsMain.removeUnmonitoredFromRequestsEnabled": "Remove Request for Movies that have been un-monitored since",
   "components.Settings.SettingsMain.toastApiKeyFailure": "Something went wrong while generating a new API key.",
   "components.Settings.SettingsMain.toastApiKeySuccess": "New API key generated successfully!",
   "components.Settings.SettingsMain.toastSettingsFailure": "Something went wrong while saving settings.",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -242,6 +242,7 @@ CoreApp.getInitialProps = async (initialProps) => {
     mediaServerType: MediaServerType.NOT_CONFIGURED,
     partialRequestsEnabled: true,
     enableSpecialEpisodes: false,
+    removeUnmonitoredEnabled: false,
     cacheImages: false,
     vapidPublic: '',
     enablePushRegistration: false,


### PR DESCRIPTION
#### Description

Quick & easy first implementation of Monitoring status support in Radarr:
When a movie - which was monitored before - is unmonitored, it won't appear as "requested" in Jellyseerr anymore

#### Issues Fixed or Closed

- https://github.com/Fallenbagel/jellyseerr/issues/695


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Remove Unmonitored Media" toggle in settings to automatically process movies that become unmonitored in Radarr, updating their status when enabled.

* **Bug Fixes**
  * Fixed documentation typo in scanner comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->