### PR TITLE
fix: use tmdb first as metadata provider and fallback to tvdb

### DIFF
--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -216,7 +216,9 @@ class JellyfinScanner {
             tvId: Number(metadata.ProviderIds.Tmdb),
           });
         } catch {
-          /* empty */
+          this.log('No TMDb ID found for this title.', 'debug', {
+            jellyfinitem,
+          });
         }
       }
       if (!tvShow && metadata.ProviderIds.Tvdb) {
@@ -500,7 +502,9 @@ class JellyfinScanner {
           }
         });
       } else {
-        this.log(`failed show: ${metadata.Name}`);
+        this.log('No TMDb or TVDb ID found for this title.', 'debug', {
+          jellyfinitem,
+        });
       }
     } catch (e) {
       this.log(

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -216,7 +216,7 @@ class JellyfinScanner {
             tvId: Number(metadata.ProviderIds.Tmdb),
           });
         } catch {
-          this.log('No TMDb ID found for this title.', 'debug', {
+          this.log('Unable to find TMDb ID for this title.', 'debug', {
             jellyfinitem,
           });
         }
@@ -227,7 +227,9 @@ class JellyfinScanner {
             tvdbId: Number(metadata.ProviderIds.Tvdb),
           });
         } catch {
-          /* empty */
+          this.log('Unable to find TVDb ID for this title.', 'debug', {
+            jellyfinitem,
+          });
         }
       }
 
@@ -502,7 +504,7 @@ class JellyfinScanner {
           }
         });
       } else {
-        this.log('No TMDb or TVDb ID found for this title.', 'debug', {
+        this.log('No information found for this show', 'debug', {
           jellyfinitem,
         });
       }

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -210,14 +210,23 @@ class JellyfinScanner {
         return;
       }
 
-      if (metadata.ProviderIds.Tvdb) {
-        tvShow = await this.tmdb.getShowByTvdbId({
-          tvdbId: Number(metadata.ProviderIds.Tvdb),
-        });
-      } else if (metadata.ProviderIds.Tmdb) {
-        tvShow = await this.tmdb.getTvShow({
-          tvId: Number(metadata.ProviderIds.Tmdb),
-        });
+      if (metadata.ProviderIds.Tmdb) {
+        try {
+          tvShow = await this.tmdb.getTvShow({
+            tvId: Number(metadata.ProviderIds.Tmdb),
+          });
+        } catch {
+          /* empty */
+        }
+      }
+      if (!tvShow && metadata.ProviderIds.Tvdb) {
+        try {
+          tvShow = await this.tmdb.getShowByTvdbId({
+            tvdbId: Number(metadata.ProviderIds.Tvdb),
+          });
+        } catch {
+          /* empty */
+        }
       }
 
       if (tvShow) {

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -504,9 +504,13 @@ class JellyfinScanner {
           }
         });
       } else {
-        this.log('No information found for this show', 'debug', {
-          jellyfinitem,
-        });
+        this.log(
+          `No information found for the show: ${metadata.Name}`,
+          'debug',
+          {
+            jellyfinitem,
+          }
+        );
       }
     } catch (e) {
       this.log(


### PR DESCRIPTION
#### Description

This PR changes the order of the metadata provider to TMDB first and then fallback to TheTVDB if no TMDB metadata is available. Previously, TheTVDB was used first and there was no fallback if the latter failed.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1137
