### PR TITLE
ci: set the pnpm version number explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ WORKDIR /app
 
 RUN apk add --no-cache tzdata tini && rm -rf /tmp/*
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9
 
 # copy from build image
 COPY --from=BUILD_IMAGE /app ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
   ;; \
   esac
 
-RUN npm install --global pnpm
+RUN npm install --global pnpm@9
 
 COPY package.json pnpm-lock.yaml postinstall-win.js ./
 RUN CYPRESS_INSTALL_BINARY=0 pnpm install --frozen-lockfile

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -3,7 +3,7 @@ FROM node:22-alpine
 COPY . /app
 WORKDIR /app
 
-Run npm install --global pnpm
+RUN npm install --global pnpm@9
 
 RUN pnpm install
 


### PR DESCRIPTION
#### Description

pnpm latest version is now v10. We still use v9, and the latest version of pnpm was used in Dockerfile instead of v9.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)