### PR TITLE
fix(externalapi): extract basic auth and pass it through header

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -32,13 +32,27 @@ class ExternalAPI {
       this.fetch = fetch;
     }
 
-    this.baseUrl = baseUrl;
-    this.params = params;
+    const url = new URL(baseUrl);
+
     this.defaultHeaders = {
       'Content-Type': 'application/json',
       Accept: 'application/json',
+      ...((url.username || url.password) && {
+        Authorization: `Basic ${Buffer.from(
+          `${url.username}:${url.password}`
+        ).toString('base64')}`,
+      }),
       ...options.headers,
     };
+
+    if (url.username || url.password) {
+      url.username = '';
+      url.password = '';
+      baseUrl = url.toString();
+    }
+
+    this.baseUrl = baseUrl;
+    this.params = params;
     this.cache = options.nodeCache;
   }
 


### PR DESCRIPTION
#### Description
This PR adds extraction of basic authentication credentials from the URL and then pass the credentials as the `Authorization` header. And then credentials are removed from the URL before being passed to fetch. This is done because fetch request cannot be constructed using a URL with credentials.

I have not tested whether the basic authentication works though. Will create a preview called `:preview-fix-basic-auth`

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Test if it works

#### Issues Fixed or Closed

- Fixes #1027
