### PR TITLE
docs: update gen-docs readme to trigger gh pages deployment

### DIFF
--- a/gen-docs/README.md
+++ b/gen-docs/README.md
@@ -2,6 +2,8 @@
 
 Jellyseerr docs is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
+Jellyseerr docs will be available at [docs.jellyseerr.com](https://docs.jellyseerr.dev).
+
 ### Installation
 
 ```


### PR DESCRIPTION
#### Description
Small update to the gen-docs readme.
(This is to trigger github pages deployment)

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
