### PR TITLE
docs(windows): add missing win-node-env dependency in the installation steps

### DIFF
--- a/docs/getting-started/buildfromsource.mdx
+++ b/docs/getting-started/buildfromsource.mdx
@@ -248,6 +248,7 @@ git checkout main
 ```
 3. Install the dependencies:
 ```powershell
+npm install -g win-node-env
 set CYPRESS_INSTALL_BINARY=0 && yarn install --frozen-lockfile --network-timeout 1000000
 ```
 4. Build the project:


### PR DESCRIPTION
#### Description
`win-node-env` dependency step was previously missing in the build from source instructions for windows. This pr re-adds it.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
