### PR TITLE
fix: Handle non-existent rottentomatoes rating for movies

### DIFF
--- a/server/api/rating/rottentomatoes.ts
+++ b/server/api/rating/rottentomatoes.ts
@@ -128,7 +128,7 @@ class RottenTomatoes extends ExternalAPI {
         movie = contentResults.hits.find((movie) => movie.title === name);
       }
 
-      if (!movie) {
+      if (!movie?.rottenTomatoes) {
         return null;
       }
 


### PR DESCRIPTION
#### Description

This fixes a bug where some movies don't have any rottentomatoes ratings, which causes ratings from other services to not show

#### Screenshot (if UI-related)

Before this change:
![Screen Shot 2024-12-20 at 12 37 49 AM](https://github.com/user-attachments/assets/bc0325b6-94b7-45de-8821-e985959ad0ce)

After this change:
![Screen Shot 2024-12-20 at 12 34 05 AM](https://github.com/user-attachments/assets/21a041cd-c612-4dd7-bc62-1fc7ac193134)

#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1168 