### PR TITLE
Add an option to specify no PVC or a preexisting one

### DIFF
--- a/charts/jellyseerr-chart/templates/deployment.yaml
+++ b/charts/jellyseerr-chart/templates/deployment.yaml
@@ -70,8 +70,12 @@ spec:
           {{- end }}
       volumes:
         - name: config
+          {{- if .Values.config.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ include "jellyseerr.configPersistenceName" . }}
+            claimName: {{ if .Values.config.persistence.existingClaim }}{{ .Values.config.persistence.existingClaim }}{{- else }}{{ include "jellyseerr.configPersistenceName" . }}{{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/jellyseerr-chart/templates/persistentvolumeclaim.yaml
+++ b/charts/jellyseerr-chart/templates/persistentvolumeclaim.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.config.persistence.enabled -}}
+{{- if not .Values.config.persistence.existingClaim -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -18,3 +20,5 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.config.persistence.size }}"
+{{- end -}}
+{{- end -}}

--- a/charts/jellyseerr-chart/values.yaml
+++ b/charts/jellyseerr-chart/values.yaml
@@ -53,6 +53,8 @@ service:
 # -- Creating PVC to store configuration
 config:
   persistence:
+    # -- set to true to use pvc
+    enabled: true
     # -- Size of persistent disk
     size: 5Gi
     # -- Annotations for PVCs
@@ -63,8 +65,9 @@ config:
     # -- Config name
     name: ""
     # -- Name of the permanent volume to reference in the claim.
-    # Can be used to bind to existing volumes.
     volumeName: ""
+    # -- specify an existing `PersistentVolumeClaim` to use
+    # existingClaim: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION
#### Description

Adds an option to specify no PVC to be created for the persistence in which case an emptyDir is used as a volume. Also, adds an option to use an existing PVC instead of defining a new one.

I am new to helm templating, my changes were inspired by MoJo2600/pihole-kubernetes chart. Please do check for any mistakes.

Also, I did not know how to regenerate the readme. Maybe it is regenerated as part of CI/CD pipeline? Be free to commit some fixes if need be.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [ ] Regenerate chart's readme

#### Issues Fixed or Closed

N/A