### PR TITLE
fix: remove language profiles dropdown for Sonarr v4

### DIFF
--- a/server/routes/service.ts
+++ b/server/routes/service.ts
@@ -123,9 +123,13 @@ serviceRoutes.get<{ sonarrId: string }>(
     });
 
     try {
+      const systemStatus = await sonarr.getSystemStatus();
+      const sonarrMajorVersion = Number(systemStatus.version.split('.')[0]);
+
       const profiles = await sonarr.getProfiles();
       const rootFolders = await sonarr.getRootFolders();
-      const languageProfiles = await sonarr.getLanguageProfiles();
+      const languageProfiles =
+        sonarrMajorVersion <= 3 ? await sonarr.getLanguageProfiles() : null;
       const tags = await sonarr.getTags();
 
       return res.status(200).json({

--- a/server/routes/settings/sonarr.ts
+++ b/server/routes/settings/sonarr.ts
@@ -43,13 +43,14 @@ sonarrRoutes.post('/test', async (req, res, next) => {
       url: SonarrAPI.buildUrl(req.body, '/api/v3'),
     });
 
-    const urlBase = await sonarr
-      .getSystemStatus()
-      .then((value) => value.urlBase)
-      .catch(() => req.body.baseUrl);
+    const systemStatus = await sonarr.getSystemStatus();
+    const sonarrMajorVersion = Number(systemStatus.version.split('.')[0]);
+
+    const urlBase = systemStatus.urlBase;
     const profiles = await sonarr.getProfiles();
     const folders = await sonarr.getRootFolders();
-    const languageProfiles = await sonarr.getLanguageProfiles();
+    const languageProfiles =
+      sonarrMajorVersion <= 3 ? await sonarr.getLanguageProfiles() : null;
     const tags = await sonarr.getTags();
 
     return res.status(200).json({

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -86,10 +86,12 @@ interface TestResponse {
     id: number;
     path: string;
   }[];
-  languageProfiles: {
-    id: number;
-    name: string;
-  }[];
+  languageProfiles:
+    | {
+        id: number;
+        name: string;
+      }[]
+    | null;
   tags: {
     id: number;
     label: string;
@@ -112,7 +114,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
   const [testResponse, setTestResponse] = useState<TestResponse>({
     profiles: [],
     rootFolders: [],
-    languageProfiles: [],
+    languageProfiles: null,
     tags: [],
   });
   const SonarrSettingsSchema = Yup.object().shape({
@@ -137,9 +139,11 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
     activeProfileId: Yup.string().required(
       intl.formatMessage(messages.validationProfileRequired)
     ),
-    activeLanguageProfileId: Yup.number().required(
-      intl.formatMessage(messages.validationLanguageProfileRequired)
-    ),
+    activeLanguageProfileId: testResponse.languageProfiles
+      ? Yup.number().required(
+          intl.formatMessage(messages.validationLanguageProfileRequired)
+        )
+      : Yup.number(),
     externalUrl: Yup.string()
       .url(intl.formatMessage(messages.validationApplicationUrl))
       .test(
@@ -658,54 +662,56 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                       )}
                   </div>
                 </div>
-                <div className="form-row">
-                  <label
-                    htmlFor="activeLanguageProfileId"
-                    className="text-label"
-                  >
-                    {intl.formatMessage(messages.languageprofile)}
-                    <span className="label-required">*</span>
-                  </label>
-                  <div className="form-input-area">
-                    <div className="form-input-field">
-                      <Field
-                        as="select"
-                        id="activeLanguageProfileId"
-                        name="activeLanguageProfileId"
-                        disabled={!isValidated || isTesting}
-                      >
-                        <option value="">
-                          {isTesting
-                            ? intl.formatMessage(
-                                messages.loadinglanguageprofiles
-                              )
-                            : !isValidated
-                            ? intl.formatMessage(
-                                messages.testFirstLanguageProfiles
-                              )
-                            : intl.formatMessage(
-                                messages.selectLanguageProfile
-                              )}
-                        </option>
-                        {testResponse.languageProfiles.length > 0 &&
-                          testResponse.languageProfiles.map((language) => (
-                            <option
-                              key={`loaded-profile-${language.id}`}
-                              value={language.id}
-                            >
-                              {language.name}
-                            </option>
-                          ))}
-                      </Field>
+                {testResponse.languageProfiles && (
+                  <div className="form-row">
+                    <label
+                      htmlFor="activeLanguageProfileId"
+                      className="text-label"
+                    >
+                      {intl.formatMessage(messages.languageprofile)}
+                      <span className="label-required">*</span>
+                    </label>
+                    <div className="form-input-area">
+                      <div className="form-input-field">
+                        <Field
+                          as="select"
+                          id="activeLanguageProfileId"
+                          name="activeLanguageProfileId"
+                          disabled={!isValidated || isTesting}
+                        >
+                          <option value="">
+                            {isTesting
+                              ? intl.formatMessage(
+                                  messages.loadinglanguageprofiles
+                                )
+                              : !isValidated
+                              ? intl.formatMessage(
+                                  messages.testFirstLanguageProfiles
+                                )
+                              : intl.formatMessage(
+                                  messages.selectLanguageProfile
+                                )}
+                          </option>
+                          {testResponse.languageProfiles.length > 0 &&
+                            testResponse.languageProfiles.map((language) => (
+                              <option
+                                key={`loaded-profile-${language.id}`}
+                                value={language.id}
+                              >
+                                {language.name}
+                              </option>
+                            ))}
+                        </Field>
+                      </div>
+                      {errors.activeLanguageProfileId &&
+                        touched.activeLanguageProfileId && (
+                          <div className="error">
+                            {errors.activeLanguageProfileId}
+                          </div>
+                        )}
                     </div>
-                    {errors.activeLanguageProfileId &&
-                      touched.activeLanguageProfileId && (
-                        <div className="error">
-                          {errors.activeLanguageProfileId}
-                        </div>
-                      )}
                   </div>
-                </div>
+                )}
                 <div className="form-row">
                   <label htmlFor="tags" className="text-label">
                     {intl.formatMessage(messages.tags)}
@@ -863,53 +869,55 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                       )}
                   </div>
                 </div>
-                <div className="form-row">
-                  <label
-                    htmlFor="activeAnimeLanguageProfileId"
-                    className="text-label"
-                  >
-                    {intl.formatMessage(messages.animelanguageprofile)}
-                  </label>
-                  <div className="form-input-area">
-                    <div className="form-input-field">
-                      <Field
-                        as="select"
-                        id="activeAnimeLanguageProfileId"
-                        name="activeAnimeLanguageProfileId"
-                        disabled={!isValidated || isTesting}
-                      >
-                        <option value="">
-                          {isTesting
-                            ? intl.formatMessage(
-                                messages.loadinglanguageprofiles
-                              )
-                            : !isValidated
-                            ? intl.formatMessage(
-                                messages.testFirstLanguageProfiles
-                              )
-                            : intl.formatMessage(
-                                messages.selectLanguageProfile
-                              )}
-                        </option>
-                        {testResponse.languageProfiles.length > 0 &&
-                          testResponse.languageProfiles.map((language) => (
-                            <option
-                              key={`loaded-profile-${language.id}`}
-                              value={language.id}
-                            >
-                              {language.name}
-                            </option>
-                          ))}
-                      </Field>
+                {testResponse.languageProfiles && (
+                  <div className="form-row">
+                    <label
+                      htmlFor="activeAnimeLanguageProfileId"
+                      className="text-label"
+                    >
+                      {intl.formatMessage(messages.animelanguageprofile)}
+                    </label>
+                    <div className="form-input-area">
+                      <div className="form-input-field">
+                        <Field
+                          as="select"
+                          id="activeAnimeLanguageProfileId"
+                          name="activeAnimeLanguageProfileId"
+                          disabled={!isValidated || isTesting}
+                        >
+                          <option value="">
+                            {isTesting
+                              ? intl.formatMessage(
+                                  messages.loadinglanguageprofiles
+                                )
+                              : !isValidated
+                              ? intl.formatMessage(
+                                  messages.testFirstLanguageProfiles
+                                )
+                              : intl.formatMessage(
+                                  messages.selectLanguageProfile
+                                )}
+                          </option>
+                          {testResponse.languageProfiles.length > 0 &&
+                            testResponse.languageProfiles.map((language) => (
+                              <option
+                                key={`loaded-profile-${language.id}`}
+                                value={language.id}
+                              >
+                                {language.name}
+                              </option>
+                            ))}
+                        </Field>
+                      </div>
+                      {errors.activeAnimeLanguageProfileId &&
+                        touched.activeAnimeLanguageProfileId && (
+                          <div className="error">
+                            {errors.activeAnimeLanguageProfileId}
+                          </div>
+                        )}
                     </div>
-                    {errors.activeAnimeLanguageProfileId &&
-                      touched.activeAnimeLanguageProfileId && (
-                        <div className="error">
-                          {errors.activeAnimeLanguageProfileId}
-                        </div>
-                      )}
                   </div>
-                </div>
+                )}
                 <div className="form-row">
                   <label htmlFor="tags" className="text-label">
                     {intl.formatMessage(messages.animeTags)}


### PR DESCRIPTION
#### Description

Currently, the language profiles removed with Sonarr v4 are still available for compatibility reasons. However, Jellyseerr still queries and displays language profiles (marking them as “Deprecated”). This PR hides and does not query language profiles unless Sonarr v3 is used.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #207
