### PR TITLE
fix(externalapi): clear cache after a request is made

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -293,6 +293,14 @@ class ExternalAPI {
     return data;
   }
 
+  protected removeCache(endpoint: string, params?: Record<string, string>) {
+    const cacheKey = this.serializeCacheKey(endpoint, {
+      ...this.params,
+      ...params,
+    });
+    this.cache?.del(cacheKey);
+  }
+
   private formatUrl(
     endpoint: string,
     params?: Record<string, string>,

--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -230,6 +230,23 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
       throw new Error(`[Radarr] Failed to remove movie: ${e.message}`);
     }
   };
+
+  public clearCache = ({
+    tmdbId,
+    externalId,
+  }: {
+    tmdbId?: number | null;
+    externalId?: number | null;
+  }) => {
+    if (tmdbId) {
+      this.removeCache('/movie/lookup', {
+        term: `tmdb:${tmdbId}`,
+      });
+    }
+    if (externalId) {
+      this.removeCache(`/movie/${externalId}`);
+    }
+  };
 }
 
 export default RadarrAPI;

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -353,6 +353,30 @@ class SonarrAPI extends ServarrBase<{
       throw new Error(`[Radarr] Failed to remove serie: ${e.message}`);
     }
   };
+
+  public clearCache = ({
+    tvdbId,
+    externalId,
+    title,
+  }: {
+    tvdbId?: number | null;
+    externalId?: number | null;
+    title?: string | null;
+  }) => {
+    if (tvdbId) {
+      this.removeCache('/series/lookup', {
+        term: `tvdb:${tvdbId}`,
+      });
+    }
+    if (externalId) {
+      this.removeCache(`/series/${externalId}`);
+    }
+    if (title) {
+      this.removeCache('/series/lookup', {
+        term: title,
+      });
+    }
+  };
 }
 
 export default SonarrAPI;

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -1006,6 +1006,14 @@ export class MediaRequest {
             );
 
             this.sendNotification(media, Notification.MEDIA_FAILED);
+          })
+          .finally(() => {
+            radarr.clearCache({
+              tmdbId: movie.id,
+              externalId: this.is4k
+                ? media.externalServiceId4k
+                : media.externalServiceId,
+            });
           });
         logger.info('Sent request to Radarr', {
           label: 'Media Request',
@@ -1288,6 +1296,15 @@ export class MediaRequest {
             );
 
             this.sendNotification(media, Notification.MEDIA_FAILED);
+          })
+          .finally(() => {
+            sonarr.clearCache({
+              tvdbId,
+              externalId: this.is4k
+                ? media.externalServiceId4k
+                : media.externalServiceId,
+              title: series.name,
+            });
           });
         logger.info('Sent request to Sonarr', {
           label: 'Media Request',


### PR DESCRIPTION
#### Description

This PR clears the Radarr/Sonarr cache after a request has been made, because the media status on Radarr/Sonarr will no longer be good. It also resolves a bug that prevented the media from being deleted after a request had been sent to Radarr/Sonarr.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1207
