### PR TITLE
fix: missing plex.tv url in images remotePatterns

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ module.exports = {
       { hostname: 'gravatar.com' },
       { hostname: 'image.tmdb.org' },
       { hostname: 'artworks.thetvdb.com' },
+      { hostname: 'plex.tv' },
     ],
   },
   webpack(config) {


### PR DESCRIPTION
#### Description

This updates `next.config.js` to allow images from `plex.tv` in Next.js' built-in image optimization (`next/image`).
Previously, attempts to load Plex users' avatar during import resulted in a `400 Bad Request` error (`"url" parameter is not allowed`), as the domain was not explicitly whitelisted.