### PR TITLE
fix(overriderules): allow override rules only when the service is created

### DIFF
--- a/src/components/Settings/RadarrModal/index.tsx
+++ b/src/components/Settings/RadarrModal/index.tsx
@@ -773,38 +773,42 @@ const RadarrModal = ({
                   </div>
                 </div>
               </div>
-              <h3 className="mb-4 text-xl font-bold leading-8 text-gray-100">
-                {intl.formatMessage(messages.overrideRules)}
-              </h3>
-              <ul className="grid gap-x-4 gap-y-8 sm:grid-cols-3 sm:gap-x-6 sm:gap-y-6 lg:grid-cols-2">
-                {rules && (
-                  <OverrideRuleTile
-                    rules={rules}
-                    setOverrideRuleModal={setOverrideRuleModal}
-                    testResponse={testResponse}
-                    radarr={radarr}
-                    revalidate={revalidate}
-                  />
-                )}
-                <li className="min-h-[8rem] rounded-lg border-2 border-dashed border-gray-400 shadow sm:min-h-[11rem]">
-                  <div className="flex h-full w-full items-center justify-center">
-                    <Button
-                      buttonType="ghost"
-                      onClick={() =>
-                        setOverrideRuleModal({
-                          open: true,
-                          rule: null,
-                          testResponse,
-                        })
-                      }
-                      disabled={!isValidated}
-                    >
-                      <PlusIcon />
-                      <span>{intl.formatMessage(messages.addrule)}</span>
-                    </Button>
-                  </div>
-                </li>
-              </ul>
+              {radarr && (
+                <>
+                  <h3 className="mb-4 text-xl font-bold leading-8 text-gray-100">
+                    {intl.formatMessage(messages.overrideRules)}
+                  </h3>
+                  <ul className="grid gap-x-4 gap-y-8 sm:grid-cols-3 sm:gap-x-6 sm:gap-y-6 lg:grid-cols-2">
+                    {rules && (
+                      <OverrideRuleTile
+                        rules={rules}
+                        setOverrideRuleModal={setOverrideRuleModal}
+                        testResponse={testResponse}
+                        radarr={radarr}
+                        revalidate={revalidate}
+                      />
+                    )}
+                    <li className="min-h-[8rem] rounded-lg border-2 border-dashed border-gray-400 shadow sm:min-h-[11rem]">
+                      <div className="flex h-full w-full items-center justify-center">
+                        <Button
+                          buttonType="ghost"
+                          onClick={() =>
+                            setOverrideRuleModal({
+                              open: true,
+                              rule: null,
+                              testResponse,
+                            })
+                          }
+                          disabled={!isValidated}
+                        >
+                          <PlusIcon />
+                          <span>{intl.formatMessage(messages.addrule)}</span>
+                        </Button>
+                      </div>
+                    </li>
+                  </ul>
+                </>
+              )}
             </Modal>
           );
         }}

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -1070,38 +1070,42 @@ const SonarrModal = ({
                   </div>
                 </div>
               </div>
-              <h3 className="mb-4 text-xl font-bold leading-8 text-gray-100">
-                {intl.formatMessage(messages.overrideRules)}
-              </h3>
-              <ul className="grid gap-x-4 gap-y-8 sm:grid-cols-3 sm:gap-x-6 sm:gap-y-6 lg:grid-cols-2">
-                {rules && (
-                  <OverrideRuleTile
-                    rules={rules}
-                    setOverrideRuleModal={setOverrideRuleModal}
-                    testResponse={testResponse}
-                    sonarr={sonarr}
-                    revalidate={revalidate}
-                  />
-                )}
-                <li className="min-h-[8rem] rounded-lg border-2 border-dashed border-gray-400 shadow sm:min-h-[11rem]">
-                  <div className="flex h-full w-full items-center justify-center">
-                    <Button
-                      buttonType="ghost"
-                      onClick={() =>
-                        setOverrideRuleModal({
-                          open: true,
-                          rule: null,
-                          testResponse,
-                        })
-                      }
-                      disabled={!isValidated}
-                    >
-                      <PlusIcon />
-                      <span>{intl.formatMessage(messages.addrule)}</span>
-                    </Button>
-                  </div>
-                </li>
-              </ul>
+              {sonarr && (
+                <>
+                  <h3 className="mb-4 text-xl font-bold leading-8 text-gray-100">
+                    {intl.formatMessage(messages.overrideRules)}
+                  </h3>
+                  <ul className="grid gap-x-4 gap-y-8 sm:grid-cols-3 sm:gap-x-6 sm:gap-y-6 lg:grid-cols-2">
+                    {rules && (
+                      <OverrideRuleTile
+                        rules={rules}
+                        setOverrideRuleModal={setOverrideRuleModal}
+                        testResponse={testResponse}
+                        sonarr={sonarr}
+                        revalidate={revalidate}
+                      />
+                    )}
+                    <li className="min-h-[8rem] rounded-lg border-2 border-dashed border-gray-400 shadow sm:min-h-[11rem]">
+                      <div className="flex h-full w-full items-center justify-center">
+                        <Button
+                          buttonType="ghost"
+                          onClick={() =>
+                            setOverrideRuleModal({
+                              open: true,
+                              rule: null,
+                              testResponse,
+                            })
+                          }
+                          disabled={!isValidated}
+                        >
+                          <PlusIcon />
+                          <span>{intl.formatMessage(messages.addrule)}</span>
+                        </Button>
+                      </div>
+                    </li>
+                  </ul>
+                </>
+              )}
             </Modal>
           );
         }}


### PR DESCRIPTION
#### Description

If you setup an override rule on a service that is not created yet, the override rule doesn't get added to the service because it has no ID, but a record for that override rule is nonetheless created. This PR allows override rules only when the service is setup.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
