### PR TITLE
fix: assign the keep-alive value explicitly

### DIFF
--- a/server/utils/customProxyAgent.ts
+++ b/server/utils/customProxyAgent.ts
@@ -6,7 +6,7 @@ import { Agent, ProxyAgent, setGlobalDispatcher } from 'undici';
 export default async function createCustomProxyAgent(
   proxySettings: ProxySettings
 ) {
-  const defaultAgent = new Agent();
+  const defaultAgent = new Agent({ keepAliveTimeout: 5000 });
 
   const skipUrl = (url: string) => {
     const hostname = new URL(url).hostname;
@@ -63,6 +63,7 @@ export default async function createCustomProxyAgent(
       interceptors: {
         Client: [noProxyInterceptor],
       },
+      keepAliveTimeout: 4000,
     });
 
     setGlobalDispatcher(proxyAgent);

--- a/server/utils/customProxyAgent.ts
+++ b/server/utils/customProxyAgent.ts
@@ -63,7 +63,7 @@ export default async function createCustomProxyAgent(
       interceptors: {
         Client: [noProxyInterceptor],
       },
-      keepAliveTimeout: 4000,
+      keepAliveTimeout: 5000,
     });
 
     setGlobalDispatcher(proxyAgent);


### PR DESCRIPTION
#### Description

The Node.js [documentation](https://nodejs.org/dist/latest-v22.x/docs/api/http.html#httpglobalagent) mentions that the default keep-alive value is not used when creating a global agent manually, which is done in `server/customProxyAgent.ts`.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Re #1365
