### PR TITLE
fix(mediaUrl): use jellyfinMediaId4k for mediaUrl4k

### DIFF
--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -231,7 +231,7 @@ class Media {
         this.mediaUrl = `${jellyfinHost}/web/index.html#!/${pageName}?id=${this.jellyfinMediaId}&context=home&serverId=${serverId}`;
       }
       if (this.jellyfinMediaId4k) {
-        this.mediaUrl4k = `${jellyfinHost}/web/index.html#!/${pageName}?id=${this.jellyfinMediaId}&context=home&serverId=${serverId}`;
+        this.mediaUrl4k = `${jellyfinHost}/web/index.html#!/${pageName}?id=${this.jellyfinMediaId4k}&context=home&serverId=${serverId}`;
       }
     }
   }


### PR DESCRIPTION
#### Description
Fixes the issue where mediaUrl4K was still using the non-4k mediaId despite having the correct 4k Id stored.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #520 
