### PR TITLE
style(overriderules): optimises the override rules tile for mobile

### DIFF
--- a/src/components/Settings/RadarrModal/index.tsx
+++ b/src/components/Settings/RadarrModal/index.tsx
@@ -776,7 +776,7 @@ const RadarrModal = ({
               <h3 className="mb-4 text-xl font-bold leading-8 text-gray-100">
                 {intl.formatMessage(messages.overrideRules)}
               </h3>
-              <ul className="grid grid-cols-2 gap-6">
+              <ul className="grid gap-x-4 gap-y-8 sm:grid-cols-3 sm:gap-x-6 sm:gap-y-6 lg:grid-cols-2">
                 {rules && (
                   <OverrideRuleTile
                     rules={rules}

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -1073,7 +1073,7 @@ const SonarrModal = ({
               <h3 className="mb-4 text-xl font-bold leading-8 text-gray-100">
                 {intl.formatMessage(messages.overrideRules)}
               </h3>
-              <ul className="grid grid-cols-2 gap-6">
+              <ul className="grid gap-x-4 gap-y-8 sm:grid-cols-3 sm:gap-x-6 sm:gap-y-6 lg:grid-cols-2">
                 {rules && (
                   <OverrideRuleTile
                     rules={rules}


### PR DESCRIPTION
#### Description
This should fix the override rule tile for mobile

#### Screenshot (if UI-related)
**Previously:**
![image](https://github.com/user-attachments/assets/34206308-23f3-47ee-a9ab-120e4ae49260)

**After:**
![image](https://github.com/user-attachments/assets/d8ad8adc-d0aa-4f5a-a6dc-66d5957a1132)


#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
