### PR TITLE
feat(plex-profiles-import): import family profiles as individual users

### DIFF
--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -32,6 +32,15 @@ interface PlexUser {
   entitlements: string[];
 }
 
+export interface ExtendedPlexUser {
+  id: string;
+  title: string;
+  username: string;
+  email?: string;
+  thumb?: string;
+  home?: string;
+}
+
 interface ConnectionResponse {
   $: {
     protocol: string;

--- a/server/migration/postgres/1741554636646-AddIsFamilyProfile.ts
+++ b/server/migration/postgres/1741554636646-AddIsFamilyProfile.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddIsFamilyProfile1610000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'user',
+      new TableColumn({
+        name: 'isFamilyProfile',
+        type: 'boolean',
+        default: false,
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('user', 'isFamilyProfile');
+  }
+}

--- a/server/migration/postgres/1741554636646-AddIsFamilyProfile.ts
+++ b/server/migration/postgres/1741554636646-AddIsFamilyProfile.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 
-export class AddIsFamilyProfile1610000000000 implements MigrationInterface {
+export class AddIsFamilyProfile1741554636646 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.addColumn(
       'user',

--- a/server/migration/sqlite/1741554636646-AddIsFamilyProfile.ts
+++ b/server/migration/sqlite/1741554636646-AddIsFamilyProfile.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddIsFamilyProfile1610000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'user',
+      new TableColumn({
+        name: 'isFamilyProfile',
+        type: 'boolean',
+        default: false,
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('user', 'isFamilyProfile');
+  }
+}

--- a/server/migration/sqlite/1741554636646-AddIsFamilyProfile.ts
+++ b/server/migration/sqlite/1741554636646-AddIsFamilyProfile.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 
-export class AddIsFamilyProfile1610000000000 implements MigrationInterface {
+export class AddIsFamilyProfile1741554636646 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.addColumn(
       'user',


### PR DESCRIPTION
#### Description
This commit enables the import of Plex home profiles—profiles that lack a dedicated
Plex account—by creating individual user records in Jellyseerr.
Fallback values are provided for missing email (using `<id>@plex.local`) and username (falling back to the
profile's title) to ensure every imported record has the required fields.

> [!NOTE]
> Currently, logging in with a Plex account does not allow users to select a specific profile. As a workaround, the owner must assign a password to each profile so that each can be logged into locally.
> Maybe future work will extend the UI to allow users to select their Plex profile.

#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)

#### Issues Fixed or Closed
- Fixes #1402