### PR TITLE
fix(mediarequest): correct download sync for Radarr

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -999,7 +999,7 @@ export class MediaRequest {
                 radarrMovie.id,
               [this.is4k ? 'externalServiceSlug4k' : 'externalServiceSlug']:
                 radarrMovie.titleSlug,
-              [this.is4k ? 'serviceId4k' : 'serviceId']: radarrMovie?.id,
+              [this.is4k ? 'serviceId4k' : 'serviceId']: radarrSettings?.id,
             };
 
             await mediaRepository.update({ id: this.media.id }, updateFields);


### PR DESCRIPTION
#### Description

This PR fixes a bug introduced by #1376, where `radarrSettings` was incorrectly replaced by `radarrMovie`.

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)