### PR TITLE
fix(jellyfin): ensure deviceID is never empty

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -110,11 +110,18 @@ class JellyfinAPI extends ExternalAPI {
     deviceId?: string | null
   ) {
     const settings = getSettings();
+    const safeDeviceId =
+      deviceId && deviceId.length > 0
+        ? deviceId
+        : Buffer.from(`BOT_jellyseerr_fallback_${Date.now()}`).toString(
+            'base64'
+          );
+
     let authHeaderVal: string;
     if (authToken) {
-      authHeaderVal = `MediaBrowser Client="Jellyseerr", Device="Jellyseerr", DeviceId="${deviceId}", Version="${getAppVersion()}", Token="${authToken}"`;
+      authHeaderVal = `MediaBrowser Client="Jellyseerr", Device="Jellyseerr", DeviceId="${safeDeviceId}", Version="${getAppVersion()}", Token="${authToken}"`;
     } else {
-      authHeaderVal = `MediaBrowser Client="Jellyseerr", Device="Jellyseerr", DeviceId="${deviceId}", Version="${getAppVersion()}"`;
+      authHeaderVal = `MediaBrowser Client="Jellyseerr", Device="Jellyseerr", DeviceId="${safeDeviceId}", Version="${getAppVersion()}"`;
     }
 
     super(


### PR DESCRIPTION
#### Description
If the deviceID becomes an empty string, login fails since jellyfin requires a non-null deviceID. This commit adds a fallback to guarantee that deviceID is always set, preventing accidental lockout.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
