### PR TITLE
feat: Add release charts workflow

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,118 @@
+name: Release Charts
+
+on:
+    push:
+      branches:
+        - develop
+
+jobs:
+  package-helm-chart:
+    name: Package helm chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      has_artifacts: ${{ steps.check-artifacts.outputs.has_artifacts }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install helm
+        uses: azure/setup-helm@v4
+
+      - name: Package helm charts
+        run: |
+          mkdir -p ./.cr-release-packages
+          for chart in ./charts/*; do
+            if [ -d "$chart" ] && [ -f "$chart/Chart.yaml" ]; then
+              # get current version
+              current_version=$(grep '^version:' "$chart/Chart.yaml" | awk '{print $2}')
+              # get latest release version
+              oras discover ghcr.io/${GITHUB_REPOSITORY}/${chart} --output json |& tee oci-tags-output.log
+              previous_version=$(cat oci-tags-output.log | jq -r '.references[].tag' | sort -V | tail -n 1)
+
+              if [ "$current_version" != "$previous_version" ]; then
+                helm dependency build "$chart"
+                helm package "$chart" --destination ./.cr-release-packages
+              else
+                echo "No version change for $chart. Skipping."
+              fi
+            else
+              echo "Skipping $chart: Not a valid Helm chart"
+            fi
+          done
+
+      - name: Check if artifacts exist
+        id: check-artifacts
+        run: |
+          if ls .cr-release-packages/* >/dev/null 2>&1; then
+            echo "has_artifacts=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_artifacts=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: steps.check-artifacts.outputs.has_artifacts == 'true'
+        with:
+          name: artifacts
+          include-hidden-files: true
+          path: .cr-release-packages/
+
+  publish:
+    name: Publish to ghcr.io
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write # needed for pushing to github registry
+      id-token: write # needed for signing the images with GitHub OIDC Token
+    needs: [package-helm-chart]
+    if: needs.package-helm-chart.outputs.has_artifacts == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Install Oras
+        uses: oras-project/setup-oras@v1
+
+      - name: Downloads artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts
+          path: .cr-release-packages/
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        env:
+          COSIGN_YES: true
+        run: |
+          for chart in `find .cr-release-packages -name '*.tgz' -print`; do
+            # push chart to OCI  
+            helm push ${chart} oci://ghcr.io/${GITHUB_REPOSITORY@L} |& tee helm-push-output.log
+            file_name=${chart##*/}
+            chart_name=${file_name%-*}-charts
+            chart_digest=$(awk -F "[, ]+" '/Digest/{print $NF}' < helm-push-output.log)
+            # sign chart
+            cosign sign "ghcr.io/${GITHUB_REPOSITORY@L}/${chart_name}@${chart_digest}"
+            # push artifacthub-repo.yml to OCI
+            oras push \
+              ghcr.io/${GITHUB_REPOSITORY@L}/${chart_name}:artifacthub.io \
+              --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+              charts/$chart_name/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml \
+              |& tee oras-push-output.log
+            artifacthub_digest=$(grep "Digest:" oras-push-output.log | awk '{print $2}')
+            # sign artifacthub-repo.yml
+            cosign sign "ghcr.io/${GITHUB_REPOSITORY@L}/${chart_name}:artifacthub.io@${artifacthub_digest}"
+          done

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -102,7 +102,8 @@ jobs:
             # push chart to OCI  
             helm push ${chart} oci://ghcr.io/${GITHUB_REPOSITORY@L} |& tee helm-push-output.log
             file_name=${chart##*/}
-            chart_name=${file_name%-*}-charts
+            chart_folder=${file_name%-*}
+            chart_name=${chart_folder}-chart
             chart_digest=$(awk -F "[, ]+" '/Digest/{print $NF}' < helm-push-output.log)
             # sign chart
             cosign sign "ghcr.io/${GITHUB_REPOSITORY@L}/${chart_name}@${chart_digest}"
@@ -110,7 +111,7 @@ jobs:
             oras push \
               ghcr.io/${GITHUB_REPOSITORY@L}/${chart_name}:artifacthub.io \
               --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
-              charts/$chart_name/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml \
+              charts/$chart_folder/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml \
               |& tee oras-push-output.log
             artifacthub_digest=$(grep "Digest:" oras-push-output.log | awk '{print $2}')
             # sign artifacthub-repo.yml

--- a/charts/jellyseerr/.helmignore
+++ b/charts/jellyseerr/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# go template
+*.gotmpl

--- a/charts/jellyseerr/Chart.yaml
+++ b/charts/jellyseerr/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 kubeVersion: ">=1.23.0-0"
-name: Jellyseerr
+name: jellyseerr
 description: Jellyseerr helm chart for Kubernetes
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "2.1.0"
 maintainers:
   - name: Jellyseerr

--- a/charts/jellyseerr/README.md
+++ b/charts/jellyseerr/README.md
@@ -1,6 +1,6 @@
-# Jellyseerr
+# jellyseerr
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Jellyseerr helm chart for Kubernetes
 

--- a/charts/jellyseerr/artifacthub-repo.yml
+++ b/charts/jellyseerr/artifacthub-repo.yml
@@ -1,0 +1,4 @@
+repositoryID: <REPOSITORY ID>
+owners:
+  - name: <Your name>
+    email: <Your email>

--- a/docs/getting-started/kubernetes.mdx
+++ b/docs/getting-started/kubernetes.mdx
@@ -10,12 +10,12 @@ This method is not recommended for most users. It is intended for advanced users
 
 ## Installation
 ```console
-helm install jellyseerr oci://ghcr.io/fallenbagel/jellyseerr/jellyseerr-charts
+helm install jellyseerr oci://ghcr.io/fallenbagel/jellyseerr/jellyseerr-chart
 ```
 Helm values can be found in the Jellyseerr repository under [charts/jellyseerr/README.md](https://github.com/Fallenbagel/jellyseerr/tree/develop/charts/jellyseerr).
 
 Verify the signature with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) (replace <TAG>, with the TAG you want to verify) :
 ```console
-cosign verify ghcr.io/fallenbagel/jellyseerr/jellyseerr-charts:<TAG> --certificate-identity=https://github.com/Fallenbagel/jellyseerr/.github/workflows/helm.yml@refs/heads/main --certificate-oidc-issuer=https://token.ac
+cosign verify ghcr.io/fallenbagel/jellyseerr/jellyseerr-chart:<TAG> --certificate-identity=https://github.com/Fallenbagel/jellyseerr/.github/workflows/helm.yml@refs/heads/main --certificate-oidc-issuer=https://token.ac
 tions.githubusercontent.com
 ```

--- a/docs/getting-started/kubernetes.mdx
+++ b/docs/getting-started/kubernetes.mdx
@@ -1,0 +1,21 @@
+---
+title: Kubernetes
+description: Install Jellyseerr in Kubernetes
+sidebar_position: 5
+---
+# Kubernetes
+:::info
+This method is not recommended for most users. It is intended for advanced users who are using Kubernetes.
+:::
+
+## Installation
+```console
+helm install jellyseerr oci://ghcr.io/fallenbagel/jellyseerr/jellyseerr-charts
+```
+Helm values can be found in the Jellyseerr repository under [charts/jellyseerr/README.md](https://github.com/Fallenbagel/jellyseerr/tree/develop/charts/jellyseerr).
+
+Verify the signature with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) (replace <TAG>, with the TAG you want to verify) :
+```console
+cosign verify ghcr.io/fallenbagel/jellyseerr/jellyseerr-charts:<TAG> --certificate-identity=https://github.com/Fallenbagel/jellyseerr/.github/workflows/helm.yml@refs/heads/main --certificate-oidc-issuer=https://token.ac
+tions.githubusercontent.com
+```


### PR DESCRIPTION
### Description

Add a Helm chart release workflow. All charts will be signed using keyless signing (with Cosign) and published to `ghcr.io` with the image name `<chart name>-chart` to avoid conflicts with the Jellyseerr Docker image.  
The ArtifactHub configuration file will also be signed and pushed to the registry.

You can see an example in my fork :
- Package : https://github.com/M0NsTeRRR?tab=packages&repo_name=jellyseerr
- Workflow : https://github.com/M0NsTeRRR/jellyseerr/actions/runs/12222721711

### TO DO

[ArtifactHub](https://artifacthub.io/) is a CNCF project—a web-based application for discovering, installing, and publishing packages. Using ArtifactHub will help new users find this Helm chart and provide greater visibility for the project.

1. Create an account at [ArtifactHub](https://artifacthub.io/)).  
2. Register this repository.  
3. Create an `artifacthub-repo.yml` file in this PR inside the chart folder:  
   ```yaml
   repositoryID: <REPOSITORY ID>
   owners:
     - name: <Your Name>
       email: <Your Email>
   ```

Documentation: [ArtifactHub Verified Publisher Guide](https://artifacthub.io/docs/topics/repositories/#verified-publisher)  

#### Issues Fixed or Closed

- Fixes #1060
