### PR TITLE
docs: remove code block from admonition

### DIFF
--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -39,9 +39,8 @@ docker run -d \
 ```
 :::tip
 If you are using emby, make sure to set the `JELLYFIN_TYPE` environment variable to `emby`.
-```bash
--e JELLYFIN_TYPE=emby
-```
+
+`-e JELLYFIN_TYPE=emby`
 :::
 
 To run the container as a specific user/group, you may optionally add `--user=[ user | user:group | uid | uid:gid | user:gid | uid:group ]` to the above command.
@@ -91,10 +90,6 @@ services:
 ```
 :::tip
 If you are using emby, make sure to set the `JELLYFIN_TYPE` environment variable to `emby`.
-```yaml
-    environment:
-      - JELLYFIN_TYPE=emby
-```
 :::
 
 Then, start all services defined in the Compose file:


### PR DESCRIPTION
#### Description
This removes the code blocks that were added in #863 as it does not look good inside the admonitions.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
