### PR TITLE
ci(docs): fix github doc deployment

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -71,11 +71,11 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Download Build Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: docusaurus-build
-          path: gen-docs/build
+      # - name: Download Build Artifact
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: docusaurus-build
+      #     path: gen-docs/build
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
#### Description
Artifact doesn't need to be downloaded. It's readily available as its the same workflow...

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
