### PR TITLE
fix(request-list): wrong avatar rendered for the modifiedBy user in request list

### DIFF
--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -635,7 +635,7 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
                         <span className="avatar-sm ml-1.5">
                           <CachedImage
                             type="avatar"
-                            src={requestData.requestedBy.avatar}
+                            src={requestData.modifiedBy.avatar}
                             alt=""
                             className="avatar-sm object-cover"
                             width={20}


### PR DESCRIPTION
#### Description
This fixes an issue where when the request is modified it was showing the avatar of the requester instead of the modifiedBy user

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1017
