### PR TITLE
feat: refresh monitored downloads before getting queue items

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -76,7 +76,7 @@ class ExternalAPI {
     }
     const data = await this.getDataFromResponse(response);
 
-    if (this.cache) {
+    if (this.cache && ttl !== 0) {
       this.cache.set(cacheKey, data, ttl ?? DEFAULT_TTL);
     }
 
@@ -120,7 +120,7 @@ class ExternalAPI {
     }
     const resData = await this.getDataFromResponse(response);
 
-    if (this.cache) {
+    if (this.cache && ttl !== 0) {
       this.cache.set(cacheKey, resData, ttl ?? DEFAULT_TTL);
     }
 
@@ -164,7 +164,7 @@ class ExternalAPI {
     }
     const resData = await this.getDataFromResponse(response);
 
-    if (this.cache) {
+    if (this.cache && ttl !== 0) {
       this.cache.set(cacheKey, resData, ttl ?? DEFAULT_TTL);
     }
 

--- a/server/api/servarr/base.ts
+++ b/server/api/servarr/base.ts
@@ -157,9 +157,13 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
 
   public getQueue = async (): Promise<(QueueItem & QueueItemAppendT)[]> => {
     try {
-      const data = await this.get<QueueResponse<QueueItemAppendT>>(`/queue`, {
-        includeEpisode: 'true',
-      });
+      const data = await this.get<QueueResponse<QueueItemAppendT>>(
+        `/queue`,
+        {
+          includeEpisode: 'true',
+        },
+        0
+      );
 
       return data.records;
     } catch (e) {
@@ -193,15 +197,24 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
     }
   };
 
+  async refreshMonitoredDownloads(): Promise<void> {
+    await this.runCommand('RefreshMonitoredDownloads', {});
+  }
+
   protected async runCommand(
     commandName: string,
     options: Record<string, unknown>
   ): Promise<void> {
     try {
-      await this.post(`/command`, {
-        name: commandName,
-        ...options,
-      });
+      await this.post(
+        `/command`,
+        {
+          name: commandName,
+          ...options,
+        },
+        {},
+        0
+      );
     } catch (e) {
       throw new Error(`[${this.apiName}] Failed to run command: ${e.message}`);
     }

--- a/server/lib/downloadtracker.ts
+++ b/server/lib/downloadtracker.ts
@@ -85,6 +85,7 @@ class DownloadTracker {
           });
 
           try {
+            await radarr.refreshMonitoredDownloads();
             const queueItems = await radarr.getQueue();
 
             this.radarrServers[server.id] = queueItems.map((item) => ({
@@ -162,6 +163,7 @@ class DownloadTracker {
           });
 
           try {
+            await sonarr.refreshMonitoredDownloads();
             const queueItems = await sonarr.getQueue();
 
             this.sonarrServers[server.id] = queueItems.map((item) => ({


### PR DESCRIPTION
#### Description

Currently, we sync with sonarr/radarr with whatever value those return. Radarr/Sonarr syncs the activity from the download clients every few minutes. This leads to inaccurate estimated download times, because of the refresh delay with Jellyseerr and the *arrs.

This PR fixes this by making a request to the *arrs to refresh the monitored downloads just before we get these downloads information.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Re #866
