### PR TITLE
fix(overriderules): enable override rules only when a service exists

### DIFF
--- a/src/components/Settings/SettingsServices.tsx
+++ b/src/components/Settings/SettingsServices.tsx
@@ -528,6 +528,7 @@ const SettingsServices = () => {
             <div className="flex h-full w-full items-center justify-center">
               <Button
                 buttonType="ghost"
+                disabled={!radarrData?.length || !sonarrData?.length}
                 onClick={() =>
                   setOverrideRuleModal({
                     open: true,


### PR DESCRIPTION
#### Description

This PR disable the 'New Override Rule' button when no Radarr/Sonarr service exists.

#### Screenshot (if UI-related)

![image](https://github.com/user-attachments/assets/63e4f54e-b735-4634-8450-415984e894f1)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)