### PR TITLE
ci: fix typo when sanitising platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Sanitize Owner and Platform name
         run: |
           echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
-          echo "PLATFORM=${PLATFORM,,}' | sed 's|/|-|g')" >> $GITHUB_ENV
+          echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >> $GITHUB_ENV
         env:
           OWNER: ${{ github.repository_owner }}
           PLATFORM: ${{ matrix.platform }}


### PR DESCRIPTION
#### Description
This pr fixes a typo made when sanitising the platform name in #1280 

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
