### PR TITLE
fix: enhance error messages when Fetch API fails

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -68,7 +68,10 @@ class ExternalAPI {
     if (!response.ok) {
       const text = await response.text();
       throw new Error(
-        `${response.status} ${response.statusText}${text ? ': ' + text : ''}`
+        `${response.status} ${response.statusText}${text ? ': ' + text : ''}`,
+        {
+          cause: response,
+        }
       );
     }
     const data = await this.getDataFromResponse(response);
@@ -106,6 +109,15 @@ class ExternalAPI {
       },
       body: JSON.stringify(data),
     });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `${response.status} ${response.statusText}${text ? ': ' + text : ''}`,
+        {
+          cause: response,
+        }
+      );
+    }
     const resData = await this.getDataFromResponse(response);
 
     if (this.cache) {
@@ -141,6 +153,15 @@ class ExternalAPI {
       },
       body: JSON.stringify(data),
     });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `${response.status} ${response.statusText}${text ? ': ' + text : ''}`,
+        {
+          cause: response,
+        }
+      );
+    }
     const resData = await this.getDataFromResponse(response);
 
     if (this.cache) {
@@ -163,6 +184,15 @@ class ExternalAPI {
         ...config?.headers,
       },
     });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `${response.status} ${response.statusText}${text ? ': ' + text : ''}`,
+        {
+          cause: response,
+        }
+      );
+    }
     const data = await this.getDataFromResponse(response);
 
     return data;
@@ -197,6 +227,17 @@ class ExternalAPI {
             ...config?.headers,
           },
         }).then(async (response) => {
+          if (!response.ok) {
+            const text = await response.text();
+            throw new Error(
+              `${response.status} ${response.statusText}${
+                text ? ': ' + text : ''
+              }`,
+              {
+                cause: response,
+              }
+            );
+          }
           const data = await this.getDataFromResponse(response);
           this.cache?.set(cacheKey, data, ttl ?? DEFAULT_TTL);
         });
@@ -212,6 +253,15 @@ class ExternalAPI {
         ...config?.headers,
       },
     });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `${response.status} ${response.statusText}${text ? ': ' + text : ''}`,
+        {
+          cause: response,
+        }
+      );
+    }
     const data = await this.getDataFromResponse(response);
 
     if (this.cache) {
@@ -250,13 +300,13 @@ class ExternalAPI {
   }
 
   private async getDataFromResponse(response: Response) {
-    const contentType = response.headers.get('Content-Type')?.split(';')[0];
-    if (contentType === 'application/json') {
+    const contentType = response.headers.get('Content-Type');
+    if (contentType?.includes('application/json')) {
       return await response.json();
     } else if (
-      contentType === 'application/xml' ||
-      contentType === 'text/html' ||
-      contentType === 'text/plain'
+      contentType?.includes('application/xml') ||
+      contentType?.includes('text/html') ||
+      contentType?.includes('text/plain')
     ) {
       return await response.text();
     } else {

--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -152,7 +152,7 @@ class JellyfinAPI extends ExternalAPI {
     try {
       return await authenticate(false);
     } catch (e) {
-      const status = e.response?.status;
+      const status = e.cause?.status;
 
       const networkErrorCodes = new Set([
         'ECONNREFUSED',
@@ -190,7 +190,7 @@ class JellyfinAPI extends ExternalAPI {
 
       return systemInfoResponse;
     } catch (e) {
-      throw new ApiError(e.response?.status, ApiErrorCode.InvalidAuthToken);
+      throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
     }
   }
 
@@ -207,7 +207,7 @@ class JellyfinAPI extends ExternalAPI {
         { label: 'Jellyfin API' }
       );
 
-      throw new ApiError(e.response?.status, ApiErrorCode.Unknown);
+      throw new ApiError(e.cause?.status, ApiErrorCode.Unknown);
     }
   }
 
@@ -222,7 +222,7 @@ class JellyfinAPI extends ExternalAPI {
         { label: 'Jellyfin API' }
       );
 
-      throw new ApiError(e.response?.status, ApiErrorCode.InvalidAuthToken);
+      throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
     }
   }
 
@@ -238,7 +238,7 @@ class JellyfinAPI extends ExternalAPI {
         { label: 'Jellyfin API' }
       );
 
-      throw new ApiError(e.response?.status, ApiErrorCode.InvalidAuthToken);
+      throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
     }
   }
 
@@ -317,7 +317,7 @@ class JellyfinAPI extends ExternalAPI {
         { label: 'Jellyfin API' }
       );
 
-      throw new ApiError(e.response?.status, ApiErrorCode.InvalidAuthToken);
+      throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
     }
   }
 
