### PR TITLE
fix: specify cached image type

### DIFF
--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -1074,6 +1074,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                           key={`provider-${p.id}`}
                         >
                           <CachedImage
+                            type="tmdb"
                             src={'https://image.tmdb.org/t/p/w45/' + p.logoPath}
                             alt={p.name}
                             width={32}

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -1254,6 +1254,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                           key={`provider-${p.id}`}
                         >
                           <CachedImage
+                            type="tmdb"
                             src={'https://image.tmdb.org/t/p/w45/' + p.logoPath}
                             alt={p.name}
                             width={32}


### PR DESCRIPTION
#### Description

Fix an issue introduced by #932, because CachedImage now requires to have a type (tmdb or avatar)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
