### PR TITLE
fix: add missing brackets

### DIFF
--- a/src/components/Settings/SettingsJellyfin.tsx
+++ b/src/components/Settings/SettingsJellyfin.tsx
@@ -252,7 +252,7 @@ const SettingsJellyfin: React.FC<SettingsJellyfinProps> = ({
 
       const searchParams = new URLSearchParams(params.enable ? params : {});
       const res = await fetch(
-        `/api/v1/settings/jellyfin/library?${searchParams.toString}`
+        `/api/v1/settings/jellyfin/library?${searchParams.toString()}`
       );
       if (!res.ok) throw new Error();
     } else {


### PR DESCRIPTION
#### Description

Add missing brackets causing an error when disabling a library in Settings > Jellyfin.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
