### PR TITLE
fix(requestlist): hide the remove from *arr button when no service exists

### DIFF
--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -17,6 +17,8 @@ import {
   FunnelIcon,
 } from '@heroicons/react/24/solid';
 import type { RequestResultsResponse } from '@server/interfaces/api/requestInterfaces';
+import { Permission } from '@server/lib/permissions';
+import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -51,7 +53,7 @@ const RequestList = () => {
   const { user } = useUser({
     id: Number(router.query.userId),
   });
-  const { user: currentUser } = useUser();
+  const { user: currentUser, hasPermission } = useUser();
   const [currentFilter, setCurrentFilter] = useState<Filter>(Filter.PENDING);
   const [currentSort, setCurrentSort] = useState<Sort>('added');
   const [currentSortDirection, setCurrentSortDirection] =
@@ -61,6 +63,13 @@ const RequestList = () => {
   const page = router.query.page ? Number(router.query.page) : 1;
   const pageIndex = page - 1;
   const updateQueryParams = useUpdateQueryParams({ page: page.toString() });
+
+  const { data: radarrData } = useSWR<RadarrSettings[]>(
+    hasPermission(Permission.ADMIN) ? '/api/v1/settings/radarr' : null
+  );
+  const { data: sonarrData } = useSWR<SonarrSettings[]>(
+    hasPermission(Permission.ADMIN) ? '/api/v1/settings/sonarr' : null
+  );
 
   const {
     data,
@@ -245,6 +254,8 @@ const RequestList = () => {
             <RequestItem
               request={request}
               revalidateList={() => revalidate()}
+              radarrData={radarrData}
+              sonarrData={sonarrData}
             />
           </div>
         );


### PR DESCRIPTION
#### Description

This PR hide the "Remove from *arr" button in the request list when the service of the request doesn't exist anymore.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1449