### PR TITLE
fix(ui): handle import-from-plex response as array

### DIFF
--- a/src/components/UserList/PlexImportModal.tsx
+++ b/src/components/UserList/PlexImportModal.tsx
@@ -57,9 +57,9 @@ const PlexImportModal = ({ onCancel, onComplete }: PlexImportProps) => {
         }),
       });
       if (!res.ok) throw new Error();
-      const { data: createdUsers } = await res.json();
+      const createdUsers = await res.json();
 
-      if (!createdUsers.length) {
+      if (!Array.isArray(createdUsers) || createdUsers.length === 0) {
         throw new Error('No users were imported from Plex.');
       }
 


### PR DESCRIPTION
#### Description

This PR fixes an issue in the `Plex User Import Modal` where the import process raises the error message 'Something went wrong while importing Plex users.' even when the import is successful.
This happens because the frontend expected the response to be an `object` with a `data` key, but the API returns an `array` directly.
Adjusted the response handling logic to correctly process imported users.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed
