### PR TITLE
ci: utilise the linux arm64 hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,12 @@ jobs:
   build_and_push:
     name: Build & Publish Docker Images
     if: github.ref == 'refs/heads/develop' && !contains(github.event.head_commit.message, '[skip ci]')
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix: [ubuntu-22.04, ubuntu-22.04-arm64]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to Docker Hub
@@ -75,13 +75,16 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          # platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.runner == 'ubuntu-22.04' && 'linux/amd64' || 'linux/arm64' }}
           push: true
           build-args: |
             COMMIT_TAG=${{ github.sha }}
           tags: |
             fallenbagel/jellyseerr:develop
             ghcr.io/${{ env.OWNER_LC }}/jellyseerr:develop
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   discord:
     name: Send Discord Notification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
     name: Build & Publish Docker Images
     if: github.ref == 'refs/heads/develop' && !contains(github.event.head_commit.message, '[skip ci]')
     strategy:
-      matrix: [ubuntu-22.04, ubuntu-22.04-arm64]
+      matrix:
+        runner: [ubuntu-22.04, ubuntu-22.04-arm64]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout


### PR DESCRIPTION
#### Description
This is an attempt to utilise the [linux arm64 hosted runners](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) which should reduce the build times significantly. In addition, this should leverage the github's built-in caching.

The PR for releases to utilise the aforementioned runner would follow this one.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
