### PR TITLE
fix(setup): page display when homepage is loading

### DIFF
--- a/src/components/Setup/index.tsx
+++ b/src/components/Setup/index.tsx
@@ -100,7 +100,7 @@ const Setup = () => {
     router,
   ]);
 
-  if (settings.currentSettings.initialized) return;
+  if (settings.currentSettings.initialized) return <></>;
 
   return (
     <div className="relative flex min-h-screen flex-col justify-center bg-gray-900 py-12">

--- a/src/components/Setup/index.tsx
+++ b/src/components/Setup/index.tsx
@@ -100,6 +100,8 @@ const Setup = () => {
     router,
   ]);
 
+  if (settings.currentSettings.initialized) return;
+
   return (
     <div className="relative flex min-h-screen flex-col justify-center bg-gray-900 py-12">
       <PageTitle title={intl.formatMessage(messages.setup)} />


### PR DESCRIPTION
#### Description

After setup is finished, the 3rd step of the /setup page was displayed while the homepage was loading.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
