### PR TITLE
fix: handle non-existent rottentomatoes rating

### DIFF
--- a/server/api/rating/rottentomatoes.ts
+++ b/server/api/rating/rottentomatoes.ts
@@ -182,7 +182,7 @@ class RottenTomatoes extends ExternalAPI {
         );
       }
 
-      if (!tvshow) {
+      if (!tvshow || !tvshow.rottenTomatoes) {
         return null;
       }
 


### PR DESCRIPTION
#### Description

This fixes a bug where some media don't have any rottentomatoes ratings.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
