### PR TITLE
feat(settings): overridable settings config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 config/db/*.sqlite3*
 config/settings.json
 config/settings.old.json
+config/settings.override.json
 
 # logs
 config/logs/*.log*

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -319,6 +319,10 @@ const SETTINGS_PATH = process.env.CONFIG_DIRECTORY
   ? `${process.env.CONFIG_DIRECTORY}/settings.json`
   : path.join(__dirname, '../../../config/settings.json');
 
+const SETTINGS_OVERRIDE_PATH = process.env.CONFIG_DIRECTORY
+  ? `${process.env.CONFIG_DIRECTORY}/settings.override.json`
+  : path.join(__dirname, '../../../config/settings.override.json');
+
 class Settings {
   private data: AllSettings;
 
@@ -695,6 +699,12 @@ class Settings {
       this.data.vapidPublic = vapidKeys.publicKey;
       change = true;
     }
+
+    const defaultOverrideSettings = JSON.parse(
+      await fs.readFile(SETTINGS_OVERRIDE_PATH, 'utf-8').catch(() => '{}')
+    );
+    this.data = merge(this.data, defaultOverrideSettings);
+
     if (change) {
       await this.save();
     }


### PR DESCRIPTION
#### Description
Load the `settings.override.json` file from the config directory, if it is set. This is useful for automating deployment tools and server setup.

##### addition
I haven't read the migration related code and hope this PR won't break it.

As well as I opened the PR blindly, I'm not sure whether it would be better to open an issue first for this feature, as this might lead to a lot of documentation maintenance work.
Apologies in advance for any confusion I may cause, I'm opening this PR because I really want to be able to use this mechanism to set it persistently on the server.

Thank you for your work and this wonderful software anyway!

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed
