### PR TITLE
docs(buildfromsource): remove references to develop

### DIFF
--- a/docs/getting-started/buildfromsource.mdx
+++ b/docs/getting-started/buildfromsource.mdx
@@ -26,7 +26,7 @@ sudo mkdir -p /opt/jellyseerr && cd /opt/jellyseerr
 ```bash
 git clone https://github.com/Fallenbagel/jellyseerr.git
 cd jellyseerr
-git checkout develop # by default, you are on the develop branch so this step is not necessary
+git checkout main
 ```
 3. Install the dependencies:
 ```bash
@@ -57,9 +57,6 @@ PORT=5055
 
 ## specify on which interface to listen, by default jellyseerr listens on all interfaces
 #HOST=127.0.0.1
-
-## Uncomment if your media server is emby instead of jellyfin.
-# JELLYFIN_TYPE=emby
 
 ## Uncomment if you want to force Node.js to resolve IPv4 before IPv6 (advanced users only)
 # FORCE_IPV4_FIRST=true
@@ -203,7 +200,7 @@ cd C:\jellyseerr
 2. Clone the Jellyseerr repository and checkout the develop branch:
 ```powershell
 git clone https://github.com/Fallenbagel/jellyseerr.git .
-git checkout develop # by default, you are on the develop branch so this step is not necessary
+git checkout main
 ```
 3. Install the dependencies:
 ```powershell


### PR DESCRIPTION
Changed instructions that said to checkout to develop branch. Also removed `JELLYFIN_TYPE`