### PR TITLE
ci: push individual arch digest only and merge from digest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,6 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
-      - name: Sanitize Owner and Platform name
-        run: |
-          echo "OWNER_LC=$(echo '${OWNER}' | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
-          echo "PLATFORM=$(echo '${PLATFORM}' | sed 's|/|-|g')" >>${GITHUB_ENV}
-        env:
-          OWNER: 'Fallenbagel'
-          PLATFORM: 'linux/amd64'
-      - name: Test Sanitized Variables
-        run: |
-          echo "Sanitized Owner: $OWNER_LC"
-          echo "Sanitized Platform: $PLATFORM"
       - name: Install dependencies
         env:
           HUSKY: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,12 @@ jobs:
         include:
           - runner: ubuntu-24.04
             platform: linux/amd64
-            id: amd64
           - runner: ubuntu-24.04-arm
             platform: linux/arm64
-            id: arm64
     runs-on: ${{ matrix.runner }}
     outputs:
-      digest-${{ matrix.id }}: ${{ steps.build.outputs.digest }}
+      digest-amd64: ${{ steps.set_outputs.outputs.digest-amd64 }}
+      digest-arm64: ${{ steps.set_outputs.outputs.digest-arm64 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -116,6 +115,11 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           provenance: false
+      - name: Set outputs
+        id: set_outputs
+        run: |
+          platform="${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}"
+          echo "digest-${platform}=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
 
   merge_and_push:
     name: Create and Push Multi-arch Manifest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
             type=ref,event=branch
             type=sha,prefix=,suffix=,format=short
       - name: Build and push by digest
+        id: ${{ matrix.platform == 'linux/amd64' && 'build-amd64' || 'build-arm64' }}
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
           - runner: ubuntu-24.04-arm
             platform: linux/arm64
     runs-on: ${{ matrix.runner }}
+    outputs:
+      digest-amd64: ${{ steps.build-amd64.outputs.digest }}
+      digest-arm64: ${{ steps.build-arm64.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -86,7 +89,17 @@ jobs:
           echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
         env:
           OWNER: ${{ github.repository_owner }}
-      - name: Build and push temp platform image
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            fallenbagel/jellyseerr
+            ghcr.io/${{ env.OWNER_LC }}/jellyseerr
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=,suffix=,format=short
+      - name: Build and push by digest
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -95,9 +108,9 @@ jobs:
           push: true
           build-args: |
             COMMIT_TAG=${{ github.sha }}
-          tags: |
-            fallenbagel/jellyseerr:temp-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
-            ghcr.io/${{ env.OWNER_LC }}/jellyseerr:temp-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          outputs: |
+            type=image,push-by-digest=true,name=fallenbagel/jellyseerr,push=true
+            type=image,push-by-digest=true,name=ghcr.io/${{ env.OWNER_LC }}/jellyseerr,push=true
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           provenance: false
@@ -126,14 +139,14 @@ jobs:
       - name: Create and push manifest
         run: |
           docker manifest create fallenbagel/jellyseerr:develop \
-            fallenbagel/jellyseerr:temp-amd64 \
-            fallenbagel/jellyseerr:temp-arm64
+            fallenbagel/jellyseerr:{{ needs.build.outputs.digest-amd64 }} \
+            fallenbagel/jellyseerr:{{ needs.build.outputs.digest-arm64 }}
           docker manifest push fallenbagel/jellyseerr:develop
 
           # GHCR manifest
           docker manifest create ghcr.io/${{ env.OWNER_LC }}/jellyseerr:develop \
-            ghcr.io/${{ env.OWNER_LC }}/jellyseerr:temp-amd64 \
-            ghcr.io/${{ env.OWNER_LC }}/jellyseerr:temp-arm64
+            ghcr.io/${{ env.OWNER_LC }}/jellyseerr:{{ needs.build.outputs.digest-amd64 }} \
+            ghcr.io/${{ env.OWNER_LC }}/jellyseerr:{{ needs.build.outputs.digest-arm64 }}
           docker manifest push ghcr.io/${{ env.OWNER_LC }}/jellyseerr:develop
 
   discord:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,14 +139,14 @@ jobs:
       - name: Create and push manifest
         run: |
           docker manifest create fallenbagel/jellyseerr:develop \
-            fallenbagel/jellyseerr:{{ needs.build.outputs.digest-amd64 }} \
-            fallenbagel/jellyseerr:{{ needs.build.outputs.digest-arm64 }}
+            --amend fallenbagel/jellyseerr@${{ needs.build.outputs.digest-amd64 }} \
+            --amend fallenbagel/jellyseerr@${{ needs.build.outputs.digest-arm64 }}
           docker manifest push fallenbagel/jellyseerr:develop
 
           # GHCR manifest
           docker manifest create ghcr.io/${{ env.OWNER_LC }}/jellyseerr:develop \
-            ghcr.io/${{ env.OWNER_LC }}/jellyseerr:{{ needs.build.outputs.digest-amd64 }} \
-            ghcr.io/${{ env.OWNER_LC }}/jellyseerr:{{ needs.build.outputs.digest-arm64 }}
+            --amend ghcr.io/${{ env.OWNER_LC }}/jellyseerr@${{ needs.build.outputs.digest-amd64 }} \
+            --amend ghcr.io/${{ env.OWNER_LC }}/jellyseerr@${{ needs.build.outputs.digest-arm64 }}
           docker manifest push ghcr.io/${{ env.OWNER_LC }}/jellyseerr:develop
 
   discord:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,13 @@ jobs:
         include:
           - runner: ubuntu-24.04
             platform: linux/amd64
+            id: amd64
           - runner: ubuntu-24.04-arm
             platform: linux/arm64
+            id: arm64
     runs-on: ${{ matrix.runner }}
     outputs:
-      digest-amd64: ${{ steps.build-amd64.outputs.digest }}
-      digest-arm64: ${{ steps.build-arm64.outputs.digest }}
+      digest-${{ matrix.id }}: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -100,7 +101,7 @@ jobs:
             type=ref,event=branch
             type=sha,prefix=,suffix=,format=short
       - name: Build and push by digest
-        id: ${{ matrix.platform == 'linux/amd64' && 'build-amd64' || 'build-arm64' }}
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
#### Description
This is an attempt to utilise the `push-by-digest` feature to push the individual architecture's digest into docker registry without tagging it and then combining those digests to create one multi-arch `develop` tag.

Reference: https://andrewlock.net/combining-multiple-docker-images-into-a-multi-arch-image/

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
