### PR TITLE
fix(requestlist): use default value of sort direction only if valid

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -5448,6 +5448,7 @@ paths:
           schema:
             type: string
             enum: [asc, desc]
+            nullable: true
             default: desc
         - in: query
           name: requestedBy

--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -87,8 +87,10 @@ const RequestList = () => {
 
       setCurrentFilter(filterSettings.currentFilter);
       setCurrentSort(filterSettings.currentSort);
-      setCurrentSortDirection(filterSettings.currentSortDirection);
       setCurrentPageSize(filterSettings.currentPageSize);
+      if (['asc', 'desc'].includes(filterSettings.currentSortDirection)) {
+        setCurrentSortDirection(filterSettings.currentSortDirection);
+      }
     }
 
     // If filter value is provided in query, use that instead


### PR DESCRIPTION
#### Description

The Sort Direction was loaded with values from the localStorage, but `undefined` was assigned if no previous Sort Direction existed, causing the client to send undefined as a string for the Sort Direction.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1147
