### PR TITLE
fix(ui): resolve streaming region dropdown overlap

### DIFF
--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -415,7 +415,7 @@ const UserGeneralSettings = () => {
                   </span>
                 </label>
                 <div className="form-input-area">
-                  <div className="form-input-field">
+                  <div className="form-input-field relative z-30">
                     <RegionSelector
                       name="discoverRegion"
                       value={values.discoverRegion ?? ''}
@@ -451,7 +451,7 @@ const UserGeneralSettings = () => {
                   </span>
                 </label>
                 <div className="form-input-area">
-                  <div className="form-input-field">
+                  <div className="form-input-field relative z-20">
                     <RegionSelector
                       name="streamingRegion"
                       value={values.streamingRegion || ''}


### PR DESCRIPTION
#### Description

The streaming region selection field is always in the foreground and overlaps other open dropdowns.

#### Screenshot (if UI-related)

Before:
![image](https://github.com/user-attachments/assets/6478ef46-a5f6-4185-a2cf-ca58d189cb3c)

After:
![image](https://github.com/user-attachments/assets/22626ff2-7f4d-4d32-9782-7d59c41adbac)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1475
