### PR TITLE
docs(readme): fix issues in readme, contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,9 @@ All help is welcome and greatly appreciated! If you would like to contribute to 
 ### Tools Required
 
 - HTML/Typescript/Javascript editor
-  - [VSCode](https://code.visualstudio.com/) is recommended. Upon opening the project, a few extensions will be automatically recommended for install.
-- [NodeJS](https://nodejs.org/en/download/) (Node 14.x or higher)
-- [Yarn](https://yarnpkg.com/)
+- [VSCode](https://code.visualstudio.com/) is recommended. Upon opening the project, a few extensions will be automatically recommended for install.
+- [NodeJS](https://nodejs.org/en/download/) (Node 20.x)
+- [Pnpm](https://pnpm.io/cli/install)
 - [Git](https://git-scm.com/downloads)
 
 ### Getting Started
@@ -18,7 +18,7 @@ All help is welcome and greatly appreciated! If you would like to contribute to 
 
    ```bash
    git clone https://github.com/YOUR_USERNAME/jellyseerr.git
-   cd overseerr/
+   cd jellyseerr/
    ```
 
 2. Add the remote `upstream`:
@@ -48,8 +48,8 @@ All help is welcome and greatly appreciated! If you would like to contribute to 
 4. Run the development environment:
 
    ```bash
-   yarn
-   yarn dev
+   pnpm
+   pnpm dev
    ```
 
    - Alternatively, you can use [Docker](https://www.docker.com/) with `docker-compose up -d`. This method does not require installing NodeJS or Yarn on your machine directly.
@@ -93,7 +93,7 @@ When adding new UI text, please try to adhere to the following guidelines:
 8. If an additional description or "tip" is required for a form field, it should be styled using the global CSS class `label-tip`.
 9. In full sentences, abbreviations like "info" or "auto" should not be used in place of full words, unless referencing the name/label of a specific setting or option which has an abbreviation in its name.
 10. Do your best to check for spelling errors and grammatical mistakes.
-11. Do not misspell "Overseerr."
+11. Do not misspell "Jellyseerr."
 
 ## Translation
 
@@ -103,4 +103,4 @@ We use [Weblate](https://jellyseerr.borgcube.de/projects/jellyseerr/jellyseerr-f
 
 ## Attribution
 
-This contribution guide was inspired by the [Next.js](https://github.com/vercel/next.js) and [Radarr](https://github.com/Radarr/Radarr) contribution guides.
+This contribution guide was inspired by the [Next.js](https://github.com/vercel/next.js), [Radarr](https://github.com/Radarr/Radarr), and [Overseerr](https://github.com/sct/Overseerr) contribution guides.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ With more features on the way! Check out our [issue tracker](https://github.com/
 ## Getting Started
 
 Check out our documentation for instructions on how to install and run Jellyseerr:
+
 https://docs.jellyseerr.dev/getting-started/
 
 ### Packages:

--- a/gen-docs/README.md
+++ b/gen-docs/README.md
@@ -2,7 +2,7 @@
 
 Jellyseerr docs is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
-Jellyseerr docs will be available at [docs.jellyseerr.com](https://docs.jellyseerr.dev).
+Jellyseerr docs will be available at [docs.jellyseerr.dev](https://docs.jellyseerr.dev).
 
 ### Installation
 


### PR DESCRIPTION
#### Description
Fixes the formatting of the getting started section so the link is on a new line. In addition adds the proper contributing instructions and fixes the docs url.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