@@ -338,7 +338,7 @@ class JellyfinAPI extends ExternalAPI {
         { label: 'Jellyfin API' }
       );
 
-      throw new ApiError(e.response?.status, ApiErrorCode.InvalidAuthToken);
+      throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
     }
   }
 
@@ -353,7 +353,7 @@ class JellyfinAPI extends ExternalAPI {
       return itemResponse;
     } catch (e) {
       if (availabilitySync.running) {
-        if (e.response && e.response.status === 500) {
+        if (e.cause?.status === 500) {
           return undefined;
         }
       }
@@ -362,7 +362,7 @@ class JellyfinAPI extends ExternalAPI {
         `Something went wrong while getting library content from the Jellyfin server: ${e.message}`,
         { label: 'Jellyfin API' }
       );
-      throw new ApiError(e.response?.status, ApiErrorCode.InvalidAuthToken);
+      throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
     }
   }
 
@@ -377,7 +377,7 @@ class JellyfinAPI extends ExternalAPI {
         { label: 'Jellyfin API' }
       );
 
-      throw new ApiError(e.response?.status, ApiErrorCode.InvalidAuthToken);
+      throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
     }
   }
 
@@ -402,7 +402,7 @@ class JellyfinAPI extends ExternalAPI {
         { label: 'Jellyfin API' }
       );
 
-      throw new ApiError(e.response?.status, ApiErrorCode.InvalidAuthToken);
+      throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
     }
   }
 }

--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -179,13 +179,20 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
       }
       return data;
     } catch (e) {
+      let errorData;
+      try {
+        errorData = await e.cause?.text();
+        errorData = JSON.parse(errorData);
+      } catch {
+        /* empty */
+      }
       logger.error(
         'Failed to add movie to Radarr. This might happen if the movie already exists, in which case you can safely ignore this error.',
         {
           label: 'Radarr',
           errorMessage: e.message,
           options,
-          response: e?.response?.data,
+          response: errorData,
         }
       );
       throw new Error('Failed to add movie to Radarr');

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -257,11 +257,18 @@ class SonarrAPI extends ServarrBase<{
 
       return createdSeriesData;
     } catch (e) {
+      let errorData;
+      try {
+        errorData = await e.cause?.text();
+        errorData = JSON.parse(errorData);
+      } catch {
+        /* empty */
+      }
       logger.error('Something went wrong while adding a series to Sonarr.', {
         label: 'Sonarr API',
         errorMessage: e.message,
         options,
-        response: e?.response?.data,
+        response: errorData,
       });
       throw new Error('Failed to add series');
     }

--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -291,7 +291,7 @@ class DiscordAgent
         }
       }
 
-      await fetch(settings.options.webhookUrl, {
+      const response = await fetch(settings.options.webhookUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -305,15 +305,25 @@ class DiscordAgent
           content: userMentions.join(' '),
         } as DiscordWebhookPayload),
       });
