### PR TITLE
fix: resolve plex user mismatch due to caching issues

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -16,10 +16,6 @@ interface ExternalAPIOptions {
   rateLimit?: RateLimitOptions;
 }
 
-interface CustomRequestConfig extends RequestInit {
-  params?: Record<string, unknown>;
-}
-
 class ExternalAPI {
   protected fetch: typeof fetch;
   protected params: Record<string, string>;
@@ -71,10 +67,14 @@ class ExternalAPI {
     endpoint: string,
     params?: Record<string, string>,
     ttl?: number,
-    config?: CustomRequestConfig
+    config?: RequestInit
   ): Promise<T> {
     const headers = { ...this.defaultHeaders, ...config?.headers };
-    const cacheKey = this.serializeCacheKey(endpoint, config?.params, headers);
+    const cacheKey = this.serializeCacheKey(
+      endpoint,
+      { ...this.params, ...params },
+      headers
+    );
 
     const cachedItem = this.cache?.get<T>(cacheKey);
     if (cachedItem) {
@@ -114,10 +114,13 @@ class ExternalAPI {
     ttl?: number,
     config?: RequestInit
   ): Promise<T> {
-    const cacheKey = this.serializeCacheKey(endpoint, {
-      config: { ...this.params, ...params },
-      data,
-    });
+    const headers = { ...this.defaultHeaders, ...config?.headers };
+    const cacheKey = this.serializeCacheKey(
+      endpoint,
+      { ...this.params, ...params },
+      headers
+    );
+
     const cachedItem = this.cache?.get<T>(cacheKey);
     if (cachedItem) {
       return cachedItem;
@@ -158,10 +161,13 @@ class ExternalAPI {
     ttl?: number,
     config?: RequestInit
   ): Promise<T> {
-    const cacheKey = this.serializeCacheKey(endpoint, {
-      config: { ...this.params, ...params },
-      data,
-    });
+    const headers = { ...this.defaultHeaders, ...config?.headers };
+    const cacheKey = this.serializeCacheKey(
+      endpoint,
+      { ...this.params, ...params },
+      headers
+    );
+
     const cachedItem = this.cache?.get<T>(cacheKey);
     if (cachedItem) {
       return cachedItem;
@@ -230,10 +236,13 @@ class ExternalAPI {
     config?: RequestInit,
     overwriteBaseUrl?: string
   ): Promise<T> {
-    const cacheKey = this.serializeCacheKey(endpoint, {
-      ...this.params,
-      ...params,
-    });
+    const headers = { ...this.defaultHeaders, ...config?.headers };
+    const cacheKey = this.serializeCacheKey(
+      endpoint,
+      { ...this.params, ...params },
+      headers
+    );
+
     const cachedItem = this.cache?.get<T>(cacheKey);
 
     if (cachedItem) {

--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -70,11 +70,11 @@ class ExternalAPI {
     config?: RequestInit
   ): Promise<T> {
     const headers = { ...this.defaultHeaders, ...config?.headers };
-    const cacheKey = this.serializeCacheKey(
-      endpoint,
-      { ...this.params, ...params },
-      headers
-    );
+    const cacheKey = this.serializeCacheKey(endpoint, {
+      ...this.params,
+      ...params,
+      headers,
+    });
 
     const cachedItem = this.cache?.get<T>(cacheKey);
     if (cachedItem) {
@@ -84,10 +84,7 @@ class ExternalAPI {
     const url = this.formatUrl(endpoint, params);
     const response = await this.fetch(url, {
       ...config,
-      headers: {
-        ...this.defaultHeaders,
-        ...config?.headers,
-      },
+      headers,
     });
     if (!response.ok) {
       const text = await response.text();
@@ -115,11 +112,11 @@ class ExternalAPI {
     config?: RequestInit
   ): Promise<T> {
     const headers = { ...this.defaultHeaders, ...config?.headers };
-    const cacheKey = this.serializeCacheKey(
-      endpoint,
-      { ...this.params, ...params },
-      headers
-    );
+    const cacheKey = this.serializeCacheKey(endpoint, {
+      config: { ...this.params, ...params },
+      headers,
+      data,
+    });
 
     const cachedItem = this.cache?.get<T>(cacheKey);
     if (cachedItem) {
@@ -130,10 +127,7 @@ class ExternalAPI {
     const response = await this.fetch(url, {
       method: 'POST',
       ...config,
-      headers: {
-        ...this.defaultHeaders,
-        ...config?.headers,
-      },
+      headers,
       body: data ? JSON.stringify(data) : undefined,
     });
     if (!response.ok) {
@@ -162,11 +156,11 @@ class ExternalAPI {
     config?: RequestInit
   ): Promise<T> {
     const headers = { ...this.defaultHeaders, ...config?.headers };
-    const cacheKey = this.serializeCacheKey(
-      endpoint,
-      { ...this.params, ...params },
-      headers
-    );
+    const cacheKey = this.serializeCacheKey(endpoint, {
+      config: { ...this.params, ...params },
+      data,
+      headers,
+    });
 
     const cachedItem = this.cache?.get<T>(cacheKey);
     if (cachedItem) {
@@ -177,10 +171,7 @@ class ExternalAPI {
     const response = await this.fetch(url, {
       method: 'PUT',
       ...config,
-      headers: {
-        ...this.defaultHeaders,
-        ...config?.headers,
-      },
+      headers,
       body: JSON.stringify(data),
     });
     if (!response.ok) {
@@ -237,12 +228,11 @@ class ExternalAPI {
     overwriteBaseUrl?: string
   ): Promise<T> {
     const headers = { ...this.defaultHeaders, ...config?.headers };
-    const cacheKey = this.serializeCacheKey(
-      endpoint,
-      { ...this.params, ...params },
-      headers
-    );
-
+    const cacheKey = this.serializeCacheKey(endpoint, {
+      ...this.params,
+      ...params,
+      headers,
+    });
     const cachedItem = this.cache?.get<T>(cacheKey);
 
     if (cachedItem) {
@@ -256,10 +246,7 @@ class ExternalAPI {
         const url = this.formatUrl(endpoint, params, overwriteBaseUrl);
         this.fetch(url, {
           ...config,
-          headers: {
-            ...this.defaultHeaders,
-            ...config?.headers,
-          },
+          headers,
         }).then(async (response) => {
           if (!response.ok) {
             const text = await response.text();
@@ -282,10 +269,7 @@ class ExternalAPI {
     const url = this.formatUrl(endpoint, params, overwriteBaseUrl);
     const response = await this.fetch(url, {
       ...config,
-      headers: {
-        ...this.defaultHeaders,
-        ...config?.headers,
-      },
+      headers,
     });
     if (!response.ok) {
       const text = await response.text();
@@ -305,10 +289,10 @@ class ExternalAPI {
     return data;
   }
 
-  protected removeCache(endpoint: string, params?: Record<string, string>) {
+  protected removeCache(endpoint: string, options?: Record<string, string>) {
     const cacheKey = this.serializeCacheKey(endpoint, {
       ...this.params,
-      ...params,
+      ...options,
     });
     this.cache?.del(cacheKey);
   }
@@ -337,15 +321,13 @@ class ExternalAPI {
 
   private serializeCacheKey(
     endpoint: string,
-    params?: Record<string, unknown>,
-    headers?: Record<string, unknown>
+    options?: Record<string, unknown>
   ) {
-    const key = `${this.baseUrl}${endpoint}`;
-    if (!params && !headers) {
-      return key;
+    if (!options) {
+      return `${this.baseUrl}${endpoint}`;
     }
 
-    return `${key}${JSON.stringify({ params, headers })}`;
+    return `${this.baseUrl}${endpoint}${JSON.stringify(options)}`;
   }
 
   private async getDataFromResponse(response: Response) {


### PR DESCRIPTION
#### Description
This PR addresses an issue introduced with #840 where cached responses for PlexTV API requests returned incorrect user data when multiple users were logged in (when previous cache existed). This was caused by a shared cache key that did not account for differences in auth tokens, i.e `X-Plex-Token`. The `serializeCacheKey` method should now include headers in the cache key generation to ensure unique cache keys. This should fix the plex user mismatch that occurred due to the same cache key being used without accounting for the difference in auth token.

**_(Note)_**
_The reason this did not occur on axios was because it was creating a new axios instance in the constructor with its own base config for each user/token, while with fetch it was reusing the same instance with shared cache._

PR can be tested with the tag `preview-fix-plex-user-mismatch`

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1227
