### PR TITLE
fix: resize header image in network and studio pages

### DIFF
--- a/src/components/Discover/DiscoverNetwork/index.tsx
+++ b/src/components/Discover/DiscoverNetwork/index.tsx
@@ -48,11 +48,11 @@ const DiscoverTvNetwork = () => {
       <div className="mt-1 mb-5">
         <Header>
           {firstResultData?.network.logoPath ? (
-            <div className="mb-6 flex justify-center">
+            <div className="relative mb-6 flex h-24 justify-center sm:h-32">
               <Image
                 src={`https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)${firstResultData.network.logoPath}`}
                 alt={firstResultData.network.name}
-                className="max-h-24 sm:max-h-32"
+                className="object-contain"
                 fill
               />
             </div>

--- a/src/components/Discover/DiscoverStudio/index.tsx
+++ b/src/components/Discover/DiscoverStudio/index.tsx
@@ -48,11 +48,11 @@ const DiscoverMovieStudio = () => {
       <div className="mt-1 mb-5">
         <Header>
           {firstResultData?.studio.logoPath ? (
-            <div className="mb-6 flex justify-center">
+            <div className="relative mb-6 flex h-24 justify-center sm:h-32">
               <Image
                 src={`https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)${firstResultData.studio.logoPath}`}
                 alt={firstResultData.studio.name}
-                className="max-h-24 sm:max-h-32"
+                className="object-contain"
                 fill
               />
             </div>


### PR DESCRIPTION
#### Description

This fixes an image size issue in the headers of discover networks and discover studio.

#### Screenshot (if UI-related)

before:
![image](https://github.com/user-attachments/assets/3fb3d9dc-5e79-49d8-afbc-810d4cf2a598)

after:
![image](https://github.com/user-attachments/assets/0259b8b5-da11-4c1e-9473-3304f101db2c)


#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
