### PR TITLE
feat(gotify): use markdown linebreaks instead of relying purely on newlines

### DIFF
--- a/server/lib/notifications/agents/gotify.ts
+++ b/server/lib/notifications/agents/gotify.ts
@@ -47,10 +47,11 @@ class GotifyAgent
     const title = payload.event
       ? `${payload.event} - ${payload.subject}`
       : payload.subject;
-    let message = payload.message ?? '';
+
+    let message = payload.message ? `${payload.message}  \n\n` : '';
 
     if (payload.request) {
-      message += `\n\nRequested By: ${payload.request.requestedBy.displayName}`;
+      message += `\n**Requested By:** ${payload.request.requestedBy.displayName}  `;
 
       let status = '';
       switch (type) {
@@ -73,16 +74,18 @@ class GotifyAgent
       }
 
       if (status) {
-        message += `\nRequest Status: ${status}`;
+        message += `\n**Request Status:** ${status}  `;
       }
     } else if (payload.comment) {
-      message += `\nComment from ${payload.comment.user.displayName}:\n${payload.comment.message}`;
+      message += `\nComment from ${payload.comment.user.displayName}:\n${payload.comment.message}  `;
     } else if (payload.issue) {
-      message += `\n\nReported By: ${payload.issue.createdBy.displayName}`;
-      message += `\nIssue Type: ${IssueTypeName[payload.issue.issueType]}`;
-      message += `\nIssue Status: ${
+      message += `\n\n**Reported By:** ${payload.issue.createdBy.displayName}  `;
+      message += `\n**Issue Type:** ${
+        IssueTypeName[payload.issue.issueType]
+      }  `;
+      message += `\n**Issue Status:** ${
         payload.issue.status === IssueStatus.OPEN ? 'Open' : 'Resolved'
-      }`;
+      }  `;
 
       if (type == Notification.ISSUE_CREATED) {
         priority = 1;
@@ -90,12 +93,14 @@ class GotifyAgent
     }
 
     for (const extra of payload.extra ?? []) {
-      message += `\n\n**${extra.name}**\n${extra.value}`;
+      message += `\n\n**${extra.name}**\n${extra.value}  `;
     }
 
     if (applicationUrl && payload.media) {
       const actionUrl = `${applicationUrl}/${payload.media.mediaType}/${payload.media.tmdbId}`;
-      message += `\n\nOpen in ${applicationTitle}(${actionUrl})`;
+      const displayUrl =
+        actionUrl.length > 40 ? `${actionUrl.slice(0, 41)}...` : actionUrl;
+      message += `\n\n**Open in ${applicationTitle}:** [${displayUrl}](${actionUrl})  `;
     }
 
     return {


### PR DESCRIPTION
#### Description
- Now uses markdown line-breaks instead of relying _purely_ on newlines (which wasn't working previously).
- Now uses markdown formatting to clean the output up a bit.
- `displayUrl` now applies an ellipsis if the URL is longer than 40 characters.
- `displayUrl` formatting _slightly_ changed to match the others.

#### Screenshot (if UI-related)
**Previous Output**
![image](https://github.com/user-attachments/assets/08e53aad-51a0-4070-b280-92bb93c18dba)

**Changed Output**
![image](https://github.com/user-attachments/assets/24987955-3017-4898-9aac-33c06471396d)