+      if (!response.ok) {
+        throw new Error(response.statusText, { cause: response });
+      }
 
       return true;
     } catch (e) {
+      let errorData;
+      try {
+        errorData = await e.cause?.text();
+        errorData = JSON.parse(errorData);
+      } catch {
+        /* empty */
+      }
       logger.error('Error sending Discord notification', {
         label: 'Notifications',
         type: Notification[type],
         subject: payload.subject,
         errorMessage: e.message,
-        response: e.response?.data,
+        response: errorData,
       });
 
       return false;

--- a/server/lib/notifications/agents/gotify.ts
+++ b/server/lib/notifications/agents/gotify.ts
@@ -132,22 +132,32 @@ class GotifyAgent
       const endpoint = `${settings.options.url}/message?token=${settings.options.token}`;
       const notificationPayload = this.getNotificationPayload(type, payload);
 
-      await fetch(endpoint, {
+      const response = await fetch(endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(notificationPayload),
       });
+      if (!response.ok) {
+        throw new Error(response.statusText, { cause: response });
+      }
 
       return true;
     } catch (e) {
+      let errorData;
+      try {
+        errorData = await e.cause?.text();
+        errorData = JSON.parse(errorData);
+      } catch {
+        /* empty */
+      }
       logger.error('Error sending Gotify notification', {
         label: 'Notifications',
         type: Notification[type],
         subject: payload.subject,
         errorMessage: e.message,
-        response: e.response?.data,
+        response: errorData,
       });
 
       return false;

--- a/server/lib/notifications/agents/lunasea.ts
+++ b/server/lib/notifications/agents/lunasea.ts
@@ -100,7 +100,7 @@ class LunaSeaAgent
     });
 
     try {
-      await fetch(settings.options.webhookUrl, {
+      const response = await fetch(settings.options.webhookUrl, {
         method: 'POST',
         headers: settings.options.profileName
           ? {
@@ -114,15 +114,25 @@ class LunaSeaAgent
             },
         body: JSON.stringify(this.buildPayload(type, payload)),
       });
+      if (!response.ok) {
+        throw new Error(response.statusText, { cause: response });
+      }
 
       return true;
     } catch (e) {
+      let errorData;
+      try {
+        errorData = await e.cause?.text();
+        errorData = JSON.parse(errorData);
+      } catch {
+        /* empty */
+      }
       logger.error('Error sending LunaSea notification', {
         label: 'Notifications',
         type: Notification[type],
         subject: payload.subject,
         errorMessage: e.message,
-        response: e.response?.data,
+        response: errorData,
       });
 
       return false;

--- a/server/lib/notifications/agents/pushbullet.ts
+++ b/server/lib/notifications/agents/pushbullet.ts
@@ -122,7 +122,7 @@ class PushbulletAgent
       });
 
       try {
-        await fetch(endpoint, {
+        const response = await fetch(endpoint, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -133,13 +133,23 @@ class PushbulletAgent
             channel_tag: settings.options.channelTag,
           }),
         });
+        if (!response.ok) {
+          throw new Error(response.statusText, { cause: response });
+        }
       } catch (e) {
+        let errorData;
+        try {
+          errorData = await e.cause?.text();
+          errorData = JSON.parse(errorData);
+        } catch {
+          /* empty */
+        }
         logger.error('Error sending Pushbullet notification', {
           label: 'Notifications',
           type: Notification[type],
           subject: payload.subject,
           errorMessage: e.message,
-          response: e.response?.data,
+          response: errorData,
         });
 
         return false;
@@ -164,7 +174,7 @@ class PushbulletAgent
         });
 
         try {
-          await fetch(endpoint, {
+          const response = await fetch(endpoint, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -172,14 +182,24 @@ class PushbulletAgent
             },
             body: JSON.stringify(notificationPayload),
           });
+          if (!response.ok) {
+            throw new Error(response.statusText, { cause: response });
+          }
         } catch (e) {
+          let errorData;
+          try {
+            errorData = await e.cause?.text();
+            errorData = JSON.parse(errorData);
+          } catch {
+            /* empty */
+          }
           logger.error('Error sending Pushbullet notification', {
             label: 'Notifications',
             recipient: payload.notifyUser.displayName,
             type: Notification[type],
             subject: payload.subject,
             errorMessage: e.message,
-            response: e.response?.data,
+            response: errorData,
           });
 
           return false;
@@ -215,7 +235,7 @@ class PushbulletAgent
               });
 
               try {
-                await fetch(endpoint, {
+                const response = await fetch(endpoint, {
                   method: 'POST',
                   headers: {
                     'Content-Type': 'application/json',
@@ -223,14 +243,24 @@ class PushbulletAgent
                   },
                   body: JSON.stringify(notificationPayload),
                 });
+                if (!response.ok) {
+                  throw new Error(response.statusText, { cause: response });
+                }
               } catch (e) {
+                let errorData;
+                try {
+                  errorData = await e.cause?.text();
+                  errorData = JSON.parse(errorData);
+                } catch {
+                  /* empty */
+                }
                 logger.error('Error sending Pushbullet notification', {
                   label: 'Notifications',
                   recipient: user.displayName,
                   type: Notification[type],
                   subject: payload.subject,
                   errorMessage: e.message,
-                  response: e.response?.data,
+                  response: errorData,
                 });
 
                 return false;

--- a/server/lib/notifications/agents/pushover.ts
+++ b/server/lib/notifications/agents/pushover.ts
@@ -52,6 +52,9 @@ class PushoverAgent
   ): Promise<Partial<PushoverImagePayload>> {
     try {
       const response = await fetch(imageUrl);
+      if (!response.ok) {
+        throw new Error(response.statusText, { cause: response });
+      }
       const arrayBuffer = await response.arrayBuffer();
       const base64 = Buffer.from(arrayBuffer).toString('base64');
       const contentType = (
@@ -64,10 +67,17 @@ class PushoverAgent
         attachment_type: contentType,
       };
     } catch (e) {
+      let errorData;
+      try {
+        errorData = await e.cause?.text();
+        errorData = JSON.parse(errorData);
+      } catch {
+        /* empty */
+      }
       logger.error('Error getting image payload', {
         label: 'Notifications',
         errorMessage: e.message,
-        response: e.response?.data,
+        response: errorData,
       });
       return {};
     }
@@ -200,7 +210,7 @@ class PushoverAgent
       });
 
       try {
-        await fetch(endpoint, {
+        const response = await fetch(endpoint, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -212,13 +222,23 @@ class PushoverAgent
             sound: settings.options.sound,
           } as PushoverPayload),
         });
+        if (!response.ok) {
+          throw new Error(response.statusText, { cause: response });
+        }
       } catch (e) {
+        let errorData;
+        try {
+          errorData = await e.cause?.text();
+          errorData = JSON.parse(errorData);
+        } catch {
+          /* empty */
+        }
         logger.error('Error sending Pushover notification', {
           label: 'Notifications',
           type: Notification[type],
           subject: payload.subject,
           errorMessage: e.message,
-          response: e.response?.data,
+          response: errorData,
         });
 
         return false;
@@ -246,7 +266,7 @@ class PushoverAgent
         });
 
         try {
-          await fetch(endpoint, {
+          const response = await fetch(endpoint, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -258,14 +278,24 @@ class PushoverAgent
               sound: payload.notifyUser.settings.pushoverSound,
             } as PushoverPayload),
           });
