### PR TITLE
 build(dockerfile): add missing pnpm command to dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
   ;; \
   esac
 
-Run npm install --global pnpm
+RUN npm install --global pnpm
 
 COPY package.json pnpm-lock.yaml ./
 RUN CYPRESS_INSTALL_BINARY=0 pnpm install --frozen-lockfile
@@ -44,6 +44,8 @@ LABEL org.opencontainers.image.source="https://github.com/Fallenbagel/jellyseerr
 WORKDIR /app
 
 RUN apk add --no-cache tzdata tini && rm -rf /tmp/*
+
+RUN npm install -g pnpm
 
 # copy from build image
 COPY --from=BUILD_IMAGE /app ./


### PR DESCRIPTION
#### Description
Running the container, this error shows up `[FATAL tini (7)] exec pnpm failed: No such file or directory`

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #834 

