### PR TITLE
docs(windows): add `win-node-env` instructions to develop build from source

### DIFF
--- a/docs/getting-started/buildfromsource.mdx
+++ b/docs/getting-started/buildfromsource.mdx
@@ -273,6 +273,7 @@ git checkout develop # by default, you are on the develop branch so this step is
 ```
 3. Install the dependencies:
 ```powershell
+npm install -g win-node-env
 set CYPRESS_INSTALL_BINARY=0 && pnpm install --frozen-lockfile
 ```
 4. Build the project:


### PR DESCRIPTION
#### Description
Same thing as #912 but for develop instructions.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
