### PR TITLE
docs: add querystring support & admonitions to docker page

### DIFF
--- a/docs/extending-jellyseerr/reverse-proxy.mdx
+++ b/docs/extending-jellyseerr/reverse-proxy.mdx
@@ -17,7 +17,7 @@ A Nginx subfolder workaround configuration is provided below, but it is not offi
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<Tabs groupId="nginx-reverse-proxy">
+<Tabs groupId="nginx-reverse-proxy" queryString>
     <TabItem value="subdomain" label="Subdomain">
 Add the following configuration to a new file `/etc/nginx/sites-available/jellyseerr.example.com.conf`:
 

--- a/docs/getting-started/aur.mdx
+++ b/docs/getting-started/aur.mdx
@@ -17,7 +17,7 @@ To install Jellyseerr from the AUR, you can use an AUR helper like `yay` or `par
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<Tabs groupId="aur-methods">
+<Tabs groupId="aur-methods" queryString>
   <TabItem value="yay" label="yay">
     ```bash
     yay -S jellyseerr

--- a/docs/getting-started/buildfromsource.mdx
+++ b/docs/getting-started/buildfromsource.mdx
@@ -12,7 +12,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 ### Prerequisites
-<Tabs groupId="versions">
+<Tabs groupId="versions" queryString>
   <TabItem value="latest" label="Latest">
     - [Node.js 18.x](https://nodejs.org/en/download/)
     - [Yarn 1.x](https://classic.yarnpkg.com/lang/en/docs/install)
@@ -29,7 +29,7 @@ import TabItem from '@theme/TabItem';
 
 ## Unix (Linux, macOS)
 ### Installation
-<Tabs groupId="versions">
+<Tabs groupId="versions" queryString>
   <TabItem value="latest" label="latest">
 1. Assuming you want the working directory to be `/opt/jellyseerr`, create the directory and navigate to it:
 ```bash
@@ -85,7 +85,7 @@ You can now access Jellyseerr by visiting `http://localhost:5055` in your web br
 :::
 
 #### Extending the installation
-<Tabs groupId="unix-extensions">
+<Tabs groupId="unix-extensions" queryString>
   <TabItem value="linux" label="Linux">
 To run jellyseerr as a systemd service:
 1. create the environment file at `/etc/jellyseerr/jellyseerr.conf`:
@@ -231,7 +231,7 @@ pm2 status jellyseerr
 
 ## Windows
 ### Installation
-<Tabs groupId="versions">
+<Tabs groupId="versions" queryString>
   <TabItem value="latest" label="latest">
 1. Assuming you want the working directory to be `C:\jellyseerr`, create the directory and navigate to it:
 ```powershell
@@ -291,7 +291,7 @@ You can now access Jellyseerr by visiting `http://localhost:5055` in your web br
 :::
 
 #### Extending the installation
-<Tabs groupId="windows-extensions">
+<Tabs groupId="windows-extensions" queryString>
   <TabItem value="task-scheduler" label="Task Scheduler">
 To run jellyseerr as a bat script:
 1. Create a file named `start-jellyseerr.bat` in the jellyseerr directory:

--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -133,7 +133,7 @@ or the Docker Desktop app:
 4. Enter a name for the volume (example: `jellyseerr-data`) and hit "Create"
 
 Then, create and start the Jellyseerr container:
-<Tabs groupId="docker-methods">
+<Tabs groupId="docker-methods" queryString>
   <TabItem value="docker-cli" label="Docker CLI">
 ```bash
 docker run -d --name jellyseerr -e LOG_LEVEL=debug -e TZ=Asia/Tashkent -p 5055:5055 -v "jellyseerr-data:/app/config" --restart unless-stopped fallenbagel/jellyseerr:latest

--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -37,6 +37,9 @@ docker run -d \
   --restart unless-stopped \
   fallenbagel/jellyseerr
 ```
+:::info
+If you are using emby, make sure to set the `JELLYFIN_TYPE` environment variable to `emby`.
+:::
 
 To run the container as a specific user/group, you may optionally add `--user=[ user | user:group | uid | uid:gid | user:gid | uid:group ]` to the above command.
 
@@ -83,6 +86,10 @@ services:
       - /path/to/appdata/config:/app/config
     restart: unless-stopped
 ```
+:::info
+If you are using emby, make sure to set the `JELLYFIN_TYPE` environment variable to `emby`.
+:::
+
 Then, start all services defined in the Compose file:
 ```bash
 docker-compose up -d
@@ -97,7 +104,6 @@ Then, restart all services defined in the Compose file:
 ```bash
 docker-compose up -d
 ```
-
 :::tip
 You may alternatively use a third-party mechanism like [dockge](https://github.com/louislam/dockge) to manage your docker compose files.
 :::
@@ -178,6 +184,12 @@ volumes:
 5. Click on the "Run" button
   </TabItem>
 </Tabs>
+
+:::tip
+If you are using a named volume, then you can safely **ignore** the warning about the `/app/config` folder being incorrectly mounted.
+
+If you are using emby, make sure to set the `JELLYFIN_TYPE` environment variable to `emby`.
+:::
 
 To access the files inside the volume created above, navigate to `\\wsl$\docker-desktop-data\version-pack-data\community\docker\volumes\jellyseerr-data\_data` using File Explorer.
 

--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -20,7 +20,7 @@ Be sure to replace `/path/to/appdata/config` in the below examples with a valid 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<Tabs groupId="docker-methods">
+<Tabs groupId="docker-methods" queryString>
   <TabItem value="docker-cli" label="Docker CLI">
 For details on the Docker CLI, please [review the official `docker run` documentation](https://docs.docker.com/engine/reference/run/).
 

--- a/docs/using-jellyseerr/settings/mediaserver.mdx
+++ b/docs/using-jellyseerr/settings/mediaserver.mdx
@@ -9,7 +9,7 @@ sidebar_position: 3
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<Tabs groupId="media-server-type">
+<Tabs groupId="media-server-type" queryString>
     <TabItem value="jellyfin" label="Jellyfin">
 :::info
 To set up Jellyfin, make sure you log in using an account with administrative privileges.
@@ -32,7 +32,7 @@ Jellyseerr will perform a full scan of your Jellyfin libraries once every 24 hou
 
 This section is where you configure the connection to your Jellyfin server.
 
-    <Tabs groupId="versions">
+    <Tabs groupId="versions" queryString>
         <TabItem value="latest" label="Latest">
 
 #### Internal URL
@@ -126,7 +126,7 @@ Jellyseerr will perform a full scan of your Emby libraries once every 24 hours (
 
 This section is where you configure the connection to your Emby server.
 
-        <Tabs groupId="versions">
+        <Tabs groupId="versions" queryString>
             <TabItem value="latest" label="Latest">
 
 #### Internal URL

--- a/docs/using-jellyseerr/users/adding-users.mdx
+++ b/docs/using-jellyseerr/users/adding-users.mdx
@@ -13,7 +13,7 @@ There are currently two methods to add users to Jellyseerr: importing Mediaserve
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<Tabs groupId="media-server-type">
+<Tabs groupId="media-server-type" queryString>
   <TabItem value="jellyfin" label="Jellyfin">
     Clicking the **Import Jellyfin Users** button on the **User List** page will fetch the list of users with access to the Jellyfin server and add them to Jellyseerr automatically.
 


### PR DESCRIPTION
#### Description
This add query string support to tabs in docs.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
