### PR TITLE
fix: add email requirement for local users

### DIFF
--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -119,27 +119,9 @@ userSettingsRoutes.post<
     }
 
     const oldEmail = user.email;
-    const oldUsername = user.username;
     user.username = req.body.username;
-    if (user.jellyfinUsername) {
+    if (user.userType !== UserType.PLEX) {
       user.email = req.body.email || user.jellyfinUsername || user.email;
-    }
-    // Edge case for local users, because they have no Jellyfin username to fall back on
-    // if the email is not provided
-    if (user.userType === UserType.LOCAL) {
-      if (req.body.email) {
-        user.email = req.body.email;
-        if (
-          !user.username &&
-          user.email !== oldEmail &&
-          !oldEmail.includes('@')
-        ) {
-          user.username = oldEmail;
-        }
-      } else if (req.body.username) {
-        user.email = oldUsername || user.email;
-        user.username = req.body.username;
-      }
     }
 
     const existingUser = await userRepository.findOne({

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -210,7 +210,9 @@ const UserList = () => {
     username: Yup.string().required(
       intl.formatMessage(messages.validationUsername)
     ),
-    email: Yup.string().email(intl.formatMessage(messages.validationEmail)),
+    email: Yup.string()
+      .required()
+      .email(intl.formatMessage(messages.validationEmail)),
     password: Yup.lazy((value) =>
       !value
         ? Yup.string()
@@ -388,6 +390,7 @@ const UserList = () => {
                   <div className="form-row">
                     <label htmlFor="email" className="text-label">
                       {intl.formatMessage(messages.email)}
+                      <span className="label-required">*</span>
                     </label>
                     <div className="form-input-area">
                       <div className="form-input-field">

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -100,7 +100,8 @@ const UserGeneralSettings = () => {
 
   const UserGeneralSettingsSchema = Yup.object().shape({
     email:
-      user?.id === 1
+      // email is required for everybody except non-admin jellyfin users
+      user?.id === 1 || user?.userType !== UserType.JELLYFIN
         ? Yup.string()
             .email(intl.formatMessage(messages.validationemailformat))
             .required(intl.formatMessage(messages.validationemailrequired))

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -101,7 +101,8 @@ const UserGeneralSettings = () => {
   const UserGeneralSettingsSchema = Yup.object().shape({
     email:
       // email is required for everybody except non-admin jellyfin users
-      user?.id === 1 || user?.userType !== UserType.JELLYFIN
+      user?.id === 1 ||
+      (user?.userType !== UserType.JELLYFIN && user?.userType !== UserType.EMBY)
         ? Yup.string()
             .email(intl.formatMessage(messages.validationemailformat))
             .required(intl.formatMessage(messages.validationemailrequired))


### PR DESCRIPTION
#### Description

Because of a misunderstanding, the requirement to have a mandatory email for local users was removed, when it shouldn't have been.

#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Related to #900
- Fixes #1367
