### PR TITLE
fix(jellyfinlogin): add proper error message when no admin user exists

### DIFF
--- a/server/constants/error.ts
+++ b/server/constants/error.ts
@@ -4,6 +4,7 @@ export enum ApiErrorCode {
   InvalidAuthToken = 'INVALID_AUTH_TOKEN',
   InvalidEmail = 'INVALID_EMAIL',
   NotAdmin = 'NOT_ADMIN',
+  NoAdminUser = 'NO_ADMIN_USER',
   SyncErrorGroupedFolders = 'SYNC_ERROR_GROUPED_FOLDERS',
   SyncErrorNoLibraries = 'SYNC_ERROR_NO_LIBRARIES',
   Unknown = 'UNKNOWN',

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -313,7 +313,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
         body.serverType !== MediaServerType.JELLYFIN &&
         body.serverType !== MediaServerType.EMBY
       ) {
-        throw new Error('select_server_type');
+        throw new ApiError(500, ApiErrorCode.NoAdminUser);
       }
       settings.main.mediaServerType = body.serverType;
 
@@ -520,6 +520,22 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       case ApiErrorCode.NotAdmin:
         logger.warn(
           'Failed login attempt from user without admin permissions',
+          {
+            label: 'Auth',
+            account: {
+              ip: req.ip,
+              email: body.username,
+            },
+          }
+        );
+        return next({
+          status: e.statusCode,
+          message: e.errorCode,
+        });
+
+      case ApiErrorCode.NoAdminUser:
+        logger.warn(
+          'Failed login attempt from user without admin permissions and no admin user exists',
           {
             label: 'Auth',
             account: {


### PR DESCRIPTION
#### Description

This PR adds an error message when the database has no admin user and Jellyseerr has already been set up (i.e. settings.json is filled in), instead of having a generic error message.

#### Screenshot (if UI-related)

Before:
![image](https://github.com/user-attachments/assets/c3678e14-3641-41a6-9146-bbbfeb4d94ee)

After:
![image](https://github.com/user-attachments/assets/3b30b46b-c8fa-40ca-b94f-fdfc576f67b3)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

