### PR TITLE
fix(emby): throw the right error message if no library exists

### DIFF
--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -352,7 +352,7 @@ settingsRoutes.get('/jellyfin/library', async (req, res, next) => {
       const account = await jellyfinClient.getUser();
 
       // Automatic Library grouping is not supported when user views are used to get library
-      if (account.Configuration.GroupedFolders.length > 0) {
+      if (account.Configuration.GroupedFolders?.length > 0) {
         return next({
           status: 501,
           message: ApiErrorCode.SyncErrorGroupedFolders,


### PR DESCRIPTION
#### Description

This PR fixes a bug where the error message when no library exists was not displayed because of a Jellyfin-specific check failing with Emby.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)