+          if (!response.ok) {
+            throw new Error(response.statusText, { cause: response });
+          }
         } catch (e) {
+          let errorData;
+          try {
+            errorData = await e.cause?.text();
+            errorData = JSON.parse(errorData);
+          } catch {
+            /* empty */
+          }
           logger.error('Error sending Pushover notification', {
             label: 'Notifications',
             recipient: payload.notifyUser.displayName,
             type: Notification[type],
             subject: payload.subject,
             errorMessage: e.message,
-            response: e.response?.data,
+            response: errorData,
           });
 
           return false;
@@ -302,7 +332,7 @@ class PushoverAgent
               });
 
               try {
-                await fetch(endpoint, {
+                const response = await fetch(endpoint, {
                   method: 'POST',
                   headers: {
                     'Content-Type': 'application/json',
@@ -313,14 +343,24 @@ class PushoverAgent
                     user: user.settings.pushoverUserKey,
                   } as PushoverPayload),
                 });
+                if (!response.ok) {
+                  throw new Error(response.statusText, { cause: response });
+                }
               } catch (e) {
+                let errorData;
+                try {
+                  errorData = await e.cause?.text();
+                  errorData = JSON.parse(errorData);
+                } catch {
+                  /* empty */
+                }
                 logger.error('Error sending Pushover notification', {
                   label: 'Notifications',
                   recipient: user.displayName,
                   type: Notification[type],
                   subject: payload.subject,
                   errorMessage: e.message,
-                  response: e.response?.data,
+                  response: errorData,
                 });
 
                 return false;

--- a/server/lib/notifications/agents/slack.ts
+++ b/server/lib/notifications/agents/slack.ts
@@ -237,22 +237,32 @@ class SlackAgent
       subject: payload.subject,
     });
     try {
-      await fetch(settings.options.webhookUrl, {
+      const response = await fetch(settings.options.webhookUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(this.buildEmbed(type, payload)),
       });
+      if (!response.ok) {
+        throw new Error(response.statusText, { cause: response });
+      }
 
       return true;
     } catch (e) {
+      let errorData;
+      try {
+        errorData = await e.cause?.text();
+        errorData = JSON.parse(errorData);
+      } catch {
+        /* empty */
+      }
       logger.error('Error sending Slack notification', {
         label: 'Notifications',
         type: Notification[type],
         subject: payload.subject,
         errorMessage: e.message,
-        response: e.response?.data,
+        response: errorData,
       });
 
       return false;

--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -174,7 +174,7 @@ class TelegramAgent
       });
 
       try {
-        await fetch(endpoint, {
+        const response = await fetch(endpoint, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -185,13 +185,23 @@ class TelegramAgent
             disable_notification: !!settings.options.sendSilently,
           } as TelegramMessagePayload | TelegramPhotoPayload),
         });
