### PR TITLE
fix(ui): correct seasons badge order

### DIFF
--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -217,7 +217,7 @@ const TvRequestModal = ({
           mediaType: 'tv',
           is4k,
           seasons: settings.currentSettings.partialRequestsEnabled
-            ? selectedSeasons
+            ? selectedSeasons.sort((a, b) => a - b)
             : getAllSeasons().filter(
                 (season) => !getAllRequestedSeasons().includes(season)
               ),


### PR DESCRIPTION
#### Description

This PR corrects the order of the seasons displayed on the request card, because it was not always ordered.

#### Screenshot (if UI-related)

Before:
![image](https://github.com/user-attachments/assets/6ab662e1-79c0-4a1e-a449-f93194315b6c)

After:
![image](https://github.com/user-attachments/assets/f2b17f57-dd1e-481b-b07f-36e0280aae01)


#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)