### PR TITLE
fix: properly fetch sonarr/radarr specific override rules

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -208,14 +208,10 @@ export class MediaRequest {
       }
     }
 
-    // Apply overrides if the user is not an admin or has the "auto approve" permission
-    const useOverrides = !user.hasPermission(
-      [
-        requestBody.is4k ? Permission.AUTO_APPROVE_4K : Permission.AUTO_APPROVE,
-        Permission.MANAGE_REQUESTS,
-      ],
-      { type: 'or' }
-    );
+    // Apply overrides if the user is not an admin or has the "advanced request" permission
+    const useOverrides = !user.hasPermission([Permission.MANAGE_REQUESTS], {
+      type: 'or',
+    });
 
     let rootFolder = requestBody.rootFolder;
     let profileId = requestBody.profileId;

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -218,12 +218,19 @@ export class MediaRequest {
     let tags = requestBody.tags;
 
     if (useOverrides) {
+      const defaultRadarrId = requestBody.is4k
+        ? settings.radarr.findIndex((r) => r.is4k && r.isDefault)
+        : settings.radarr.findIndex((r) => !r.is4k && r.isDefault);
+      const defaultSonarrId = requestBody.is4k
+        ? settings.sonarr.findIndex((s) => s.is4k && s.isDefault)
+        : settings.sonarr.findIndex((s) => !s.is4k && s.isDefault);
+
       const overrideRuleRepository = getRepository(OverrideRule);
       const overrideRules = await overrideRuleRepository.find({
         where:
           requestBody.mediaType === MediaType.MOVIE
-            ? { radarrServiceId: 0 }
-            : { sonarrServiceId: 0 },
+            ? { radarrServiceId: defaultRadarrId }
+            : { sonarrServiceId: defaultSonarrId },
       });
 
       const appliedOverrideRules = overrideRules.filter((rule) => {


### PR DESCRIPTION
#### Description
- This will fetch the proper sonarr/radarr specific override rule to apply.
- This will skip override rules for anime TV shows unless the `overrideRule` explicitly includes the anime keyword.
- Apply the most specific override rule first (e.g., rules with multiple conditions like `genre`, `language`, and `keywords`)
- Debug logs for override rules

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