+        if (!response.ok) {
+          throw new Error(response.statusText, { cause: response });
+        }
       } catch (e) {
+        let errorData;
+        try {
+          errorData = await e.cause?.text();
+          errorData = JSON.parse(errorData);
+        } catch {
+          /* empty */
+        }
         logger.error('Error sending Telegram notification', {
           label: 'Notifications',
           type: Notification[type],
           subject: payload.subject,
           errorMessage: e.message,
-          response: e.response?.data,
+          response: errorData,
         });
 
         return false;
@@ -215,7 +225,7 @@ class TelegramAgent
         });
 
         try {
-          await fetch(endpoint, {
+          const response = await fetch(endpoint, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -227,14 +237,24 @@ class TelegramAgent
                 !!payload.notifyUser.settings.telegramSendSilently,
             } as TelegramMessagePayload | TelegramPhotoPayload),
           });
+          if (!response.ok) {
+            throw new Error(response.statusText, { cause: response });
+          }
         } catch (e) {
+          let errorData;
+          try {
+            errorData = await e.cause?.text();
+            errorData = JSON.parse(errorData);
+          } catch {
+            /* empty */
+          }
           logger.error('Error sending Telegram notification', {
             label: 'Notifications',
             recipient: payload.notifyUser.displayName,
             type: Notification[type],
             subject: payload.subject,
             errorMessage: e.message,
-            response: e.response?.data,
+            response: errorData,
           });
 
           return false;
@@ -268,7 +288,7 @@ class TelegramAgent
               });
 
               try {
-                await fetch(endpoint, {
+                const response = await fetch(endpoint, {
                   method: 'POST',
                   headers: {
                     'Content-Type': 'application/json',
@@ -279,14 +299,24 @@ class TelegramAgent
                     disable_notification: !!user.settings?.telegramSendSilently,
                   } as TelegramMessagePayload | TelegramPhotoPayload),
                 });
+                if (!response.ok) {
+                  throw new Error(response.statusText, { cause: response });
+                }
               } catch (e) {
+                let errorData;
+                try {
+                  errorData = await e.cause?.text();
+                  errorData = JSON.parse(errorData);
+                } catch {
+                  /* empty */
+                }
                 logger.error('Error sending Telegram notification', {
                   label: 'Notifications',
                   recipient: user.displayName,
                   type: Notification[type],
                   subject: payload.subject,
                   errorMessage: e.message,
-                  response: e.response?.data,
+                  response: errorData,
                 });
 
                 return false;

--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -177,7 +177,7 @@ class WebhookAgent
     });
 
     try {
-      await fetch(settings.options.webhookUrl, {
+      const response = await fetch(settings.options.webhookUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -187,15 +187,25 @@ class WebhookAgent
         },
         body: JSON.stringify(this.buildPayload(type, payload)),
       });
+      if (!response.ok) {
+        throw new Error(response.statusText, { cause: response });
+      }
 
       return true;
     } catch (e) {
+      let errorData;
+      try {
+        errorData = await e.cause?.text();
+        errorData = JSON.parse(errorData);
+      } catch {
+        /* empty */
+      }
       logger.error('Error sending webhook notification', {
         label: 'Notifications',
         type: Notification[type],
         subject: payload.subject,
         errorMessage: e.message,
-        response: e.response?.data,
+        response: errorData,
       });
 
       return false;

--- a/src/components/Login/JellyfinLogin.tsx
+++ b/src/components/Login/JellyfinLogin.tsx
@@ -119,10 +119,17 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
                 email: values.email,
               }),
             });
