### PR TITLE
fix: set correct user type when importing from emby

### DIFF
--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -2,6 +2,7 @@ import JellyfinAPI from '@server/api/jellyfin';
 import PlexTvAPI from '@server/api/plextv';
 import TautulliAPI from '@server/api/tautulli';
 import { MediaType } from '@server/constants/media';
+import { MediaServerType } from '@server/constants/server';
 import { UserType } from '@server/constants/user';
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
@@ -550,7 +551,10 @@ router.post(
                   default: 'mm',
                   size: 200,
                 }),
-            userType: UserType.JELLYFIN,
+            userType:
+              settings.main.mediaServerType === MediaServerType.JELLYFIN
+                ? UserType.JELLYFIN
+                : UserType.EMBY,
           });
 
           await userRepository.save(newUser);


### PR DESCRIPTION
#### Description

When importing users from Emby now it sets and displays the correct user type.

#### Screenshot (if UI-related)
![output](https://github.com/user-attachments/assets/4cab283a-163d-40c8-8a91-74ff56452a1c)


#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #948 
