### PR TITLE
refactor: auto close manage slide on media delete

### DIFF
--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -117,6 +117,7 @@ const ManageSlideOver = ({
       });
       if (!res.ok) throw new Error();
       revalidate();
+      onClose();
     }
   };
 

--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -134,6 +134,7 @@ const ManageSlideOver = ({
       if (!res2.ok) throw new Error();
 
       revalidate();
+      onClose();
     }
   };
 


### PR DESCRIPTION
re #841

#### Description

This simple code fix closes the "manage slide-over" after the user removes the media data from the database or *arr.

#### Screenshot (if UI-related)
![movie-output](https://github.com/user-attachments/assets/318ed46c-1709-4822-a56e-79cd5bb3c57c)
![tv-output](https://github.com/user-attachments/assets/e863642a-9eec-4c7d-ba19-61b31e6073be)
![radarr-output](https://github.com/user-attachments/assets/68d8353b-19ef-4d34-9fc6-d6a7c7e4f4cc)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #841
