### PR TITLE
fix(avatarproxy): add support for Emby avatars

### DIFF
--- a/server/routes/avatarproxy.ts
+++ b/server/routes/avatarproxy.ts
@@ -54,9 +54,15 @@ router.get('/:jellyfinUserId', async (req, res) => {
       default: 'mm',
       size: 200,
     });
-    const jellyfinAvatarUrl = `${getHostname()}/UserImage?UserId=${
-      req.params.jellyfinUserId
-    }`;
+
+    const setttings = getSettings();
+    const jellyfinAvatarUrl =
+      setttings.main.mediaServerType === MediaServerType.JELLYFIN
+        ? `${getHostname()}/UserImage?UserId=${req.params.jellyfinUserId}`
+        : `${getHostname()}/Users/${
+            req.params.jellyfinUserId
+          }/Images/Primary?quality=90`;
+
     let imageData = await avatarImageCache.getImage(
       jellyfinAvatarUrl,
       fallbackUrl


### PR DESCRIPTION
#### Description

Refactoring avatarproxy to retrieve avatars from the Jellyfin API instead of the public endpoint broke Emby avatars that doesn't have this API method.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1101
