### PR TITLE
feat: add anidb support to jellyfin scanner

### DIFF
--- a/server/api/animelist.ts
+++ b/server/api/animelist.ts
@@ -48,6 +48,7 @@ export interface AnidbItem {
   tvdbId?: number;
   tmdbId?: number;
   imdbId?: string;
+  tvdbSeason?: number;
 }
 
 class AnimeListMapping {
@@ -97,6 +98,7 @@ class AnimeListMapping {
           tvdbId: anime.$.defaulttvdbseason === '0' ? undefined : tvdbId,
           tmdbId: tmdbId,
           imdbId: imdbIds[0], // this is used for one AniDB -> one imdb movie mapping
+          tvdbSeason: Number(anime.$.defaulttvdbseason),
         };
 
         if (tvdbId) {

--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -103,6 +103,7 @@ export interface JellyfinLibraryItemExtended extends JellyfinLibraryItem {
     Tmdb?: string;
     Imdb?: string;
     Tvdb?: string;
+    AniDB?: string;
   };
   MediaSources?: JellyfinMediaSource[];
   Width?: number;

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -116,7 +116,10 @@ class JellyfinScanner {
           });
           return;
         }
-        const episodes = this.jfClient.getEpisodes(jellyfinitem.Id, season.Id);
+        const episodes = await this.jfClient.getEpisodes(
+          jellyfinitem.Id,
+          season.Id
+        );
         if (!episodes[0]) {
           this.log('No episode found for anidb movie', 'debug', {
             jellyfinitem,

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -116,16 +116,14 @@ class JellyfinScanner {
           });
           return;
         }
-        const episode = (
-          await this.jfClient.getEpisodes(jellyfinitem.Id, season.Id)
-        ).at(0);
-        if (!episode) {
+        const episodes = this.jfClient.getEpisodes(jellyfinitem.Id, season.Id);
+        if (!episodes[0]) {
           this.log('No episode found for anidb movie', 'debug', {
             jellyfinitem,
           });
           return;
         }
-        metadata = await this.jfClient.getItemData(episode.Id);
+        metadata = await this.jfClient.getItemData(episodes[0].Id);
         if (!metadata) {
           this.log('No metadata found for anidb movie', 'debug', {
             jellyfinitem,

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -79,7 +79,7 @@ class JellyfinScanner {
         return;
       }
 
-      const anidbId = Number(metadata.ProviderIds.AniDB);
+      const anidbId = Number(metadata.ProviderIds.AniDB ?? null);
 
       newMedia.tmdbId = Number(metadata.ProviderIds.Tmdb ?? null);
       newMedia.imdbId = metadata.ProviderIds.Imdb;


### PR DESCRIPTION
#### Description
This PR adds AniDB support in the Jellyfin scanner.

The AniDB ID is used only if there's no other provider id available to ensure it doesn't change the way it works now with TMDB/TVDB.

In some cases it doesn't work correctly, for example if the show is splitted in multiple season while on anidb it's a single season.
I know it's not optimal, but these are quite rare cases and i think it's better than nothing.
#### Screenshot (if UI-related)

#### To-Dos

- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)
