### PR TITLE
fix(api): handle non-existent ratings on IMDb

### DIFF
--- a/server/api/rating/imdbRadarrProxy.ts
+++ b/server/api/rating/imdbRadarrProxy.ts
@@ -175,7 +175,11 @@ class IMDBRadarrProxy extends ExternalAPI {
         `/movie/imdb/${IMDBid}`
       );
 
-      if (!data?.length || data[0].ImdbId !== IMDBid) {
+      if (
+        !data?.length ||
+        data[0].ImdbId !== IMDBid ||
+        !data[0].MovieRatings.Imdb
+      ) {
         return null;
       }
 


### PR DESCRIPTION
#### Description

For some new movies, ratings are not yet available on IMDb. This throws this kind of error in the logs: 
```
Error: [IMDB RADARR PROXY API] Failed to retrieve movie ratings: Cannot read properties of null (reading 'Value')
```
This PR removes this unwanted log message.

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)
