### PR TITLE
fix(setup): resolve looping library validation error message

### DIFF
--- a/src/components/Setup/index.tsx
+++ b/src/components/Setup/index.tsx
@@ -133,10 +133,6 @@ const Setup = () => {
         setCurrentStep(3);
       }
     }
-
-    if (currentStep === 3) {
-      validateLibraries();
-    }
   }, [
     settings.currentSettings.mediaServerType,
     settings.currentSettings.initialized,
@@ -147,6 +143,13 @@ const Setup = () => {
     mediaServerType,
     validateLibraries,
   ]);
+
+  useEffect(() => {
+    if (currentStep === 3) {
+      validateLibraries();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentStep]);
 
   const handleComplete = () => {
     validateLibraries();


### PR DESCRIPTION
#### Description

This PR fixes a bug where the validation error message is displayed over and over because of a React useEffect dependency issue. Previously, the `validateLibraries()` function was being called inside a useEffect that depended on a state that this function was updating.

#### Screenshot (if UI-related)

![image](https://github.com/user-attachments/assets/05a68bbf-d440-46dd-97c2-c1b1595caab1)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)