### PR TITLE
fix: disable first page revalidation in useSWRInfinite

### DIFF
--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -56,6 +56,7 @@ const MediaSlider = ({
     },
     {
       initialSize: 2,
+      revalidateFirstPage: false,
     }
   );
 

--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -80,6 +80,7 @@ const useDiscover = <
     },
     {
       initialSize: 3,
+      revalidateFirstPage: false,
     }
   );
 


### PR DESCRIPTION
#### Description

By default, useSWRInfinite revalidates the first page every time a new page is loaded, resulting in additional requests being sent. This PR disables this behavior.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1380
