### PR TITLE
docs: fix broken anchors

### DIFF
--- a/docs/getting-started/nixpkg.mdx
+++ b/docs/getting-started/nixpkg.mdx
@@ -22,7 +22,7 @@ export const VersionMismatchWarning = () => {
     <>
       {!isUpToDate ? (
         <Admonition type="warning">
-          The <a href="https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/servers/jellyseerr/default.nix#L14">upstream Jellyseerr Nix Package (v{nixpkgVersion})</a> is not <b>up-to-date</b>. If you want to use <b>Jellyseerr v{jellyseerrVersion}</b>, you will need to <a href="#overriding-the-package">override the package derivation</a>.
+          The <a href="https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/servers/jellyseerr/default.nix#L14">upstream Jellyseerr Nix Package (v{nixpkgVersion})</a> is not <b>up-to-date</b>. If you want to use <b>Jellyseerr v{jellyseerrVersion}</b>, you will need to <a href="#overriding-the-package-derivation">override the package derivation</a>.
         </Admonition>
       ) : (
         <Admonition type="success">
@@ -95,12 +95,12 @@ export const VersionMatch = () => {
       };
 
       offlineCache = pkgs.fetchYarnDeps {
-        sha256 = pkgs.lib.fakeSha256; 
+        sha256 = pkgs.lib.fakeSha256;
       };
-    }); 
+    });
   };
 }`;
- 
+
   const module = `{ config, pkgs, lib, ... }:
 
 with lib;

--- a/docs/using-jellyseerr/users/editing-users.md
+++ b/docs/using-jellyseerr/users/editing-users.md
@@ -35,7 +35,7 @@ Users can override the [global display language](/using-jellyseerr/settings/gene
 
 ### Discover Region & Discover Language
 
-Users can override the [global filter settings](/using-jellyseerr/settings/general#discover-region-and-discover-language) to suit their own preferences.
+Users can override the [global filter settings](/using-jellyseerr/settings/general#discover-region--discover-language) to suit their own preferences.
 
 ### Movie Request Limit & Series Request Limit
 


### PR DESCRIPTION
#### Description

Fix broken documentation anchors. This gave a warning when building docs:

```
Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /getting-started/nixpkg:
   -> linking to #overriding-the-package (resolved as: /getting-started/nixpkg#overriding-the-package)
- Broken anchor on source page path = /using-jellyseerr/users/editing-users:
   -> linking to /using-jellyseerr/settings/general#discover-region-and-discover-language
```

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
