### PR TITLE
refactor(tmdb): replace apikey

### DIFF
--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -108,7 +108,7 @@ class TheMovieDb extends ExternalAPI {
     super(
       'https://api.themoviedb.org/3',
       {
-        api_key: 'db55323b8d3e4154498498a75642b381',
+        api_key: '431a8708161bcd1f1fbe7536137e61ed',
       },
       {
         nodeCache: cacheManager.getCache('tmdb').data,


### PR DESCRIPTION
#### Description
This change is done to adhere with the TMDB rule of having one apikey per app and since jellyseerr has diverged from overseerr, it is best practice to use our own apikey so that TMDB can properly identify any issues that could be caused by jellyseerr

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
