### PR TITLE
fix: add missing parameter to delete requests from ExternalAPI

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -178,6 +178,7 @@ class ExternalAPI {
   ): Promise<T> {
     const url = this.formatUrl(endpoint, params);
     const response = await this.fetch(url, {
+      method: 'DELETE',
       ...config,
       headers: {
         ...this.defaultHeaders,
@@ -313,7 +314,11 @@ class ExternalAPI {
       try {
         return await response.json();
       } catch {
-        return await response.blob();
+        try {
+          return await response.blob();
+        } catch {
+          return null;
+        }
       }
     }
   }


### PR DESCRIPTION
#### Description

This PR fixes the ExternalAPI class where a parameter was missing in the Fetch options.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #903
