### PR TITLE
fix: check if the file still exists in the service before deleting

### DIFF
--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -237,6 +237,19 @@ mediaRoutes.delete(
       }
 
       if (isMovie) {
+        // check if the movie exists
+        try {
+          await (service as RadarrAPI).getMovie({
+            id: parseInt(
+              is4k
+                ? (media.externalServiceSlug4k as string)
+                : (media.externalServiceSlug as string)
+            ),
+          });
+        } catch {
+          return res.status(204).send();
+        }
+        // remove the movie
         await (service as RadarrAPI).removeMovie(
           parseInt(
             is4k
@@ -251,6 +264,13 @@ mediaRoutes.delete(
         if (!tvdbId) {
           throw new Error('TVDB ID not found');
         }
+        // check if the series exists
+        try {
+          await (service as SonarrAPI).getSeriesByTvdbId(tvdbId);
+        } catch {
+          return res.status(204).send();
+        }
+        // remove the series
         await (service as SonarrAPI).removeSerie(tvdbId);
       }
 


### PR DESCRIPTION
#### Description

This PR add a check to verify if the item to be deleted inside the *arr service still exists before actually sending the delete request.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
