### PR TITLE
fix: prevent TypeORM subscribers from calling itself over and over

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -719,7 +719,8 @@ export class MediaRequest {
       // Do not update the status if the item is already partially available or available
       media[this.is4k ? 'status4k' : 'status'] !== MediaStatus.AVAILABLE &&
       media[this.is4k ? 'status4k' : 'status'] !==
-        MediaStatus.PARTIALLY_AVAILABLE
+        MediaStatus.PARTIALLY_AVAILABLE &&
+      media[this.is4k ? 'status4k' : 'status'] !== MediaStatus.PROCESSING
     ) {
       media[this.is4k ? 'status4k' : 'status'] = MediaStatus.PROCESSING;
       mediaRepository.save(media);


### PR DESCRIPTION
#### Description

When a series is requested, an event is triggered by TypeORM after the request status has been updated. The function executed by this event updated the request status to "PROCESSING", even if the request already had this status. This triggered the same function once again, which repeated the update, in an endless loop.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
