### PR TITLE
ci: attempt to fix arm64 runners with proper scoped caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,11 @@ jobs:
     if: github.ref == 'refs/heads/develop' && !contains(github.event.head_commit.message, '[skip ci]')
     strategy:
       matrix:
-        runner: [ubuntu-22.04, ubuntu-22.04-arm64]
+        include:
+          - runner: ubuntu-22.04
+            platform: linux/amd64
+          - runner: ubuntu-22.04-arm64
+            platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
@@ -77,15 +81,16 @@ jobs:
           context: .
           file: ./Dockerfile
           # platforms: linux/amd64,linux/arm64
-          platforms: ${{ matrix.runner == 'ubuntu-22.04' && 'linux/amd64' || 'linux/arm64' }}
+          platforms: ${{ matrix.platform }}
           push: true
           build-args: |
             COMMIT_TAG=${{ github.sha }}
           tags: |
             fallenbagel/jellyseerr:develop
             ghcr.io/${{ env.OWNER_LC }}/jellyseerr:develop
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          provenance: false
 
   discord:
     name: Send Discord Notification


### PR DESCRIPTION
#### Description
Added platform specific cache scoping and turned off provenance to prevent manifest merging. In addition we are now using ubuntu24.04 in an attempt to get the job to run as ubuntu-22.04 were stalled for more than 18 hours.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
