### PR TITLE
fix(ui): correct media action icon size

### DIFF
--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -590,7 +590,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                   buttonSize={'md'}
                   onClick={() => setShowBlacklistModal(true)}
                 >
-                  <EyeSlashIcon className={'h-3'} />
+                  <EyeSlashIcon />
                 </Button>
               </Tooltip>
             )}
@@ -608,9 +608,9 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                       onClick={onClickWatchlistBtn}
                     >
                       {isUpdating ? (
-                        <Spinner className="h-3" />
+                        <Spinner />
                       ) : (
-                        <StarIcon className={'h-3 text-amber-300'} />
+                        <StarIcon className={'text-amber-300'} />
                       )}
                     </Button>
                   </Tooltip>
@@ -623,11 +623,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                       buttonSize={'md'}
                       onClick={onClickDeleteWatchlistBtn}
                     >
-                      {isUpdating ? (
-                        <Spinner className="h-3" />
-                      ) : (
-                        <MinusCircleIcon className={'h-3'} />
-                      )}
+                      {isUpdating ? <Spinner /> : <MinusCircleIcon />}
                     </Button>
                   </Tooltip>
                 )}

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -632,7 +632,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                   buttonSize={'md'}
                   onClick={() => setShowBlacklistModal(true)}
                 >
-                  <EyeSlashIcon className={'h-3'} />
+                  <EyeSlashIcon />
                 </Button>
               </Tooltip>
             )}
@@ -650,9 +650,9 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                       onClick={onClickWatchlistBtn}
                     >
                       {isUpdating ? (
-                        <Spinner className="h-3" />
+                        <Spinner />
                       ) : (
-                        <StarIcon className={'h-3 text-amber-300'} />
+                        <StarIcon className={'text-amber-300'} />
                       )}
                     </Button>
                   </Tooltip>
@@ -665,11 +665,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                       buttonSize={'md'}
                       onClick={onClickDeleteWatchlistBtn}
                     >
-                      {isUpdating ? (
-                        <Spinner className="h-3" />
-                      ) : (
-                        <MinusCircleIcon className={'h-3'} />
-                      )}
+                      {isUpdating ? <Spinner /> : <MinusCircleIcon />}
                     </Button>
                   </Tooltip>
                 )}


### PR DESCRIPTION
#### Description

This PR fixes an UI issue with inconsistent size for media action icons.

#### Screenshot (if UI-related)

Before:
![image](https://github.com/user-attachments/assets/4af0e8cb-8425-44e0-80ad-fa3cb84237a5)

After:
![image](https://github.com/user-attachments/assets/871842f1-0e50-4654-a61f-c5047b8a5386)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1440
