### PR TITLE
revert: "fix(api): fix nextjs error handler (#882)"

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -26,6 +26,7 @@ import { getClientIp } from '@supercharge/request-ip';
 import { TypeormStore } from 'connect-typeorm/out';
 import cookieParser from 'cookie-parser';
 import csurf from 'csurf';
+import type { NextFunction, Request, Response } from 'express';
 import express from 'express';
 import * as OpenApiValidator from 'express-openapi-validator';
 import type { Store } from 'express-session';
@@ -179,16 +180,6 @@ app
     );
     const apiDocs = YAML.load(API_SPEC_PATH);
     server.use('/api-docs', swaggerUi.serve, swaggerUi.setup(apiDocs));
-    /**
-     * Workaround to avoid the error from the OpenAPI validator when an user send a
-     * request without any session cookie
-     */
-    server.use((req, res, next) => {
-      if (!req.cookies['connect.sid']) {
-        req.cookies['connect.sid'] = 'none';
-      }
-      next();
-    });
     server.use(
       OpenApiValidator.middleware({
         apiSpec: API_SPEC_PATH,
@@ -212,7 +203,23 @@ app
     // Do not set cookies so CDNs can cache them
     server.use('/imageproxy', clearCookies, imageproxy);
 
-    server.all('*', (req, res) => handle(req, res));
+    server.get('*', (req, res) => handle(req, res));
+    server.use(
+      (
+        err: { status: number; message: string; errors: string[] },
+        _req: Request,
+        res: Response,
+        // We must provide a next function for the function signature here even though its not used
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _next: NextFunction
+      ) => {
+        // format error
+        res.status(err.status || 500).json({
+          message: err.message,
+          errors: err.errors,
+        });
+      }
+    );
 
     const port = Number(process.env.PORT) || 5055;
     const host = process.env.HOST;


### PR DESCRIPTION
#### Description
This PR reverts the nextjs error handler fix that was introduced in #882 as that change requires further refactor which should be held off for another version owing to the fact that there are currently a lot of changes ready for the next version of jellyseerr.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
