### PR TITLE
fix(ui): move watch trailer button above the 4k request button

### DIFF
--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -629,7 +629,9 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                 )}
               </>
             )}
-          <PlayButton links={mediaLinks} />
+          <div className="z-20">
+            <PlayButton links={mediaLinks} />
+          </div>
           <RequestButton
             mediaType="movie"
             media={data.mediaInfo}

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -671,7 +671,9 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                 )}
               </>
             )}
-          <PlayButton links={mediaLinks} />
+          <div className="z-20">
+            <PlayButton links={mediaLinks} />
+          </div>
           <RequestButton
             mediaType="tv"
             onUpdate={() => revalidate()}


### PR DESCRIPTION
#### Description

Fix a z-index issue with the "Watch Trailer" button being under the "Request in 4k" button

#### Screenshot (if UI-related)

Before:
![image](https://github.com/user-attachments/assets/e6b1234c-0cd0-4904-89c3-43c6af4f5dd7)

After:
![image](https://github.com/user-attachments/assets/74390170-f9ac-4f72-839a-15f9fe424cb9)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1462
