### PR TITLE
feat(notifications): Make embedded images optional

### DIFF
--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -108,7 +108,9 @@ class DiscordAgent
     type: Notification,
     payload: NotificationPayload
   ): DiscordRichEmbed {
-    const { applicationUrl } = getSettings().main;
+    const settings = getSettings();
+    const { applicationUrl } = settings.main;
+    const { embedImage } = settings.notifications.agents.discord;
 
     let color = EmbedColors.DARK_PURPLE;
     const fields: Field[] = [];
@@ -220,9 +222,11 @@ class DiscordAgent
           }
         : undefined,
       fields,
-      thumbnail: {
-        url: payload.image,
-      },
+      thumbnail: embedImage
+        ? {
+            url: payload.image,
+          }
+        : undefined,
     };
   }
 

--- a/server/lib/notifications/agents/email.ts
+++ b/server/lib/notifications/agents/email.ts
@@ -48,7 +48,9 @@ class EmailAgent
     recipientEmail: string,
     recipientName?: string
   ): EmailOptions | undefined {
-    const { applicationUrl, applicationTitle } = getSettings().main;
+    const settings = getSettings();
+    const { applicationUrl, applicationTitle } = settings.main;
+    const { embedImage } = settings.notifications.agents.email;
 
     if (type === Notification.TEST_NOTIFICATION) {
       return {
@@ -129,7 +131,7 @@ class EmailAgent
           body,
           mediaName: payload.subject,
           mediaExtra: payload.extra ?? [],
-          imageUrl: payload.image,
+          imageUrl: embedImage ? payload.image : undefined,
           timestamp: new Date().toTimeString(),
           requestedBy: payload.request.requestedBy.displayName,
           actionUrl: applicationUrl
@@ -176,7 +178,7 @@ class EmailAgent
           issueComment: payload.comment?.message,
           mediaName: payload.subject,
           extra: payload.extra ?? [],
-          imageUrl: payload.image,
+          imageUrl: embedImage ? payload.image : undefined,
           timestamp: new Date().toTimeString(),
           actionUrl: applicationUrl
             ? `${applicationUrl}/issues/${payload.issue.id}`

--- a/server/lib/notifications/agents/lunasea.ts
+++ b/server/lib/notifications/agents/lunasea.ts
@@ -22,12 +22,13 @@ class LunaSeaAgent
   }
 
   private buildPayload(type: Notification, payload: NotificationPayload) {
+    const { embedImage } = getSettings().notifications.agents.lunasea;
     return {
       notification_type: Notification[type],
       event: payload.event,
       subject: payload.subject,
       message: payload.message,
-      image: payload.image ?? null,
+      image: embedImage && payload.image != null ? payload.image : null,
       email: payload.notifyUser?.email,
       username: payload.notifyUser?.displayName,
       avatar: payload.notifyUser?.avatar,

--- a/server/lib/notifications/agents/pushover.ts
+++ b/server/lib/notifications/agents/pushover.ts
@@ -87,7 +87,9 @@ class PushoverAgent
     type: Notification,
     payload: NotificationPayload
   ): Promise<Partial<PushoverPayload>> {
-    const { applicationUrl, applicationTitle } = getSettings().main;
+    const settings = getSettings();
+    const { applicationUrl, applicationTitle } = settings.main;
+    const { embedImage } = settings.notifications.agents.pushover;
 
     const title = payload.event ?? payload.subject;
     let message = payload.event ? `<b>${payload.subject}</b>` : '';
@@ -164,7 +166,7 @@ class PushoverAgent
 
     let attachment_base64;
     let attachment_type;
-    if (payload.image) {
+    if (embedImage && payload.image) {
       const imagePayload = await this.getImagePayload(payload.image);
       if (imagePayload.attachment_base64 && imagePayload.attachment_type) {
         attachment_base64 = imagePayload.attachment_base64;

--- a/server/lib/notifications/agents/slack.ts
+++ b/server/lib/notifications/agents/slack.ts
@@ -62,7 +62,9 @@ class SlackAgent
     type: Notification,
     payload: NotificationPayload
   ): SlackBlockEmbed {
-    const { applicationUrl, applicationTitle } = getSettings().main;
+    const settings = getSettings();
+    const { applicationUrl, applicationTitle } = settings.main;
+    const { embedImage } = settings.notifications.agents.slack;
 
     const fields: EmbedField[] = [];
 
@@ -158,13 +160,14 @@ class SlackAgent
           type: 'mrkdwn',
           text: payload.message,
         },
-        accessory: payload.image
-          ? {
-              type: 'image',
-              image_url: payload.image,
-              alt_text: payload.subject,
-            }
-          : undefined,
+        accessory:
+          embedImage && payload.image
+            ? {
+                type: 'image',
+                image_url: payload.image,
+                alt_text: payload.subject,
+              }
+            : undefined,
       });
     }
 

--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -64,7 +64,9 @@ class TelegramAgent
     type: Notification,
     payload: NotificationPayload
   ): Partial<TelegramMessagePayload | TelegramPhotoPayload> {
-    const { applicationUrl, applicationTitle } = getSettings().main;
+    const settings = getSettings();
+    const { applicationUrl, applicationTitle } = settings.main;
+    const { embedImage } = settings.notifications.agents.telegram;
 
     /* eslint-disable no-useless-escape */
     let message = `\*${this.escapeText(
@@ -141,7 +143,7 @@ class TelegramAgent
     }
     /* eslint-enable */
 
-    return payload.image
+    return embedImage && payload.image
       ? {
           photo: payload.image,
           caption: message,
@@ -159,7 +161,7 @@ class TelegramAgent
   ): Promise<boolean> {
     const settings = this.getSettings();
     const endpoint = `${this.baseUrl}bot${settings.options.botAPI}/${
-      payload.image ? 'sendPhoto' : 'sendMessage'
+      settings.embedImage && payload.image ? 'sendPhoto' : 'sendMessage'
     }`;
     const notificationPayload = this.getNotificationPayload(type, payload);
 

--- a/server/lib/notifications/agents/webpush.ts
+++ b/server/lib/notifications/agents/webpush.ts
@@ -39,6 +39,8 @@ class WebPushAgent
     type: Notification,
     payload: NotificationPayload
   ): PushNotificationPayload {
+    const { embedImage } = getSettings().notifications.agents.webpush;
+
     const mediaType = payload.media
       ? payload.media.mediaType === MediaType.MOVIE
         ? 'movie'
@@ -125,7 +127,7 @@ class WebPushAgent
       notificationType: Notification[type],
       subject: payload.subject,
       message,
-      image: payload.image,
+      image: embedImage ? payload.image : undefined,
       requestId: payload.request?.id,
       actionUrl,
       actionUrlTitle,

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -169,6 +169,7 @@ interface FullPublicSettings extends PublicSettings {
 
 export interface NotificationAgentConfig {
   enabled: boolean;
+  embedImage: boolean;
   types?: number;
   options: Record<string, unknown>;
 }
@@ -391,6 +392,7 @@ class Settings {
         agents: {
           email: {
             enabled: false,
+            embedImage: true,
             options: {
               userEmailRequired: false,
               emailFrom: '',
@@ -405,6 +407,7 @@ class Settings {
           },
           discord: {
             enabled: false,
+            embedImage: true,
             types: 0,
             options: {
               webhookUrl: '',
@@ -414,6 +417,7 @@ class Settings {
           },
           lunasea: {
             enabled: false,
+            embedImage: true,
             types: 0,
             options: {
               webhookUrl: '',
@@ -421,6 +425,7 @@ class Settings {
           },
           slack: {
             enabled: false,
+            embedImage: true,
             types: 0,
             options: {
               webhookUrl: '',
@@ -428,6 +433,7 @@ class Settings {
           },
           telegram: {
             enabled: false,
+            embedImage: true,
             types: 0,
             options: {
               botAPI: '',
@@ -438,6 +444,7 @@ class Settings {
           },
           pushbullet: {
             enabled: false,
+            embedImage: false,
             types: 0,
             options: {
               accessToken: '',
@@ -445,6 +452,7 @@ class Settings {
           },
           pushover: {
             enabled: false,
+            embedImage: true,
             types: 0,
             options: {
               accessToken: '',
@@ -454,6 +462,7 @@ class Settings {
           },
           webhook: {
             enabled: false,
+            embedImage: true,
             types: 0,
             options: {
               webhookUrl: '',
@@ -463,10 +472,12 @@ class Settings {
           },
           webpush: {
             enabled: false,
+            embedImage: true,
             options: {},
           },
           gotify: {
             enabled: false,
+            embedImage: false,
             types: 0,
             options: {
               url: '',

--- a/server/routes/settings/notifications.ts
+++ b/server/routes/settings/notifications.ts
@@ -270,6 +270,7 @@ notificationRoutes.get('/webhook', (_req, res) => {
 
   const response: typeof webhookSettings = {
     enabled: webhookSettings.enabled,
+    embedImage: webhookSettings.embedImage,
     types: webhookSettings.types,
     options: {
       ...webhookSettings.options,
@@ -291,6 +292,7 @@ notificationRoutes.post('/webhook', async (req, res, next) => {
 
     settings.notifications.agents.webhook = {
       enabled: req.body.enabled,
+      embedImage: req.body.embedImage,
       types: req.body.types,
       options: {
         jsonPayload: Buffer.from(req.body.options.jsonPayload).toString(
@@ -321,6 +323,7 @@ notificationRoutes.post('/webhook/test', async (req, res, next) => {
 
     const testBody = {
       enabled: req.body.enabled,
+      embedImage: req.body.embedImage,
       types: req.body.types,
       options: {
         jsonPayload: Buffer.from(req.body.options.jsonPayload).toString(

--- a/server/templates/email/media-request/html.pug
+++ b/server/templates/email/media-request/html.pug
@@ -53,10 +53,11 @@ div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
                       b(style='color: #9ca3af; font-weight: 700;')
                         | #{extra.name}&nbsp;
                       | #{extra.value}
-              td(rowspan='2' style='width: 7rem;')
-                a(style='display: block; width: 7rem; overflow: hidden; border-radius: .375rem;' href=actionUrl)
-                  div(style='overflow: hidden; box-sizing: border-box; margin: 0px;')
-                    img(alt='' src=imageUrl style='box-sizing: border-box; padding: 0px; border: none; margin: auto; display: block; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;')
+              if imageUrl
+                td(rowspan='2' style='width: 7rem;')
+                  a(style='display: block; width: 7rem; overflow: hidden; border-radius: .375rem;' href=actionUrl)
+                    div(style='overflow: hidden; box-sizing: border-box; margin: 0px;')
+                      img(alt='' src=imageUrl style='box-sizing: border-box; padding: 0px; border: none; margin: auto; display: block; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;')
             tr
               td(style='font-size: .85em; color: #9ca3af; line-height: 1em; vertical-align: bottom; margin-right: 1rem')
                 span

--- a/src/components/Settings/Notifications/NotificationsDiscord.tsx
+++ b/src/components/Settings/Notifications/NotificationsDiscord.tsx
@@ -14,6 +14,7 @@ import * as Yup from 'yup';
 
 const messages = defineMessages('components.Settings.Notifications', {
   agentenabled: 'Enable Agent',
+  embedImage: 'Embed Image',
   botUsername: 'Bot Username',
   botAvatarUrl: 'Bot Avatar URL',
   webhookUrl: 'Webhook URL',
@@ -73,6 +74,7 @@ const NotificationsDiscord = () => {
     <Formik
       initialValues={{
         enabled: data.enabled,
+        embedImage: data.embedImage,
         types: data.types,
         botUsername: data?.options.botUsername,
         botAvatarUrl: data?.options.botAvatarUrl,
@@ -90,6 +92,7 @@ const NotificationsDiscord = () => {
             },
             body: JSON.stringify({
               enabled: values.enabled,
+              embedImage: values.embedImage,
               types: values.types,
               options: {
                 botUsername: values.botUsername,
@@ -148,6 +151,7 @@ const NotificationsDiscord = () => {
                 },
                 body: JSON.stringify({
                   enabled: true,
+                  embedImage: values.embedImage,
                   types: values.types,
                   options: {
                     botUsername: values.botUsername,
@@ -190,6 +194,14 @@ const NotificationsDiscord = () => {
               </label>
               <div className="form-input-area">
                 <Field type="checkbox" id="enabled" name="enabled" />
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="embedImage" className="checkbox-label">
+                {intl.formatMessage(messages.embedImage)}
+              </label>
+              <div className="form-input-area">
+                <Field type="checkbox" id="embedImage" name="embedImage" />
               </div>
             </div>
             <div className="form-row">

--- a/src/components/Settings/Notifications/NotificationsEmail.tsx
+++ b/src/components/Settings/Notifications/NotificationsEmail.tsx
@@ -16,6 +16,7 @@ const messages = defineMessages('components.Settings.Notifications', {
   validationSmtpHostRequired: 'You must provide a valid hostname or IP address',
   validationSmtpPortRequired: 'You must provide a valid port number',
   agentenabled: 'Enable Agent',
+  embedImage: 'Embed Image',
   userEmailRequired: 'Require user email',
   emailsender: 'Sender Address',
   smtpHost: 'SMTP Host',
@@ -126,6 +127,7 @@ const NotificationsEmail = () => {
     <Formik
       initialValues={{
         enabled: data.enabled,
+        embedImage: data.embedImage,
         userEmailRequired: data.options.userEmailRequired,
         emailFrom: data.options.emailFrom,
         smtpHost: data.options.smtpHost,
@@ -154,6 +156,7 @@ const NotificationsEmail = () => {
             },
             body: JSON.stringify({
               enabled: values.enabled,
+              embedImage: values.embedImage,
               options: {
                 userEmailRequired: values.userEmailRequired,
                 emailFrom: values.emailFrom,
@@ -212,6 +215,7 @@ const NotificationsEmail = () => {
                 },
                 body: JSON.stringify({
                   enabled: true,
+                  embedImage: values.embedImage,
                   options: {
                     emailFrom: values.emailFrom,
                     smtpHost: values.smtpHost,
@@ -259,6 +263,14 @@ const NotificationsEmail = () => {
               </label>
               <div className="form-input-area">
                 <Field type="checkbox" id="enabled" name="enabled" />
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="embedImage" className="checkbox-label">
+                {intl.formatMessage(messages.embedImage)}
+              </label>
+              <div className="form-input-area">
+                <Field type="checkbox" id="embedImage" name="embedImage" />
               </div>
             </div>
             <div className="form-row">

--- a/src/components/Settings/Notifications/NotificationsLunaSea/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsLunaSea/index.tsx
@@ -15,6 +15,7 @@ const messages = defineMessages(
   'components.Settings.Notifications.NotificationsLunaSea',
   {
     agentenabled: 'Enable Agent',
+    embedImage: 'Embed Image',
     webhookUrl: 'Webhook URL',
     webhookUrlTip:
       'Your user- or device-based <LunaSeaLink>notification webhook URL</LunaSeaLink>',
@@ -61,6 +62,7 @@ const NotificationsLunaSea = () => {
     <Formik
       initialValues={{
         enabled: data.enabled,
+        embedImage: data.embedImage,
         types: data.types,
         webhookUrl: data.options.webhookUrl,
         profileName: data.options.profileName,
@@ -75,6 +77,7 @@ const NotificationsLunaSea = () => {
             },
             body: JSON.stringify({
               enabled: values.enabled,
+              embedImage: values.embedImage,
               types: values.types,
               options: {
                 webhookUrl: values.webhookUrl,
@@ -129,6 +132,7 @@ const NotificationsLunaSea = () => {
                 },
                 body: JSON.stringify({
                   enabled: true,
+                  embedImage: values.embedImage,
                   types: values.types,
                   options: {
                     webhookUrl: values.webhookUrl,
@@ -168,6 +172,14 @@ const NotificationsLunaSea = () => {
               </label>
               <div className="form-input-area">
                 <Field type="checkbox" id="enabled" name="enabled" />
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="embedImage" className="checkbox-label">
+                {intl.formatMessage(messages.embedImage)}
+              </label>
+              <div className="form-input-area">
+                <Field type="checkbox" id="embedImage" name="embedImage" />
               </div>
             </div>
             <div className="form-row">

--- a/src/components/Settings/Notifications/NotificationsPushover/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsPushover/index.tsx
@@ -16,6 +16,7 @@ const messages = defineMessages(
   'components.Settings.Notifications.NotificationsPushover',
   {
     agentenabled: 'Enable Agent',
+    embedImage: 'Embed Image',
     accessToken: 'Application API Token',
     accessTokenTip:
       '<ApplicationRegistrationLink>Register an application</ApplicationRegistrationLink> for use with Jellyseerr',
@@ -85,6 +86,7 @@ const NotificationsPushover = () => {
     <Formik
       initialValues={{
         enabled: data?.enabled,
+        embedImage: data?.embedImage,
         types: data?.types,
         accessToken: data?.options.accessToken,
         userToken: data?.options.userToken,
@@ -100,6 +102,7 @@ const NotificationsPushover = () => {
             },
             body: JSON.stringify({
               enabled: values.enabled,
+              embedImage: values.embedImage,
               types: values.types,
               options: {
                 accessToken: values.accessToken,
@@ -154,6 +157,7 @@ const NotificationsPushover = () => {
                 },
                 body: JSON.stringify({
                   enabled: true,
+                  embedImage: values.embedImage,
                   types: values.types,
                   options: {
                     accessToken: values.accessToken,
@@ -193,6 +197,14 @@ const NotificationsPushover = () => {
               </label>
               <div className="form-input-area">
                 <Field type="checkbox" id="enabled" name="enabled" />
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="embedImage" className="checkbox-label">
+                {intl.formatMessage(messages.embedImage)}
+              </label>
+              <div className="form-input-area">
+                <Field type="checkbox" id="embedImage" name="embedImage" />
               </div>
             </div>
             <div className="form-row">

--- a/src/components/Settings/Notifications/NotificationsSlack/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsSlack/index.tsx
@@ -15,6 +15,7 @@ const messages = defineMessages(
   'components.Settings.Notifications.NotificationsSlack',
   {
     agentenabled: 'Enable Agent',
+    embedImage: 'Embed Image',
     webhookUrl: 'Webhook URL',
     webhookUrlTip:
       'Create an <WebhookLink>Incoming Webhook</WebhookLink> integration',
@@ -58,6 +59,7 @@ const NotificationsSlack = () => {
     <Formik
       initialValues={{
         enabled: data.enabled,
+        embedImage: data.embedImage,
         types: data.types,
         webhookUrl: data.options.webhookUrl,
       }}
@@ -71,6 +73,7 @@ const NotificationsSlack = () => {
             },
             body: JSON.stringify({
               enabled: values.enabled,
+              embedImage: values.embedImage,
               types: values.types,
               options: {
                 webhookUrl: values.webhookUrl,
@@ -124,6 +127,7 @@ const NotificationsSlack = () => {
                 },
                 body: JSON.stringify({
                   enabled: true,
+                  embedImage: values.embedImage,
                   types: values.types,
                   options: {
                     webhookUrl: values.webhookUrl,
@@ -162,6 +166,14 @@ const NotificationsSlack = () => {
               </label>
               <div className="form-input-area">
                 <Field type="checkbox" id="enabled" name="enabled" />
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="embedImage" className="checkbox-label">
+                {intl.formatMessage(messages.embedImage)}
+              </label>
+              <div className="form-input-area">
+                <Field type="checkbox" id="embedImage" name="embedImage" />
               </div>
             </div>
             <div className="form-row">

--- a/src/components/Settings/Notifications/NotificationsTelegram.tsx
+++ b/src/components/Settings/Notifications/NotificationsTelegram.tsx
@@ -14,6 +14,7 @@ import * as Yup from 'yup';
 
 const messages = defineMessages('components.Settings.Notifications', {
   agentenabled: 'Enable Agent',
+  embedImage: 'Embed Image',
   botUsername: 'Bot Username',
   botUsernameTip:
     'Allow users to also start a chat with your bot and configure their own notifications',
@@ -88,6 +89,7 @@ const NotificationsTelegram = () => {
     <Formik
       initialValues={{
         enabled: data?.enabled,
+        embedImage: data?.embedImage,
         types: data?.types,
         botUsername: data?.options.botUsername,
         botAPI: data?.options.botAPI,
@@ -105,6 +107,7 @@ const NotificationsTelegram = () => {
             },
             body: JSON.stringify({
               enabled: values.enabled,
+              embedImage: values.embedImage,
               types: values.types,
               options: {
                 botAPI: values.botAPI,
@@ -163,6 +166,7 @@ const NotificationsTelegram = () => {
                 },
                 body: JSON.stringify({
                   enabled: true,
+                  embedImage: values.embedImage,
                   types: values.types,
                   options: {
                     botAPI: values.botAPI,
@@ -205,6 +209,14 @@ const NotificationsTelegram = () => {
               </label>
               <div className="form-input-area">
                 <Field type="checkbox" id="enabled" name="enabled" />
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="embedImage" className="checkbox-label">
+                {intl.formatMessage(messages.embedImage)}
+              </label>
+              <div className="form-input-area">
+                <Field type="checkbox" id="embedImage" name="embedImage" />
               </div>
             </div>
             <div className="form-row">

--- a/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
@@ -14,6 +14,7 @@ const messages = defineMessages(
   'components.Settings.Notifications.NotificationsWebPush',
   {
     agentenabled: 'Enable Agent',
+    embedImage: 'Embed Image',
     webpushsettingssaved: 'Web push notification settings saved successfully!',
     webpushsettingsfailed: 'Web push notification settings failed to save.',
     toastWebPushTestSending: 'Sending web push test notification…',
@@ -54,6 +55,7 @@ const NotificationsWebPush = () => {
       <Formik
         initialValues={{
           enabled: data.enabled,
+          embedImage: data.embedImage,
         }}
         onSubmit={async (values) => {
           try {
@@ -64,6 +66,7 @@ const NotificationsWebPush = () => {
               },
               body: JSON.stringify({
                 enabled: values.enabled,
+                embedImage: values.embedImage,
                 options: {},
               }),
             });
@@ -83,7 +86,7 @@ const NotificationsWebPush = () => {
           }
         }}
       >
-        {({ isSubmitting }) => {
+        {({ isSubmitting, values }) => {
           const testSettings = async () => {
             setIsTesting(true);
             let toastId: string | undefined;
@@ -107,6 +110,7 @@ const NotificationsWebPush = () => {
                   },
                   body: JSON.stringify({
                     enabled: true,
+                    embedImage: values.embedImage,
                     options: {},
                   }),
                 }
@@ -142,6 +146,15 @@ const NotificationsWebPush = () => {
                 </label>
                 <div className="form-input-area">
                   <Field type="checkbox" id="enabled" name="enabled" />
+                </div>
+              </div>
+              <div className="form-row">
+                <label htmlFor="embedImage" className="checkbox-label">
+                  {intl.formatMessage(messages.embedImage)}
+                  <span className="label-required">*</span>
+                </label>
+                <div className="form-input-area">
+                  <Field type="checkbox" id="embedImage" name="embedImage" />
                 </div>
               </div>
               <div className="actions">


### PR DESCRIPTION
#### Description

This PR adds a "Embed Image" toggle in notification settings. Images will not be embedded/linked in the notification channels if this flag is disabled.

I am adding this feature because images just take up too much space and I will prefer if they are not attached to the notification.

The default value for this flag is `true` so nothing will change for existing users unless they choose to disable this flag.

There are some channels that don't support images, In those channels the flag has the default value of `false` and the toggle is not added to their UI in settings

#### Screenshot (if UI-related)

<img width="1124" alt="Screenshot 2025-02-17 at 06 47 21" src="https://github.com/user-attachments/assets/1dc38581-b971-4bcf-9cc1-c198b0ea09e4" />


#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)