### PR TITLE
style: implement thin dark scrollbar for better UI consistency

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,6 +7,29 @@
     min-height: calc(100% + env(safe-area-inset-top));
     padding: env(safe-area-inset-top) env(safe-area-inset-right)
       calc(4rem + env(safe-area-inset-bottom)) env(safe-area-inset-left);
+    scrollbar-width: thin;
+    scrollbar-color: #4b5563 #1f2937;
+  }
+
+  html:hover {
+    scrollbar-color: #6b7280 #1f2937;
+  }
+
+  /* WebKit scrollbar styles */
+  html::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  html::-webkit-scrollbar-track {
+    background: #1f2937;
+  }
+
+  html::-webkit-scrollbar-thumb {
+    background-color: #4b5563;
+  }
+
+  html:hover::-webkit-scrollbar-thumb {
+    background-color: #6b7280;
   }
 
   @media (min-width: 640px) {


### PR DESCRIPTION
#### Description

Changed the scrollbar to be a thinner and darker to match the theme of jellyseerr.

#### Screenshot (if UI-related)
Before:
![image](https://github.com/Fallenbagel/jellyseerr/assets/39034192/f7f6335a-fa7b-434e-ab73-c18c3f948989)

After:
![image](https://github.com/Fallenbagel/jellyseerr/assets/39034192/9ae51ff8-0989-481d-84e2-e6e1d852c3d0)


#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #856
