### PR TITLE
ci: correct arm runner label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         include:
           - runner: ubuntu-24.04
             platform: linux/amd64
-          - runner: ubuntu-24.04-arm64
+          - runner: ubuntu-24.04-arm
             platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
#### Description
The issue was all because of using the wrong label. 18 hours wasted waiting for a non-existent runner to start. It is `ubuntu-24.04-arm`
https://github.com/orgs/community/discussions/148648#discussion-7793082

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
