### PR TITLE
fix(discover): resolve a typing issue with the WatchlistItem interface

### DIFF
--- a/server/interfaces/api/discoverInterfaces.ts
+++ b/server/interfaces/api/discoverInterfaces.ts
@@ -5,6 +5,7 @@ export interface GenreSliderItem {
 }
 
 export interface WatchlistItem {
+  id: number;
   ratingKey: string;
   tmdbId: number;
   mediaType: 'movie' | 'tv';

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -875,6 +875,7 @@ discoverRoutes.get<Record<string, unknown>, WatchlistResponse>(
       totalPages: Math.ceil(watchlist.totalSize / itemsPerPage),
       totalResults: watchlist.totalSize,
       results: watchlist.items.map((item) => ({
+        id: item.tmdbId,
         ratingKey: item.ratingKey,
         title: item.title,
         mediaType: item.type === 'show' ? 'tv' : 'movie',

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -764,6 +764,7 @@ router.get<{ id: string }, WatchlistResponse>(
       totalPages: Math.ceil(watchlist.totalSize / itemsPerPage),
       totalResults: watchlist.totalSize,
       results: watchlist.items.map((item) => ({
+        id: item.tmdbId,
         ratingKey: item.ratingKey,
         title: item.title,
         mediaType: item.type === 'show' ? 'tv' : 'movie',


### PR DESCRIPTION
#### Description

This issue introduced by #708 was breaking the build of the app. An `id` property was missing.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)