### PR TITLE
fix(blacklist): request data only when modal is shown, remove useless ratelimit and lazy load blacklist

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -4142,6 +4142,21 @@ paths:
         '412':
           description: Item has already been blacklisted
   /blacklist/{tmdbId}:
+    get:
+      summary: Get media from blacklist
+      tags:
+        - blacklist
+      parameters:
+        - in: path
+          name: tmdbId
+          description: tmdbId ID
+          required: true
+          example: '1'
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Blacklist details in JSON
     delete:
       summary: Remove media from blacklist
       tags:

--- a/server/entity/Blacklist.ts
+++ b/server/entity/Blacklist.ts
@@ -80,12 +80,12 @@ export class Blacklist implements BlacklistItem {
         status: MediaStatus.BLACKLISTED,
         status4k: MediaStatus.BLACKLISTED,
         mediaType: blacklistRequest.mediaType,
-        blacklist: blacklist,
+        blacklist: Promise.resolve(blacklist),
       });
 
       await mediaRepository.save(media);
     } else {
-      media.blacklist = blacklist;
+      media.blacklist = Promise.resolve(blacklist);
       media.status = MediaStatus.BLACKLISTED;
       media.status4k = MediaStatus.BLACKLISTED;
 

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -118,10 +118,8 @@ class Media {
   @OneToMany(() => Issue, (issue) => issue.media, { cascade: true })
   public issues: Issue[];
 
-  @OneToOne(() => Blacklist, (blacklist) => blacklist.media, {
-    eager: true,
-  })
-  public blacklist: Blacklist;
+  @OneToOne(() => Blacklist, (blacklist) => blacklist.media)
+  public blacklist: Promise<Blacklist>;
 
   @CreateDateColumn()
   public createdAt: Date;

--- a/server/routes/blacklist.ts
+++ b/server/routes/blacklist.ts
@@ -7,7 +7,6 @@ import { Permission } from '@server/lib/permissions';
 import logger from '@server/logger';
 import { isAuthenticated } from '@server/middleware/auth';
 import { Router } from 'express';
-import rateLimit from 'express-rate-limit';
 import { EntityNotFoundError, QueryFailedError } from 'typeorm';
 import { z } from 'zod';
 
@@ -25,7 +24,6 @@ blacklistRoutes.get(
   isAuthenticated([Permission.MANAGE_BLACKLIST, Permission.VIEW_BLACKLIST], {
     type: 'or',
   }),
-  rateLimit({ windowMs: 60 * 1000, max: 50 }),
   async (req, res, next) => {
     const pageSize = req.query.take ? Number(req.query.take) : 25;
     const skip = req.query.skip ? Number(req.query.skip) : 0;

--- a/server/routes/blacklist.ts
+++ b/server/routes/blacklist.ts
@@ -2,14 +2,13 @@ import { MediaType } from '@server/constants/media';
 import { getRepository } from '@server/datasource';
 import { Blacklist } from '@server/entity/Blacklist';
 import Media from '@server/entity/Media';
-import { NotFoundError } from '@server/entity/Watchlist';
 import type { BlacklistResultsResponse } from '@server/interfaces/api/blacklistInterfaces';
 import { Permission } from '@server/lib/permissions';
 import logger from '@server/logger';
 import { isAuthenticated } from '@server/middleware/auth';
 import { Router } from 'express';
 import rateLimit from 'express-rate-limit';
-import { QueryFailedError } from 'typeorm';
+import { EntityNotFoundError, QueryFailedError } from 'typeorm';
 import { z } from 'zod';
 
 const blacklistRoutes = Router();
@@ -67,6 +66,32 @@ blacklistRoutes.get(
         status: 500,
         message: 'Unable to retrieve blacklisted items.',
       });
+    }
+  }
+);
+
+blacklistRoutes.get(
+  '/:id',
+  isAuthenticated([Permission.MANAGE_BLACKLIST], {
+    type: 'or',
+  }),
+  async (req, res, next) => {
+    try {
+      const blacklisteRepository = getRepository(Blacklist);
+
+      const blacklistItem = await blacklisteRepository.findOneOrFail({
+        where: { tmdbId: Number(req.params.id) },
+      });
+
+      return res.status(200).send(blacklistItem);
+    } catch (e) {
+      if (e instanceof EntityNotFoundError) {
+        return next({
+          status: 401,
+          message: e.message,
+        });
+      }
+      return next({ status: 500, message: e.message });
     }
   }
 );
@@ -134,7 +159,7 @@ blacklistRoutes.delete(
 
       return res.status(204).send();
     } catch (e) {
-      if (e instanceof NotFoundError) {
+      if (e instanceof EntityNotFoundError) {
         return next({
           status: 401,
           message: e.message,

--- a/src/components/BlacklistModal/index.tsx
+++ b/src/components/BlacklistModal/index.tsx
@@ -38,7 +38,7 @@ const BlacklistModal = ({
   const intl = useIntl();
 
   const { data, error } = useSWR<TvDetails | MovieDetails>(
-    `/api/v1/${type}/${tmdbId}`
+    show ? `/api/v1/${type}/${tmdbId}` : null
   );
 
   return (

--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -292,7 +292,7 @@ const ManageSlideOver = ({
             </h3>
             <div className="overflow-hidden rounded-md border border-gray-700 shadow">
               <BlacklistBlock
-                blacklistItem={data.mediaInfo.blacklist}
+                tmdbId={data.mediaInfo.tmdbId}
                 onUpdate={() => revalidate()}
                 onDelete={() => onClose()}
               />


### PR DESCRIPTION
#### Description

For admin users, the button to blacklist a media (used on every media card) was displaying a Modal, that was requesting data BEFORE the modal was displayed. This resulted in dozens of additional requests everytime media cards were displayed.

A useless ratelimit has also been removed on the blacklist endpoint.

Joins between the Media table and the Blacklist table will be lazy loaded instead of being eager loaded.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
