### PR TITLE
fix(setup): fix continue button disabled on refresh in setup 3

### DIFF
--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1137,6 +1137,7 @@
   "components.Setup.continue": "Continue",
   "components.Setup.finish": "Finish Setup",
   "components.Setup.finishing": "Finishing…",
+  "components.Setup.librarieserror": "Validation failed. Please toggle the libraries again to continue.",
   "components.Setup.servertype": "Choose Server Type",
   "components.Setup.setup": "Setup",
   "components.Setup.signin": "Sign In",


### PR DESCRIPTION
#### Description
This pr resolves an issue where the continue button in setup step 3 remained disabled after a page refresh even when libraries are toggled. This was happening because `mediaServerSettingsComplete` state was reset on refresh and not correctly re-initialized.

- The state is properly initialized from localStorage when the component mounts.
- Validation for enabled libraries is done when the state is hydrated so the continue button state is correct
- The continue button remains enabled if a library has already been toggled.

#### Screenshot (if UI-related)
**Previously** (there is a library enabled after refresh but continue button disabled until i re-toggle):
![image](https://github.com/user-attachments/assets/5cf1d8b2-4c84-4d98-b9f3-436e73575684)

After this PR the continue button will always stay enabled if there is a library setup. 

#### To-Dos

- [ ] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
