### PR TITLE
fix(ui): allow thetvdb images for unmatched series

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,7 @@ module.exports = {
     remotePatterns: [
       { hostname: 'gravatar.com' },
       { hostname: 'image.tmdb.org' },
+      { hostname: 'artworks.thetvdb.com' },
     ],
   },
   webpack(config) {

--- a/src/components/RequestModal/SearchByNameModal/index.tsx
+++ b/src/components/RequestModal/SearchByNameModal/index.tsx
@@ -88,14 +88,14 @@ const SearchByNameModal = ({
                 tvdbId === item.tvdbId ? 'ring ring-indigo-500' : ''
               } `}
             >
-              <div className="flex w-24 flex-none items-center space-x-4">
+              <div className="relative flex w-24 flex-none items-center space-x-4 self-stretch">
                 <Image
                   src={
                     item.remotePoster ??
                     '/images/overseerr_poster_not_found.png'
                   }
                   alt={item.title}
-                  className="h-100 w-auto rounded-md"
+                  className="w-100 h-auto rounded-md"
                   fill
                 />
               </div>


### PR DESCRIPTION
#### Description

When a series has no equivalent in TheTVDB used by Sonarr, a popup is displayed to select the series on TheTVDB. The images in this popup come from artworks.thetvdb.com, which was not an authorized domain for Next.js images.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1075
