### PR TITLE
fix(emby): change default value of Accept-Encoding header

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -1,3 +1,5 @@
+import { MediaServerType } from '@server/constants/server';
+import { getSettings } from '@server/lib/settings';
 import type { RateLimitOptions } from '@server/utils/rateLimit';
 import rateLimit from '@server/utils/rateLimit';
 import type NodeCache from 'node-cache';
@@ -34,6 +36,8 @@ class ExternalAPI {
 
     const url = new URL(baseUrl);
 
+    const settings = getSettings();
+
     this.defaultHeaders = {
       'Content-Type': 'application/json',
       Accept: 'application/json',
@@ -41,6 +45,9 @@ class ExternalAPI {
         Authorization: `Basic ${Buffer.from(
           `${url.username}:${url.password}`
         ).toString('base64')}`,
+      }),
+      ...(settings.main.mediaServerType === MediaServerType.EMBY && {
+        'Accept-Encoding': 'gzip',
       }),
       ...options.headers,
     };


### PR DESCRIPTION
#### Description

An issue with undici throwing an error because the response body was not decompressed properly: https://github.com/nodejs/undici/issues/3762

```
TypeError: terminated
    at Fetch.onAborted (node:internal/deps/undici/undici:10916:53)
    at Fetch.emit (node:events:518:28)
    at Fetch.emit (node:domain:488:12)
    at Fetch.terminate (node:internal/deps/undici/undici:10102:14)
    at Fetch.fetchParams.controller.resume (node:internal/deps/undici/undici:10893:36)
    at processTicksAndRejections (node:internal/process/task_queues:95:5) {
  [cause]: Error: incorrect header check
      at Zlib.zlibOnError [as onerror] (node:zlib:189:17) {
      errno: -3,
      code: 'Z_DATA_ERROR'
    }
}
```

This PR forces the Accept-Encoding header to gzip without deflate for Emby.

This undici issue been fixed in undici 6.21, which is only available with Node.js 23.3.0, the current version of Node.js.
We will have to wait for the next Node.js v24 LTS version to remove this patch.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)