### PR TITLE
feat: exit Jellyseerr when migration fails

### DIFF
--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -648,7 +648,7 @@ class Settings {
 
     if (data) {
       const parsedJson = JSON.parse(data);
-      this.data = await runMigrations(parsedJson);
+      this.data = await runMigrations(parsedJson, SETTINGS_PATH);
 
       this.data = merge(this.data, parsedJson);
 

--- a/server/lib/settings/migrator.ts
+++ b/server/lib/settings/migrator.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import type { AllSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import fs from 'fs';
@@ -6,7 +7,8 @@ import path from 'path';
 const migrationsDir = path.join(__dirname, 'migrations');
 
 export const runMigrations = async (
-  settings: AllSettings
+  settings: AllSettings,
+  SETTINGS_PATH: string
 ): Promise<AllSettings> => {
   const migrations = fs
     .readdirSync(migrationsDir)
@@ -17,14 +19,43 @@ export const runMigrations = async (
   let migrated = settings;
 
   try {
+    const settingsBefore = JSON.stringify(migrated);
+
     for (const migration of migrations) {
       migrated = await migration(migrated);
+    }
+
+    const settingsAfter = JSON.stringify(migrated);
+
+    if (settingsBefore !== settingsAfter) {
+      // a migration occured
+      // we check that the new config will be saved
+      fs.writeFileSync(SETTINGS_PATH, JSON.stringify(migrated, undefined, ' '));
+      const fileSaved = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf-8'));
+      if (JSON.stringify(fileSaved) !== settingsAfter) {
+        // something went wrong while saving file
+        throw new Error('Unable to save settings after migration.');
+      }
     }
   } catch (e) {
     logger.error(
       `Something went wrong while running settings migrations: ${e.message}`,
       { label: 'Settings Migrator' }
     );
+    // we stop jellyseerr if the migration failed
+    console.log(
+      '===================================================================='
+    );
+    console.log(
+      '       SOMETHING WENT WRONG WHILE RUNNING SETTINGS MIGRATIONS       '
+    );
+    console.log(
+      '   Please check that your configuration folder is properly set up   '
+    );
+    console.log(
+      '===================================================================='
+    );
+    process.exit();
   }
 
   return migrated;


### PR DESCRIPTION
#### Description

Exit Jellyseerr if the migration fails because of a configuration error.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
