### PR TITLE
feat(sidebar): show pending requests count in the sidebar

### DIFF
--- a/server/interfaces/api/requestInterfaces.ts
+++ b/server/interfaces/api/requestInterfaces.ts
@@ -20,3 +20,14 @@ export type MediaRequestBody = {
   userId?: number;
   tags?: number[];
 };
+
+export type RequestCountResponse = {
+  total: number;
+  movie: number;
+  tv: number;
+  pending: number;
+  approved: number;
+  declined: number;
+  processing: number;
+  available: number;
+};

--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -1,3 +1,4 @@
+import Badge from '@app/components/Common/Badge';
 import UserWarnings from '@app/components/Layout/UserWarnings';
 import VersionStatus from '@app/components/Layout/VersionStatus';
 import useClickOutside from '@app/hooks/useClickOutside';
@@ -15,11 +16,13 @@ import {
   UsersIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
+import type { RequestCountResponse } from '@server/interfaces/api/requestInterfaces';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Fragment, useRef } from 'react';
 import { useIntl } from 'react-intl';
+import useSWR from 'swr';
 
 export const menuMessages = defineMessages('components.Layout.Sidebar', {
   dashboard: 'Discover',
@@ -119,6 +122,9 @@ const Sidebar = ({ open, setClosed }: SidebarProps) => {
   const router = useRouter();
   const intl = useIntl();
   const { hasPermission } = useUser();
+  const { data: requests } = useSWR<RequestCountResponse>(
+    '/api/v1/request/count'
+  );
   useClickOutside(navRef, () => setClosed());
 
   return (
@@ -204,6 +210,15 @@ const Sidebar = ({ open, setClosed }: SidebarProps) => {
                             {intl.formatMessage(
                               menuMessages[sidebarLink.messagesKey]
                             )}
+                            {sidebarLink.messagesKey === 'requests' &&
+                              requests &&
+                              requests.pending > 0 && (
+                                <span className="ml-3">
+                                  <Badge badgeType="default">
+                                    {requests.pending}
+                                  </Badge>
+                                </span>
+                              )}
                           </Link>
                         );
                       })}
@@ -265,6 +280,15 @@ const Sidebar = ({ open, setClosed }: SidebarProps) => {
                       {intl.formatMessage(
                         menuMessages[sidebarLink.messagesKey]
                       )}
+                      {sidebarLink.messagesKey === 'requests' &&
+                        requests &&
+                        requests.pending > 0 && (
+                          <span className="ml-3">
+                            <Badge badgeType="default">
+                              {requests.pending}
+                            </Badge>
+                          </span>
+                        )}
                     </Link>
                   );
                 })}

--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -150,7 +150,11 @@ const Sidebar = ({ open, setClosed }: SidebarProps) => {
   const intl = useIntl();
   const { hasPermission } = useUser();
   const { data: requests } = useSWR<RequestCountResponse>(
-    '/api/v1/request/count'
+    hasPermission([Permission.MANAGE_REQUESTS, Permission.ADMIN], {
+      type: 'or',
+    })
+      ? '/api/v1/request/count'
+      : null
   );
   useClickOutside(navRef, () => setClosed());
 

--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -117,6 +117,33 @@ const SidebarLinks: SidebarLinkProps[] = [
   },
 ];
 
+const PendingRequestsBadge = ({
+  requests,
+  hasPermission,
+}: {
+  requests: RequestCountResponse | undefined;
+  hasPermission: (
+    permission: Permission | Permission[],
+    options?: { type: 'and' | 'or' }
+  ) => boolean;
+}) => {
+  if (
+    !hasPermission([Permission.MANAGE_REQUESTS, Permission.ADMIN], {
+      type: 'or',
+    }) ||
+    !requests ||
+    requests.pending === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <span className="ml-3">
+      <Badge badgeType="default">{requests.pending}</Badge>
+    </span>
+  );
+};
+
 const Sidebar = ({ open, setClosed }: SidebarProps) => {
   const navRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
@@ -210,15 +237,12 @@ const Sidebar = ({ open, setClosed }: SidebarProps) => {
                             {intl.formatMessage(
                               menuMessages[sidebarLink.messagesKey]
                             )}
-                            {sidebarLink.messagesKey === 'requests' &&
-                              requests &&
-                              requests.pending > 0 && (
-                                <span className="ml-3">
-                                  <Badge badgeType="default">
-                                    {requests.pending}
-                                  </Badge>
-                                </span>
-                              )}
+                            {sidebarLink.messagesKey === 'requests' && (
+                              <PendingRequestsBadge
+                                requests={requests}
+                                hasPermission={hasPermission}
+                              />
+                            )}
                           </Link>
                         );
                       })}
@@ -280,15 +304,12 @@ const Sidebar = ({ open, setClosed }: SidebarProps) => {
                       {intl.formatMessage(
                         menuMessages[sidebarLink.messagesKey]
                       )}
-                      {sidebarLink.messagesKey === 'requests' &&
-                        requests &&
-                        requests.pending > 0 && (
-                          <span className="ml-3">
-                            <Badge badgeType="default">
-                              {requests.pending}
-                            </Badge>
-                          </span>
-                        )}
+                      {sidebarLink.messagesKey === 'requests' && (
+                        <PendingRequestsBadge
+                          requests={requests}
+                          hasPermission={hasPermission}
+                        />
+                      )}
                     </Link>
                   );
                 })}

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -246,6 +246,7 @@
   "components.Login.initialsigningin": "Connecting…",
   "components.Login.invalidurlerror": "Unable to connect to {mediaServerName} server.",
   "components.Login.loginerror": "Something went wrong while trying to sign in.",
+  "components.Login.noadminerror": "No admin user found on the server.",
   "components.Login.password": "Password",
   "components.Login.port": "Port",
   "components.Login.save": "Add",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -246,7 +246,6 @@
   "components.Login.initialsigningin": "Connecting…",
   "components.Login.invalidurlerror": "Unable to connect to {mediaServerName} server.",
   "components.Login.loginerror": "Something went wrong while trying to sign in.",
-  "components.Login.noadminerror": "No admin user found on the server.",
   "components.Login.password": "Password",
   "components.Login.port": "Port",
   "components.Login.save": "Add",


### PR DESCRIPTION
#### Description

Add a pending requests count badge near the Requests tab in the sidebar, this helps to be able to view if there are any pending requests more easily rather than having to navigate specifically to the requests tab.

#### Screenshot (if UI-related)
<img width="254" alt="image" src="https://github.com/user-attachments/assets/36bff81f-9b29-4f98-9de5-ab1c8ff6a4bb" />
<img width="344" alt="image" src="https://github.com/user-attachments/assets/76897108-4b34-4f89-b6db-b34e97ebd3e4" />


#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- N.A
