### PR TITLE
Merge jellyseerr tags with existing *arr tags instead of overwriting

### DIFF
--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -28,6 +28,7 @@ export interface RadarrMovie {
   qualityProfileId: number;
   added: string;
   hasFile: boolean;
+  tags: number[];
 }
 
 class RadarrAPI extends ServarrBase<{ movieId: number }> {
@@ -104,7 +105,7 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
           minimumAvailability: options.minimumAvailability,
           tmdbId: options.tmdbId,
           year: options.year,
-          tags: options.tags,
+          tags: Array.from(new Set([...movie.tags, ...options.tags])),
           rootFolderPath: options.rootFolderPath,
           monitored: options.monitored,
           addOptions: {

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -184,7 +184,9 @@ class SonarrAPI extends ServarrBase<{
       // If the series already exists, we will simply just update it
       if (series.id) {
         series.monitored = options.monitored ?? series.monitored;
-        series.tags = options.tags ?? series.tags;
+        series.tags = options.tags
+          ? Array.from(new Set([...series.tags, ...options.tags]))
+          : series.tags;
         series.seasons = this.buildSeasonList(options.seasons, series.seasons);
 
         const newSeriesData = await this.put<SonarrSeries>(


### PR DESCRIPTION
I recently got this same PR merged into overseerr (https://github.com/sct/overseerr/pull/4019), but jellyseerr seems more alive, so I am submitting it here too.

By default, jellyseerr clobbers any existing tags within sonarr/radarr when it adds it's own tags. This change merges them instead.
