### PR TITLE
docs(aur): add disclaimer about being maintained by third-party

### DIFF
--- a/docs/getting-started/aur.mdx
+++ b/docs/getting-started/aur.mdx
@@ -6,6 +6,10 @@ sidebar_position: 4
 
 # AUR (Arch User Repository)
 
+:::note Disclaimer
+This AUR package is not maintained by us but by a third party. Please refer to the maintainer for any issues.
+:::
+
 :::info
 This method is not recommended for most users. It is intended for advanced users who are using Arch Linux or an Arch-based distribution.
 :::


### PR DESCRIPTION
This pull requests adds a disclaimer about aur package being maintained by a third-party and to refer to them for any issues