### PR TITLE
fix(settingsmigrator): prevent region migration from running multiple  times

### DIFF
--- a/server/lib/settings/migrations/0004_migrate_region_setting.ts
+++ b/server/lib/settings/migrations/0004_migrate_region_setting.ts
@@ -1,6 +1,13 @@
 import type { AllSettings } from '@server/lib/settings';
 
 const migrateRegionSetting = (settings: any): AllSettings => {
+  if (
+    settings.main.discoverRegion !== undefined &&
+    settings.main.streamingRegion !== undefined
+  ) {
+    return settings;
+  }
+
   const oldRegion = settings.main.region;
   if (oldRegion) {
     settings.main.discoverRegion = oldRegion;


### PR DESCRIPTION
#### Description
Adds a guard clause to skip region migration if discoverRegion and streamingRegion properties already exist in settings. This prevents accidental overwrites of existing region settings during multiple runs and ensures the migration only executes when needed.

Previously, the migration would run every time regardless of whether the new region properties existed, potentially overwriting user preferences.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1251
