### PR TITLE
fix(users): correct user list for Postgres

### DIFF
--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -60,22 +60,24 @@ router.get('/', async (req, res, next) => {
         query = query.orderBy('user.updatedAt', 'DESC');
         break;
       case 'displayname':
-        query = query.orderBy(
-          `CASE WHEN (user.username IS NULL OR user.username = '') THEN (
-             CASE WHEN (user.plexUsername IS NULL OR user.plexUsername = '') THEN (
-               CASE WHEN (user.jellyfinUsername IS NULL OR user.jellyfinUsername = '') THEN
-                 "user"."email"
-               ELSE
-                 LOWER(user.jellyfinUsername)
-               END)
-             ELSE
-               LOWER(user.jellyfinUsername)
-             END)
-           ELSE
-             LOWER(user.username)
-           END`,
-          'ASC'
-        );
+        query = query
+          .addSelect(
+            `CASE WHEN (user.username IS NULL OR user.username = '') THEN (
+              CASE WHEN (user.plexUsername IS NULL OR user.plexUsername = '') THEN (
+                CASE WHEN (user.jellyfinUsername IS NULL OR user.jellyfinUsername = '') THEN
+                  "user"."email"
+                ELSE
+                  LOWER(user.jellyfinUsername)
+                END)
+              ELSE
+                LOWER(user.jellyfinUsername)
+              END)
+            ELSE
+              LOWER(user.username)
+            END`,
+            'displayname_sort_key'
+          )
+          .orderBy('displayname_sort_key', 'ASC');
         break;
       case 'requests':
         query = query


### PR DESCRIPTION
#### Description

PostgreSQL requires that the ORDER BY expression must appear in the SELECT list when using DISTINCT. Since we were using a computed expression in the ORDER BY clause, we need to include it in the SELECT list as well.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Re #1333