### PR TITLE
refactor(i18n): add better types to our custom defineMessages

### DIFF
--- a/src/components/Discover/DiscoverTvUpcoming.tsx
+++ b/src/components/Discover/DiscoverTvUpcoming.tsx
@@ -7,7 +7,9 @@ import defineMessages from '@app/utils/defineMessages';
 import type { TvResult } from '@server/models/Search';
 import { useIntl } from 'react-intl';
 
-const messages = defineMessages('components.DiscoverTvUpcoming', {});
+const messages = defineMessages('components.DiscoverTvUpcoming', {
+  upcomingtv: 'Upcoming Series',
+});
 
 const DiscoverTvUpcoming = () => {
   const intl = useIntl();

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -100,6 +100,7 @@
   "components.Discover.StudioSlider.studios": "Studios",
   "components.Discover.TvGenreList.seriesgenres": "Series Genres",
   "components.Discover.TvGenreSlider.tvgenres": "Series Genres",
+  "components.DiscoverTvUpcoming.upcomingtv": "Upcoming Series",
   "components.Discover.createnewslider": "Create New Slider",
   "components.Discover.customizediscover": "Customize Discover",
   "components.Discover.discover": "Discover",

--- a/src/utils/defineMessages.ts
+++ b/src/utils/defineMessages.ts
@@ -1,18 +1,26 @@
 import { defineMessages as intlDefineMessages } from 'react-intl';
 
-export default function defineMessages(
+type Messages<T extends Record<string, string>> = {
+  [K in keyof T]: {
+    id: string;
+    defaultMessage: T[K];
+  };
+};
+
+export default function defineMessages<T extends Record<string, string>>(
   prefix: string,
-  messages: Record<string, string>
-) {
-  const modifiedMessages: Record<
-    string,
-    { id: string; defaultMessage: string }
-  > = {};
-  for (const key of Object.keys(messages)) {
-    modifiedMessages[key] = {
-      id: prefix + '.' + key,
+  messages: T
+): Messages<T> {
+  const keys: (keyof T)[] = Object.keys(messages);
+  const modifiedMessagesEntries = keys.map((key) => [
+    key,
+    {
+      id: `${prefix}.${key as string}`,
       defaultMessage: messages[key],
-    };
-  }
+    },
+  ]);
+  const modifiedMessages: Messages<T> = Object.fromEntries(
+    modifiedMessagesEntries
+  );
   return intlDefineMessages(modifiedMessages);
 }


### PR DESCRIPTION
#### Description

Add better types to our custom `defineMessages` implementation replacing the one from `react-intl`.
The returned object will now be typed with the keys coming from the input of the `defineMessages`, to better intercept some mistakes with i18n messages.

#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
