### PR TITLE
fix(i18n): update extractMessages function for better escaping of characters

### DIFF
--- a/src/i18n/extractMessages.ts
+++ b/src/i18n/extractMessages.ts
@@ -25,15 +25,14 @@ async function extractMessages(
     try {
       const formattedMessages = messages
         .trim()
-        .replace(/^\s*(['"])?([a-zA-Z0-9_-]+)(['"])?:/gm, '"$2":')
-        .replace(
-          /'.*'/g,
-          (match) =>
-            `"${match
-              .match(/'(.*)'/)?.[1]
-              .replace(/\\/g, '\\\\')
-              .replace(/"/g, '\\"')}"`
-        )
+        .replace(/^\s*(['"])?([a-zA-Z0-9_-]+)(['"])?:[\s\n]*/gm, '"$2":')
+        .replace(/^"[a-zA-Z0-9_-]+":'.*',?$/gm, (match) => {
+          const parts = /^("[a-zA-Z0-9_-]+":)'(.*)',?$/.exec(match);
+          if (!parts) return match;
+          return `${parts[1]}"${parts[2]
+            .replace(/\\/g, '\\\\')
+            .replace(/"/g, '\\"')}",`;
+        })
         .replace(/,$/, '');
       const messagesJson = JSON.parse(`{${formattedMessages}}`);
       return { namespace: namespace.trim(), messages: messagesJson };


### PR DESCRIPTION
#### Description

This PR fix a bug when a translation message has two single quote like `{"message": "hello 'world'"}`, the extractMessages function was escaping the message correctly.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
