### PR TITLE
chore(gen-docs): set deploymentBranch for the docs

### DIFF
--- a/gen-docs/docusaurus.config.ts
+++ b/gen-docs/docusaurus.config.ts
@@ -13,6 +13,7 @@ const config: Config = {
 
   organizationName: 'Fallenbagel',
   projectName: 'Jellyseerr',
+  deploymentBranch: 'gh-pages',
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
#### Description
This sets the deployment branch to gh-pages explicitly

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
