### PR TITLE
refactor(jellyfinapi): improve logging of jellyfin api

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -138,39 +138,38 @@ class JellyfinAPI extends ExternalAPI {
     try {
       return await authenticate(true);
     } catch (e) {
-      logger.debug(`Failed to authenticate with headers: ${e.message}`, {
+      logger.debug('Failed to authenticate with headers', {
         label: 'Jellyfin API',
+        error: e.cause.message ?? e.cause.statusText,
         ip: ClientIP,
       });
+
+      if (!e.cause.status) {
+        throw new ApiError(404, ApiErrorCode.InvalidUrl);
+      }
+
+      if (e.cause.status === 401) {
+        throw new ApiError(e.cause.status, ApiErrorCode.InvalidCredentials);
+      }
     }
 
     try {
       return await authenticate(false);
     } catch (e) {
-      const status = e.cause?.status;
-
-      const networkErrorCodes = new Set([
-        'ECONNREFUSED',
-        'EHOSTUNREACH',
-        'ENOTFOUND',
-        'ETIMEDOUT',
-        'ECONNRESET',
-        'EADDRINUSE',
-        'ENETDOWN',
-        'ENETUNREACH',
-        'EPIPE',
-        'ECONNABORTED',
-        'EPROTO',
-        'EHOSTDOWN',
-        'EAI_AGAIN',
-        'ERR_INVALID_URL',
-      ]);
-
-      if (networkErrorCodes.has(e.code) || status === 404) {
-        throw new ApiError(status, ApiErrorCode.InvalidUrl);
+      if (e.cause.status === 401) {
+        throw new ApiError(e.cause.status, ApiErrorCode.InvalidCredentials);
       }
 
-      throw new ApiError(status, ApiErrorCode.InvalidCredentials);
+      logger.error(
+        'Something went wrong while authenticating with the Jellyfin server',
+        {
+          label: 'Jellyfin API',
+          error: e.cause.message ?? e.cause.statusText,
+          ip: ClientIP,
+        }
+      );
+
+      throw new ApiError(e.cause.status, ApiErrorCode.Unknown);
     }
   }
 
@@ -198,8 +197,8 @@ class JellyfinAPI extends ExternalAPI {
       return serverResponse.ServerName;
     } catch (e) {
       logger.error(
-        `Something went wrong while getting the server name from the Jellyfin server: ${e.message}`,
-        { label: 'Jellyfin API' }
+        'Something went wrong while getting the server name from the Jellyfin server',
+        { label: 'Jellyfin API', error: e.cause.message ?? e.cause.statusText }
       );
 
       throw new ApiError(e.cause?.status, ApiErrorCode.Unknown);
@@ -213,8 +212,8 @@ class JellyfinAPI extends ExternalAPI {
       return { users: userReponse };
     } catch (e) {
       logger.error(
-        `Something went wrong while getting the account from the Jellyfin server: ${e.message}`,
-        { label: 'Jellyfin API' }
+        'Something went wrong while getting the account from the Jellyfin server',
+        { label: 'Jellyfin API', error: e.cause.message ?? e.cause.statusText }
       );
 
       throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
@@ -229,8 +228,8 @@ class JellyfinAPI extends ExternalAPI {
       return userReponse;
     } catch (e) {
       logger.error(
-        `Something went wrong while getting the account from the Jellyfin server: ${e.message}`,
-        { label: 'Jellyfin API' }
+        'Something went wrong while getting the account from the Jellyfin server',
+        { label: 'Jellyfin API', error: e.cause.message ?? e.cause.statusText }
       );
 
       throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
@@ -253,8 +252,11 @@ class JellyfinAPI extends ExternalAPI {
         return this.mapLibraries(mediaFolderResponse.Items);
       } catch (e) {
         logger.error(
-          `Something went wrong while getting libraries from the Jellyfin server: ${e.message}`,
-          { label: 'Jellyfin API' }
+          'Something went wrong while getting libraries from the Jellyfin server',
+          {
+            label: 'Jellyfin API',
+            error: e.cause.message ?? e.cause.statusText,
+          }
         );
 
         return [];
@@ -308,8 +310,8 @@ class JellyfinAPI extends ExternalAPI {
       );
     } catch (e) {
       logger.error(
-        `Something went wrong while getting library content from the Jellyfin server: ${e.message}`,
-        { label: 'Jellyfin API' }
+        'Something went wrong while getting library content from the Jellyfin server',
+        { label: 'Jellyfin API', error: e.cause.message ?? e.cause.statusText }
       );
 
       throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
@@ -329,8 +331,8 @@ class JellyfinAPI extends ExternalAPI {
       return itemResponse;
     } catch (e) {
       logger.error(
-        `Something went wrong while getting library content from the Jellyfin server: ${e.message}`,
-        { label: 'Jellyfin API' }
+        'Something went wrong while getting library content from the Jellyfin server',
+        { label: 'Jellyfin API', error: e.cause.message ?? e.cause.statusText }
       );
 
       throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
@@ -354,8 +356,8 @@ class JellyfinAPI extends ExternalAPI {
       }
 
       logger.error(
-        `Something went wrong while getting library content from the Jellyfin server: ${e.message}`,
-        { label: 'Jellyfin API' }
+        'Something went wrong while getting library content from the Jellyfin server',
+        { label: 'Jellyfin API', error: e.cause.message ?? e.cause.statusText }
       );
       throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
     }
@@ -368,8 +370,8 @@ class JellyfinAPI extends ExternalAPI {
       return seasonResponse.Items;
     } catch (e) {
       logger.error(
-        `Something went wrong while getting the list of seasons from the Jellyfin server: ${e.message}`,
-        { label: 'Jellyfin API' }
+        'Something went wrong while getting the list of seasons from the Jellyfin server',
+        { label: 'Jellyfin API', error: e.cause.message ?? e.cause.statusText }
       );
 
       throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
@@ -393,8 +395,8 @@ class JellyfinAPI extends ExternalAPI {
       );
     } catch (e) {
       logger.error(
-        `Something went wrong while getting the list of episodes from the Jellyfin server: ${e.message}`,
-        { label: 'Jellyfin API' }
+        'Something went wrong while getting the list of episodes from the Jellyfin server',
+        { label: 'Jellyfin API', error: e.cause.message ?? e.cause.statusText }
       );
 
       throw new ApiError(e.cause?.status, ApiErrorCode.InvalidAuthToken);
@@ -410,8 +412,8 @@ class JellyfinAPI extends ExternalAPI {
       ).AccessToken;
     } catch (e) {
       logger.error(
-        `Something went wrong while creating an API key from the Jellyfin server: ${e.message}`,
-        { label: 'Jellyfin API' }
+        'Something went wrong while creating an API key from the Jellyfin server',
+        { label: 'Jellyfin API', error: e.cause.message ?? e.cause.statusText }
       );
 
       throw new ApiError(e.response?.status, ApiErrorCode.InvalidAuthToken);


### PR DESCRIPTION
#### Description
This PR improves the logging of jellyfin api. This will also fix the wrong logging of throwing an invalid credentials when jellyfin/emby is unreachable.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Re #1053