### PR TITLE
fix(ui): display Rotten Tomatoes for 0% ratings

### DIFF
--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -780,13 +780,13 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
           <div className="media-facts">
             {(!!data.voteCount ||
               (ratingData?.rt?.criticsRating &&
-                !!ratingData?.rt?.criticsScore) ||
+                typeof ratingData?.rt?.criticsScore === 'number') ||
               (ratingData?.rt?.audienceRating &&
                 !!ratingData?.rt?.audienceScore) ||
               ratingData?.imdb?.criticsScore) && (
               <div className="media-ratings">
                 {ratingData?.rt?.criticsRating &&
-                  !!ratingData?.rt?.criticsScore && (
+                  typeof ratingData?.rt?.criticsScore === 'number' && (
                     <Tooltip
                       content={intl.formatMessage(messages.rtcriticsscore)}
                     >


### PR DESCRIPTION
#### Description

The frontend was coercing the zero value to false.

#### Screenshot (if UI-related)

Before:
![image](https://github.com/user-attachments/assets/95d1217e-dfc2-48d5-8257-4b9d9488db35)
After:
![image](https://github.com/user-attachments/assets/d8e3e5f4-3ab0-4cfa-9450-4ebf59267f17)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1166
