### PR TITLE
fix(ui): resolve streaming region dropdown overlap

### DIFF
--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -433,7 +433,7 @@ const SettingsMain = () => {
                     </span>
                   </label>
                   <div className="form-input-area">
-                    <div className="form-input-field">
+                    <div className="form-input-field relative z-30">
                       <LanguageSelector
                         setFieldValue={setFieldValue}
                         value={values.originalLanguage}
@@ -449,7 +449,7 @@ const SettingsMain = () => {
                     </span>
                   </label>
                   <div className="form-input-area">
-                    <div className="form-input-field">
+                    <div className="form-input-field relative z-20">
                       <RegionSelector
                         value={values.streamingRegion}
                         name="streamingRegion"


### PR DESCRIPTION
#### Description

The streaming region selection field is always in the foreground and overlaps other open dropdowns.

#### Screenshot (if UI-related)

Before:
![image](https://github.com/user-attachments/assets/5cf62494-74ba-4476-86d9-015753871e3d)

After:
![image](https://github.com/user-attachments/assets/0bf40e48-6259-465e-afed-61b49e4299fd)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1206
