### PR TITLE
ci:  attempt to fix the arm64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,8 @@ jobs:
     name: Build & Publish Docker Images
     if: github.ref == 'refs/heads/develop' && !contains(github.event.head_commit.message, '[skip ci]')
     strategy:
-<<<<<<< HEAD
       matrix:
         runner: [ubuntu-22.04, ubuntu-22.04-arm64]
-=======
-      matrix: [ubuntu-22.04, ubuntu-22.04-arm64]
->>>>>>> 56121c38 (ci: utilise the linux arm64 hosted runners)
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     name: Lint & Test Build
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: node:22-alpine
     steps:
       - name: Checkout
@@ -48,7 +48,11 @@ jobs:
     if: github.ref == 'refs/heads/develop' && !contains(github.event.head_commit.message, '[skip ci]')
     strategy:
       matrix:
-        runner: [ubuntu-22.04, ubuntu-22.04-arm64]
+        include:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+          - runner: ubuntu-24.04
+            platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
@@ -77,21 +81,22 @@ jobs:
           context: .
           file: ./Dockerfile
           # platforms: linux/amd64,linux/arm64
-          platforms: ${{ matrix.runner == 'ubuntu-22.04' && 'linux/amd64' || 'linux/arm64' }}
+          platforms: ${{ matrix.platform }}
           push: true
           build-args: |
             COMMIT_TAG=${{ github.sha }}
           tags: |
             fallenbagel/jellyseerr:develop
             ghcr.io/${{ env.OWNER_LC }}/jellyseerr:develop
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          provenance: false
 
   discord:
     name: Send Discord Notification
     needs: build_and_push
     if: always() && github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip ci]')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Get Build Job Status
         uses: technote-space/workflow-conclusion-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,12 @@ jobs:
     name: Build & Publish Docker Images
     if: github.ref == 'refs/heads/develop' && !contains(github.event.head_commit.message, '[skip ci]')
     strategy:
+<<<<<<< HEAD
       matrix:
         runner: [ubuntu-22.04, ubuntu-22.04-arm64]
+=======
+      matrix: [ubuntu-22.04, ubuntu-22.04-arm64]
+>>>>>>> 56121c38 (ci: utilise the linux arm64 hosted runners)
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout


### PR DESCRIPTION
#### Description
 Added platform specific cache scoping and turned off provenance to prevent manifest merging. In addition we are now using ubuntu24.04 in an attempt to get the job to run as ubuntu-22.04 were stalled for more than 18 hours.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
