### PR TITLE
ci: add a job to merge and create multi-arch image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,22 +75,46 @@ jobs:
           echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
         env:
           OWNER: ${{ github.repository_owner }}
-      - name: Build and push
+      - name: Build architecture specific images
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           # platforms: linux/amd64,linux/arm64
           platforms: ${{ matrix.platform }}
-          push: true
+          # dont push until merged
+          push: false
           build-args: |
             COMMIT_TAG=${{ github.sha }}
           tags: |
-            fallenbagel/jellyseerr:develop
-            ghcr.io/${{ env.OWNER_LC }}/jellyseerr:develop
+            fallenbagel/jellyseerr:develop-${{ matrix.platform }}
+            ghcr.io/${{ env.OWNER_LC }}/jellyseerr:develop-${{ matrix.platform }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           provenance: false
+
+  create_manifest:
+    name: Create Multi-Architecture Image
+    needs: build_and_push
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Create and Push Multi-Architecture Image
+        uses: docker/build-push-action@v5
+        with:
+          images: |
+            fallenbagel/jellyseerr:develop-linux-amd64
+            fallenbagel/jellyseerr:develop-linux-arm64
+            ghcr.io/${{ github.repository_owner }}/jellyseerr:develop-linux-amd64
+            ghcr.io/${{ github.repository_owner }}/jellyseerr:develop-linux-arm64
+          target: |
+            fallenbagel/jellyseerr:develop
+            ghcr.io/${{ github.repository_owner }}/jellyseerr:develop
+      - name: Inspect Manifest
+        run: |
+          docker buildx imagetools inspect fallenbagel/jellyseerr:develop
+          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/jellyseerr:develop
 
   discord:
     name: Send Discord Notification


### PR DESCRIPTION
#### Description
This has to be done now that arm64 and amd64 runs as two separate jobs. Otherwise, whichever finishes the last would override the other one when pushed

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
