### PR TITLE
Fix link to docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ With more features on the way! Check out our [issue tracker](https://github.com/
 
 Check out our documentation for instructions on how to install and run Jellyseerr:
 
-https://docs.jellyseerr.dev/getting-started/
+https://docs.jellyseerr.dev/getting-started
 
 ### Packages:
 


### PR DESCRIPTION
#### Description
The link to the documentation had a trailing backslash that broke it
#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #957 
