### PR TITLE
docs(helm): use ghcr.io registry instead of dockerhub

### DIFF
--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -37,7 +37,7 @@ docker run -d \
   -p 5055:5055 \
   -v /path/to/appdata/config:/app/config \
   --restart unless-stopped \
-  fallenbagel/jellyseerr
+  ghcr.io/fallenbagel/jellyseerr
 ```
 :::tip
 If you are using emby, make sure to set the `JELLYFIN_TYPE` environment variable to `emby`.
@@ -55,7 +55,7 @@ docker stop jellyseerr && docker rm Jellyseerr
 ```
 Pull the latest image:
 ```bash
-docker pull fallenbagel/jellyseerr
+docker pull ghcr.io/fallenbagel/jellyseerr
 ```
 Finally, run the container with the same parameters originally used to create the container:
 ```bash
@@ -78,7 +78,7 @@ Define the `jellyseerr` service in your `compose.yaml` as follows:
 ---
 services:
   jellyseerr:
-    image: fallenbagel/jellyseerr:latest
+    image: ghcr.io/fallenbagel/jellyseerr:latest
     container_name: jellyseerr
     environment:
       - LOG_LEVEL=debug
@@ -146,7 +146,7 @@ Then, create and start the Jellyseerr container:
 <Tabs groupId="docker-methods" queryString>
   <TabItem value="docker-cli" label="Docker CLI">
 ```bash
-docker run -d --name jellyseerr -e LOG_LEVEL=debug -e TZ=Asia/Tashkent -p 5055:5055 -v "jellyseerr-data:/app/config" --restart unless-stopped fallenbagel/jellyseerr:latest
+docker run -d --name jellyseerr -e LOG_LEVEL=debug -e TZ=Asia/Tashkent -p 5055:5055 -v "jellyseerr-data:/app/config" --restart unless-stopped ghcr.io/fallenbagel/jellyseerr:latest
 ```
 
 #### Updating:


### PR DESCRIPTION
#### Description

Switch to ghcr.io instead of dockerhub in the doc for helm

Reason : https://docs.docker.com/docker-hub/usage/
