### PR TITLE
fix: resolve a vulnerability with admin token

### DIFF
--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -83,13 +83,13 @@ export class User {
   @Column({ nullable: true })
   public jellyfinUserId?: string;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, select: false })
   public jellyfinDeviceId?: string;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, select: false })
   public jellyfinAuthToken?: string;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, select: false })
   public plexToken?: string;
 
   @Column({ type: 'integer', default: 0 })

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -263,6 +263,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
     // Try to find deviceId that corresponds to jellyfin user, else generate a new one
     let user = await userRepository.findOne({
       where: { jellyfinUsername: body.username },
+      select: { id: true, jellyfinDeviceId: true },
     });
 
     let deviceId = '';


### PR DESCRIPTION
#### Description

By default, the jellyfinAuthToken of every user was always retrieved from the database, and sometimes sent back to the client. Any logged-in user could retrieve this token via a request containing admin user information, and use it to gain full access to Jellyfin. This PR removes the auth token and the device ID from the fields selected by default by TypeORM.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
