### PR TITLE
ci: seperate job to pass in sanitised platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set lower case owner name
+      - name: Sanitize Owner and Platform name
         run: |
           echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+          echo "PLATFORM=${PLATFORM,,}' | sed 's|/|-|g')" >> $GITHUB_ENV
         env:
           OWNER: ${{ github.repository_owner }}
+          PLATFORM: ${{ matrix.platform }}
       - name: Build architecture specific images
         uses: docker/build-push-action@v5
         with:
@@ -87,8 +89,8 @@ jobs:
           build-args: |
             COMMIT_TAG=${{ github.sha }}
           tags: |
-            fallenbagel/jellyseerr:develop-${{ matrix.platform // '/' / '-' }}
-            ghcr.io/${{ env.OWNER_LC }}/jellyseerr:develop-${{ matrix.platform // '/' / '-' }}
+            fallenbagel/jellyseerr:develop-${{ env.PLATFORM }}
+            ghcr.io/${{ env.OWNER_LC }}/jellyseerr:develop-${{ env.PLATFORM }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           provenance: false


### PR DESCRIPTION
#### Description
This is done as github actions doesnt support inline replacement that was done on #1279

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
