### PR TITLE
fix: abort availability sync job if auth token invalid/connection lost

### DIFF
--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -73,29 +73,50 @@ class AvailabilitySync {
         });
       }
 
-      if (mediaServerType === MediaServerType.PLEX) {
-        if (admin && admin.plexToken) {
-          this.plexClient = new PlexAPI({ plexToken: admin.plexToken });
-        } else {
-          logger.error('Plex admin is not configured.');
-        }
-      } else if (
-        mediaServerType === MediaServerType.JELLYFIN ||
-        mediaServerType === MediaServerType.EMBY
-      ) {
-        if (admin) {
-          this.jellyfinClient = new JellyfinAPI(
-            getHostname(),
-            admin.jellyfinAuthToken,
-            admin.jellyfinDeviceId
-          );
+      switch (mediaServerType) {
+        case MediaServerType.PLEX:
+          if (admin && admin.plexToken) {
+            this.plexClient = new PlexAPI({ plexToken: admin.plexToken });
+          } else {
+            logger.error('Plex admin is not configured.');
+          }
+          break;
+        case MediaServerType.JELLYFIN:
+        case MediaServerType.EMBY:
+          if (admin) {
+            this.jellyfinClient = new JellyfinAPI(
+              getHostname(),
+              admin.jellyfinAuthToken,
+              admin.jellyfinDeviceId
+            );
 
-          this.jellyfinClient.setUserId(admin.jellyfinUserId ?? '');
-        } else {
-          logger.error('Jellyfin admin is not configured.');
-        }
-      } else {
-        logger.error('An admin is not configured.');
+            this.jellyfinClient.setUserId(admin.jellyfinUserId ?? '');
+
+            try {
+              await this.jellyfinClient.getSystemInfo();
+            } catch (e) {
+              logger.error('Sync interrupted.', {
+                label: 'AvailabilitySync',
+                status: e.statusCode,
+                error: e.name,
+                errorMessage: e.errorCode,
+              });
+
+              this.running = false;
+              return;
+            }
+          } else {
+            logger.error('Jellyfin admin is not configured.');
+
+            this.running = false;
+            return;
+          }
+          break;
+        default:
+          logger.error('An admin is not configured.');
+
+          this.running = false;
+          return;
       }
 
       for await (const media of this.loadAvailableMediaPaginated(pageSize)) {


### PR DESCRIPTION
#### Description
This fix aborts the media availability sync job if the following conditions are met:
- auth token has expired
- connection to jellyfin/emby has been lost

Previously, the sync job will continue even if auth token was invalid or connection was lost, thereby, resulting in removal of series/movies that were never removed on jellyfin/emby/sonarr/radarr. This also removed the requests. With the current fix, the sync job should refuse to run unless the auth token is valid.

supersedes #844 

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
