### PR TITLE
fix(server/settings): write settings to a temp file then move

### DIFF
--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -682,10 +682,9 @@ class Settings {
   }
 
   public async save(): Promise<void> {
-    await fs.writeFile(
-      SETTINGS_PATH,
-      JSON.stringify(this.data, undefined, ' ')
-    );
+    const tmp = SETTINGS_PATH + '.tmp';
+    await fs.writeFile(tmp, JSON.stringify(this.data, undefined, ' '));
+    await fs.rename(tmp, SETTINGS_PATH);
   }
 }
 


### PR DESCRIPTION
When writing the settings.json file ensure that the file is fully written by writing it to temporary file before renaming it to the final settings path. This should prevent issues where the config gets lost due to the file being corrupted.

#### Description
When running in K8S both Jellyseerr and Overseerr have suffered from losing the config due to pod restarts, this change makes it so that the settings.json is first wirtten to a temporary file then it is renamed to its final name. This should help prevent cases where a partial or unflushed write cause the loss of the whole settings.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

