### PR TITLE
revert(airdate): reverts airdate offset & changes relative time to only display date (not time)

### DIFF
--- a/src/components/AirDateBadge/index.tsx
+++ b/src/components/AirDateBadge/index.tsx
@@ -28,20 +28,8 @@ const AirDateBadge = ({ airDate }: AirDateBadgeProps) => {
     showRelative = true;
   }
 
-  const airDateStartOfDay = new Date(
-    dAirDate.getFullYear(),
-    dAirDate.getMonth(),
-    dAirDate.getDate()
-  ).getTime();
-
-  const nowStartOfDay = new Date(
-    nowDate.getFullYear(),
-    nowDate.getMonth(),
-    nowDate.getDate()
-  ).getTime();
-
   const diffInDays = Math.round(
-    (airDateStartOfDay - nowStartOfDay) / (1000 * 60 * 60 * 24)
+    (dAirDate.getTime() - nowDate.getTime()) / (1000 * 60 * 60 * 24)
   );
 
   return (

--- a/src/components/AirDateBadge/index.tsx
+++ b/src/components/AirDateBadge/index.tsx
@@ -14,7 +14,6 @@ type AirDateBadgeProps = {
 const AirDateBadge = ({ airDate }: AirDateBadgeProps) => {
   const WEEK = 1000 * 60 * 60 * 24 * 8;
   const intl = useIntl();
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const dAirDate = new Date(airDate);
   const nowDate = new Date();
   const alreadyAired = dAirDate.getTime() < nowDate.getTime();
@@ -39,7 +38,7 @@ const AirDateBadge = ({ airDate }: AirDateBadgeProps) => {
           year: 'numeric',
           month: 'long',
           day: 'numeric',
-          timeZone,
+          timeZone: 'UTC',
         })}
       </Badge>
       {showRelative && (

--- a/src/components/AirDateBadge/index.tsx
+++ b/src/components/AirDateBadge/index.tsx
@@ -17,19 +17,32 @@ const AirDateBadge = ({ airDate }: AirDateBadgeProps) => {
   const dAirDate = new Date(airDate);
   const nowDate = new Date();
   const alreadyAired = dAirDate.getTime() < nowDate.getTime();
-
   const compareWeek = new Date(
     alreadyAired ? Date.now() - WEEK : Date.now() + WEEK
   );
-
   let showRelative = false;
-
   if (
     (alreadyAired && dAirDate.getTime() > compareWeek.getTime()) ||
     (!alreadyAired && dAirDate.getTime() < compareWeek.getTime())
   ) {
     showRelative = true;
   }
+
+  const airDateStartOfDay = new Date(
+    dAirDate.getFullYear(),
+    dAirDate.getMonth(),
+    dAirDate.getDate()
+  ).getTime();
+
+  const nowStartOfDay = new Date(
+    nowDate.getFullYear(),
+    nowDate.getMonth(),
+    nowDate.getDate()
+  ).getTime();
+
+  const diffInDays = Math.round(
+    (airDateStartOfDay - nowStartOfDay) / (1000 * 60 * 60 * 24)
+  );
 
   return (
     <div className="flex items-center space-x-2">
@@ -48,17 +61,9 @@ const AirDateBadge = ({ airDate }: AirDateBadgeProps) => {
             {
               relativeTime: (
                 <FormattedRelativeTime
-                  value={
-                    (new Date(
-                      dAirDate.getFullYear(),
-                      dAirDate.getMonth(),
-                      dAirDate.getDate()
-                    ).getTime() -
-                      Date.now()) /
-                    1000
-                  }
+                  value={diffInDays}
+                  unit="day"
                   numeric="auto"
-                  updateIntervalInSeconds={1}
                 />
               ),
             }

--- a/src/components/AirDateBadge/index.tsx
+++ b/src/components/AirDateBadge/index.tsx
@@ -48,7 +48,15 @@ const AirDateBadge = ({ airDate }: AirDateBadgeProps) => {
             {
               relativeTime: (
                 <FormattedRelativeTime
-                  value={(dAirDate.getTime() - Date.now()) / 1000}
+                  value={
+                    (new Date(
+                      dAirDate.getFullYear(),
+                      dAirDate.getMonth(),
+                      dAirDate.getDate()
+                    ).getTime() -
+                      Date.now()) /
+                    1000
+                  }
                   numeric="auto"
                   updateIntervalInSeconds={1}
                 />


### PR DESCRIPTION
#### Description
This reverts #1390 as it created more confusion when we offsetted the air date in relevance to the timezone. It also changes the relative time to use date instead of time (so it will say `aired yesterday` `today` `5 days ago` instead of `aired x hours ago` since we dont really the airtime data.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
