### PR TITLE
fix(users): correct request count query for PostgreSQL compatibility

### DIFF
--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -70,11 +70,11 @@ router.get('/', async (req, res, next) => {
         query = query
           .addSelect((subQuery) => {
             return subQuery
-              .select('COUNT(request.id)', 'requestCount')
+              .select('COUNT(request.id)', 'request_count')
               .from(MediaRequest, 'request')
               .where('request.requestedBy.id = user.id');
-          }, 'requestCount')
-          .orderBy('requestCount', 'DESC');
+          }, 'request_count')
+          .orderBy('request_count', 'DESC');
         break;
       default:
         query = query.orderBy('user.id', 'ASC');


### PR DESCRIPTION
#### Description
Fixes an infinite loading issue on the users page caused by incompatible request count query syntax with certain PostgreSQL configurations. The issue manifested as a "column requestcount does not exist" error when sorting users by request count.

#### Screenshot (if UI-related)
![image](https://github.com/user-attachments/assets/29ffa68c-0dbd-4dfe-bb6e-b23d3ecb038a)


#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
