### PR TITLE
fix(tmdb): fallback movie/show overview to English when none is available in requested locale

### DIFF
--- a/server/routes/movie.ts
+++ b/server/routes/movie.ts
@@ -33,9 +33,15 @@ movieRoutes.get('/:id', async (req, res, next) => {
       },
     });
 
-    return res
-      .status(200)
-      .json(mapMovieDetails(tmdbMovie, media, onUserWatchlist));
+    const data = mapMovieDetails(tmdbMovie, media, onUserWatchlist);
+
+    // TMDB issue where it doesnt fallback to English when no overview is available in requested locale.
+    if (!data.overview) {
+      const tvEnglish = await tmdb.getMovie({ movieId: Number(req.params.id) });
+      data.overview = tvEnglish.overview;
+    }
+
+    return res.status(200).json(data);
   } catch (e) {
     logger.debug('Something went wrong retrieving movie', {
       label: 'API',

--- a/server/routes/tv.ts
+++ b/server/routes/tv.ts
@@ -30,7 +30,15 @@ tvRoutes.get('/:id', async (req, res, next) => {
       },
     });
 
-    return res.status(200).json(mapTvDetails(tv, media, onUserWatchlist));
+    const data = mapTvDetails(tv, media, onUserWatchlist);
+
+    // TMDB issue where it doesnt fallback to English when no overview is available in requested locale.
+    if (!data.overview) {
+      const tvEnglish = await tmdb.getTvShow({ tvId: Number(req.params.id) });
+      data.overview = tvEnglish.overview;
+    }
+
+    return res.status(200).json(data);
   } catch (e) {
     logger.debug('Something went wrong retrieving series', {
       label: 'API',


### PR DESCRIPTION
#### Description

This PR adds a second call to TMDB to retried the overview in English if no overview is available in the requested locale

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #925
