### PR TITLE
ci: fix typo when passing sanitised platform to github env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
           PLATFORM: 'linux/amd64'
       - name: Test Sanitized Variables
         run: |
-          echo "Sanitized Owner: ${OWNER_LC}"
-          echo "Sanitized Platform: ${PLATFORM}"
+          echo "Sanitized Owner: ${{ env.OWNER_LC }}"
+          echo "Sanitized Platform: ${{ env.PLATFORM }}"
       - name: Install dependencies
         env:
           HUSKY: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
           PLATFORM: 'linux/amd64'
       - name: Test Sanitized Variables
         run: |
-          echo "Sanitized Owner: ${{ env.OWNER_LC }}"
-          echo "Sanitized Platform: ${{ env.PLATFORM }}"
+          echo "Sanitized Owner: $OWNER_LC"
+          echo "Sanitized Platform: $PLATFORM"
       - name: Install dependencies
         env:
           HUSKY: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,6 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
-      - name: Sanitize Owner and Platform name
-        run: |
-          echo "OWNER_LC=$(echo '${OWNER}' | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
-          echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >>${GITHUB_ENV}
-        env:
-          OWNER: 'Fallenbagel'
-          PLATFORM: 'linux/amd64'
-      - name: Test Sanitized Variables
-        run: |
-          echo "Sanitized Owner: $OWNER_LC"
-          echo "Sanitized Platform: $PLATFORM"
       - name: Install dependencies
         env:
           HUSKY: 0
@@ -84,7 +73,7 @@ jobs:
       - name: Sanitize Owner and Platform name
         run: |
           echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
-          echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >>${GITHUB_ENV}
+          echo "PLATFORM=${PLATFORM,,} | sed 's|/|-|g')" >>${GITHUB_ENV}
         env:
           OWNER: ${{ github.repository_owner }}
           PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,14 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Sanitize Owner and Platform name
         run: |
-          echo "OWNER_LC=$(echo '${OWNER}' | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
           echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >>${GITHUB_ENV}
         env:
           OWNER: 'Fallenbagel'
           PLATFORM: 'linux/amd64'
       - name: Test sanitation
         run: |
-          echo "OWNER_LC=${OWNER,,}"
+          echo "OWNER_LC=${OWNER}"
           echo "PLATFORM=${PLATFORM}"
       - name: Install dependencies
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Sanitize Owner and Platform name
         run: |
-          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+          echo "OWNER_LC=$(echo '${OWNER}' | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
           echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >>${GITHUB_ENV}
         env:
           OWNER: 'Fallenbagel'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Sanitize Owner and Platform name
         run: |
-          echo "OWNER_LC=$(echo '${OWNER} | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
+          echo "OWNER_LC=$(echo '${OWNER}' | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
           echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >>${GITHUB_ENV}
         env:
           OWNER: 'Fallenbagel'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,17 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
+      - name: Sanitize Owner and Platform name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+          echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >>${GITHUB_ENV}
+        env:
+          OWNER: ${{ github.repository_owner }}
+          PLATFORM: ${{ matrix.platform }}
+      - name: Test sanitation
+        run: |
+          echo "OWNER_LC=${OWNER,,}"
+          echo "PLATFORM=${PLATFORM}"
       - name: Install dependencies
         env:
           HUSKY: 0
@@ -73,7 +84,7 @@ jobs:
       - name: Sanitize Owner and Platform name
         run: |
           echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
-          echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >> $GITHUB_ENV
+          echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >>${GITHUB_ENV}
         env:
           OWNER: ${{ github.repository_owner }}
           PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Sanitize Owner and Platform name
         run: |
-          echo "OWNER_LC=$(echo $OWNER | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
+          echo "OWNER_LC=$(echo '${OWNER} | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
           echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >>${GITHUB_ENV}
         env:
           OWNER: 'Fallenbagel'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
         env:
           OWNER: 'Fallenbagel'
           PLATFORM: 'linux/amd64'
-      - name: Test sanitation
+      - name: Test Sanitized Variables
         run: |
-          echo "OWNER_LC=${OWNER}"
-          echo "PLATFORM=${PLATFORM}"
+          echo "Sanitized Owner: ${OWNER_LC}"
+          echo "Sanitized Platform: ${PLATFORM}"
       - name: Install dependencies
         env:
           HUSKY: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Sanitize Owner and Platform name
         run: |
-          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+          echo "OWNER_LC=$(echo $OWNER | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
           echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >>${GITHUB_ENV}
         env:
-          OWNER: ${{ github.repository_owner }}
-          PLATFORM: ${{ matrix.platform }}
+          OWNER: 'Fallenbagel'
+          PLATFORM: 'linux/amd64'
       - name: Test sanitation
         run: |
           echo "OWNER_LC=${OWNER,,}"


### PR DESCRIPTION
#### Description
This PR fixes sanitation typo when passing to github env. This also adds the sanitation step to test so that we can test it before merging this pr. That part will be removed after testing.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
