### PR TITLE
docs: remove docker desktop container creation tab

### DIFF
--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -167,22 +167,6 @@ volumes:
     external: true
 ```
   </TabItem>
-
-  <TabItem value="docker-desktop" label="Docker Desktop">
-1. Open the Docker Desktop app
-2. Head to the Containers/Apps tab
-3. Click on the "Add Container/App" button near the top right
-4. Fill in the container details:
-   - **Name**: `jellyseerr`
-   - **Image**: `fallenbagel/jellyseerr:latest`
-   - **Port**: `5055:5055`
-   - **Volume**: `jellyseerr-data:/app/config`
-   - **Environment Variables**:
-     - **LOG_LEVEL**: `debug`
-     - **TZ**: `Asia/Tashkent`
-   - **Restart Policy**: `unless-stopped`
-5. Click on the "Run" button
-  </TabItem>
 </Tabs>
 
 :::tip


### PR DESCRIPTION
#### Description
I had added the podman desktop like steps as docker desktop steps. This pr removes that tab.
Future PR would replace this tab with podman desktop tabs (after verifying the full steps).

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
