### PR TITLE
fix: add missing header when creating an issue

### DIFF
--- a/src/components/IssueModal/CreateIssueModal/index.tsx
+++ b/src/components/IssueModal/CreateIssueModal/index.tsx
@@ -102,6 +102,9 @@ const CreateIssueModal = ({
         try {
           const res = await fetch('/api/v1/issue', {
             method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
             body: JSON.stringify({
               issueType: values.selectedIssue.issueType,
               message: values.message,


### PR DESCRIPTION
#### Description

Fix an issue where the user is not able to create an issue because a header is missing in the fetch request.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

