### PR TITLE
fix(setup): add leading slash validation for baseUrl

### DIFF
--- a/src/components/Login/JellyfinLogin.tsx
+++ b/src/components/Login/JellyfinLogin.tsx
@@ -82,10 +82,17 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
       port: Yup.number().required(
         intl.formatMessage(messages.validationPortRequired)
       ),
-      urlBase: Yup.string().matches(
-        /^(.*[^/])$/,
-        intl.formatMessage(messages.validationUrlBaseTrailingSlash)
-      ),
+      urlBase: Yup.string()
+        .test(
+          'leading-slash',
+          intl.formatMessage(messages.validationUrlBaseLeadingSlash),
+          (value) => !value || value.startsWith('/')
+        )
+        .test(
+          'trailing-slash',
+          intl.formatMessage(messages.validationUrlBaseTrailingSlash),
+          (value) => !value || !value.endsWith('/')
+        ),
       email: Yup.string()
         .email(intl.formatMessage(messages.validationemailformat))
         .required(intl.formatMessage(messages.validationemailrequired)),


### PR DESCRIPTION
#### Description

Add a missing validation to ensure that the baseUrl starts with a slash.

#### Screenshot (if UI-related)

![image](https://github.com/user-attachments/assets/6aa87667-1fe1-444c-8ddc-c6f0ddf28f89)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)