### PR TITLE
fix(usersettings): fix the streaming region setting toggling itself

### DIFF
--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -157,7 +157,7 @@ const SettingsMain = () => {
             locale: data?.locale ?? 'en',
             discoverRegion: data?.discoverRegion,
             originalLanguage: data?.originalLanguage,
-            streamingRegion: data?.streamingRegion,
+            streamingRegion: data?.streamingRegion || 'US',
             partialRequestsEnabled: data?.partialRequestsEnabled,
             enableSpecialEpisodes: data?.enableSpecialEpisodes,
             trustProxy: data?.trustProxy,
@@ -451,7 +451,7 @@ const SettingsMain = () => {
                   <div className="form-input-area">
                     <div className="form-input-field">
                       <RegionSelector
-                        value={values.streamingRegion || 'US'}
+                        value={values.streamingRegion}
                         name="streamingRegion"
                         onChange={setFieldValue}
                         regionType="streaming"


### PR DESCRIPTION
#### Description

When the streaming region is set to another value than the default one, the setting starts toggling itself from the default value to the new value and vice-versa constantly

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1200
