### PR TITLE
feat(watchlist): implement Plex watchlist GraphQL API fallback

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -109,7 +109,8 @@ class ExternalAPI {
     data?: Record<string, unknown>,
     params?: Record<string, string>,
     ttl?: number,
-    config?: RequestInit
+    config?: RequestInit,
+    overwriteBaseUrl?: string
   ): Promise<T> {
     const headers = { ...this.defaultHeaders, ...config?.headers };
     const cacheKey = this.serializeCacheKey(endpoint, {
@@ -123,7 +124,7 @@ class ExternalAPI {
       return cachedItem;
     }
 
-    const url = this.formatUrl(endpoint, params);
+    const url = this.formatUrl(endpoint, params, overwriteBaseUrl);
     const response = await this.fetch(url, {
       method: 'POST',
       ...config,


### PR DESCRIPTION
#### Description

Proof of concept implementation using the Plex GraphQL API to fetch watchlists for users with no Plex token. This works by using the admin's Plex token to make GraphQL requests for a user's watchlist which the admin account has permission to view. Due to the pagination issue detailed below, in it's current form this is only called by the watchlist sync job, and only fetches the most recent 20 items on a watchlist. This is identical to the current token-based watchlist sync functionality (for better or for worse).

This has a couple significant deficiencies that will need to be addressed before it gets close to a truly functional state:
- the GQL API handles pagination through an opaque base64 `endCursor` (e.g. `"endCursor": "MTY3NzAzMjA4NDI1OA=="`) which is passed into the next API call to request the next page. This means that 1) we can't mimic the `offset` parameter of the existing `getWatchlist()` and 2) we can't return a `totalSize` variable like the existing function without first fetching the entire watchlist. Basically, we can't handle pagination the same way the existing implementation does. I think this will require either reworking fetching logic everywhere that watchlists are touched, or to limit GQL calls only to the watchlist sync job, and not use it to display watchlists in the UI.
- The `/api/users` endpoint that Jellyseerr uses to import users from Plex does not discretely provide user UUIDs, which the GQL API requires in order to query for a specific user. My janky workaround is that the endpoint _does_ provide it as a part of the users' avatar thumbnail URL. Extracting the UUID from this does seem to work consistently in the limited testing I can do with my users, but I'm not entirely convinced it's a robust or future-proof solution.
- The GQL API does support ETags, so caching could most likely be implemented for GQL-fetched watchlists just like the existing token-based implementation.
- We may want to consider using an actual GQL package to format queries, as opposed to hardcoding the query as a barely legible multiline string.
- Down the line, we may want to consider whether this should be default functionality or manually enabled through the UI, either as a global toggle or a per-user setting.

I would love to get some feedback on the initial implementation and any thoughts on how to progress this towards a functional/fully integrated state.

#### To-Dos
- [ ] Handle pagination differences
- [ ] Find a more robust way to fetch UUIDs
- [ ] Implement ETag-based caching for GQL-sourced watchlists
- [ ] GQL package?
- [ ] Enabled by default?
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- https://github.com/fallenbagel/jellyseerr/issues/1378
