### PR TITLE
fix(smtp-notification-test): missing allowSelfSigned option in test function

### DIFF
--- a/src/components/Settings/Notifications/NotificationsEmail.tsx
+++ b/src/components/Settings/Notifications/NotificationsEmail.tsx
@@ -133,10 +133,10 @@ const NotificationsEmail = () => {
         encryption: data.options.secure
           ? 'implicit'
           : data.options.requireTls
-          ? 'opportunistic'
-          : data.options.ignoreTls
-          ? 'none'
-          : 'default',
+            ? 'opportunistic'
+            : data.options.ignoreTls
+              ? 'none'
+              : 'default',
         authUser: data.options.authUser,
         authPass: data.options.authPass,
         allowSelfSigned: data.options.allowSelfSigned,
@@ -221,6 +221,7 @@ const NotificationsEmail = () => {
                     requireTls: values.encryption === 'opportunistic',
                     authUser: values.authUser,
                     authPass: values.authPass,
+                    allowSelfSigned: values.allowSelfSigned,
                     senderName: values.senderName,
                     pgpPrivateKey: values.pgpPrivateKey,
                     pgpPassword: values.pgpPassword,

--- a/src/components/Settings/Notifications/NotificationsEmail.tsx
+++ b/src/components/Settings/Notifications/NotificationsEmail.tsx
@@ -133,10 +133,10 @@ const NotificationsEmail = () => {
         encryption: data.options.secure
           ? 'implicit'
           : data.options.requireTls
-            ? 'opportunistic'
-            : data.options.ignoreTls
-              ? 'none'
-              : 'default',
+          ? 'opportunistic'
+          : data.options.ignoreTls
+          ? 'none'
+          : 'default',
         authUser: data.options.authUser,
         authPass: data.options.authPass,
         allowSelfSigned: data.options.allowSelfSigned,


### PR DESCRIPTION
#### Description

The SMTP test functionality was not working when using self-signed certificates due to the missing `allowSelfSigned` option in the request body.

This commit ensures that `allowSelfSigned: values.allowSelfSigned` is properly included, allowing self-signed certificates when enabled in the settings.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1374