-            if (!res.ok) throw new Error();
+            if (!res.ok) throw new Error(res.statusText, { cause: res });
           } catch (e) {
+            let errorData;
+            try {
+              errorData = await e.cause?.text();
+              errorData = JSON.parse(errorData);
+            } catch {
+              /* empty */
+            }
             let errorMessage = null;
-            switch (e.response?.data?.message) {
+            switch (errorData?.message) {
               case ApiErrorCode.InvalidUrl:
                 errorMessage = messages.invalidurlerror;
                 break;

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -50,14 +50,21 @@ const Login = () => {
           },
           body: JSON.stringify({ authToken }),
         });
-        if (!res.ok) throw new Error();
+        if (!res.ok) throw new Error(res.statusText, { cause: res });
         const data = await res.json();
 
         if (data?.id) {
           revalidate();
         }
       } catch (e) {
-        setError(e.response.data.message);
+        let errorData;
+        try {
+          errorData = await e.cause?.text();
+          errorData = JSON.parse(errorData);
+        } catch {
+          /* empty */
+        }
+        setError(errorData?.message);
         setAuthToken(undefined);
         setProcessing(false);
       }

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -295,16 +295,23 @@ const UserList = () => {
                   password: values.genpassword ? null : values.password,
                 }),
               });
-              if (!res.ok) throw new Error();
+              if (!res.ok) throw new Error(res.statusText, { cause: res });
               addToast(intl.formatMessage(messages.usercreatedsuccess), {
                 appearance: 'success',
                 autoDismiss: true,
               });
               setCreateModal({ isOpen: false });
             } catch (e) {
+              let errorData;
+              try {
+                errorData = await e.cause?.text();
+                errorData = JSON.parse(errorData);
+              } catch {
+                /* empty */
+              }
               addToast(
                 intl.formatMessage(
-                  e.response.data.errors?.includes('USER_EXISTS')
+                  errorData.errors?.includes('USER_EXISTS')
                     ? messages.usercreatedfailedexisting
                     : messages.usercreatedfailed
                 ),


### PR DESCRIPTION
#### Description

This PR adds missing error handling, such as retrieving the error message in the response, when a Fetch request fails.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
