### PR TITLE
fix(api): save new password when reset password of local account

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -730,6 +730,7 @@ authRoutes.post('/reset-password/:guid', async (req, res, next) => {
     });
   }
   user.recoveryLinkExpirationDate = null;
+  await user.setPassword(req.body.password);
   userRepository.save(user);
   logger.info('Successfully reset password', {
     label: 'API',


### PR DESCRIPTION
#### Description

Add a missing call to setPassword when an user reset his password for a local Jellyseerr account.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #662
