### PR TITLE
docs: change the OpenAPI parameter for jellyfinUserIds

### DIFF
--- a/overseerr-api.yml
+++ b/overseerr-api.yml
@@ -3878,7 +3878,7 @@ paths:
             schema:
               type: object
               properties:
-                jellyfinIds:
+                jellyfinUserIds:
                   type: array
                   items:
                     type: string


### PR DESCRIPTION
#### Description

The OpenAPI spec had the wrong parameter name, which was fixed in this PR.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1161
