### PR TITLE
build(postinstall): postinstall script to downgrade typeorm on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Pre-requisites:
 npm i -g win-node-env
 set CYPRESS_INSTALL_BINARY=0
 pnpm install --frozen-lockfile
-pnpm add typeorm@0.13.11
 pnpm run build
 pnpm start
 ```

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",
+    "postinstall": "node postinstall-win.js",
     "dev": "nodemon -e ts --watch server --watch overseerr-api.yml -e .json,.ts,.yml -x ts-node -r tsconfig-paths/register --files --project server/tsconfig.json server/index.ts",
     "build:server": "tsc --project server/tsconfig.json && copyfiles -u 2 server/templates/**/*.{html,pug} dist/templates && tsc-alias -p server/tsconfig.json",
     "build:next": "next build",

--- a/postinstall-win.js
+++ b/postinstall-win.js
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+if (process.platform === 'win') {
+  const typeormPath = path.resolve('node_modules/typeorm');
+
+  if (fs.existsSync(typeormPath)) {
+    process.stdout.write('> Installing typeorm@0.3.11 for Windows\n');
+    execSync('pnpm add typeorm@0.3.11', { stdio: 'inherit' });
+  }
+}

--- a/postinstall-win.js
+++ b/postinstall-win.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
-if (process.platform === 'win') {
+if (process.platform === 'win32') {
   const typeormPath = path.resolve('node_modules/typeorm');
 
   if (fs.existsSync(typeormPath)) {


### PR DESCRIPTION
#### Description
This is a temporary fix for windows baremetal users until we fix #478

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Re #478
