### PR TITLE
fix(job): handle media removal for 4k on the same server

### DIFF
--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -29,6 +29,38 @@ export interface RadarrMovie {
   added: string;
   hasFile: boolean;
   tags: number[];
+  movieFile?: {
+    id: number;
+    movieId: number;
+    relativePath?: string;
+    path?: string;
+    size: number;
+    dateAdded: string;
+    sceneName?: string;
+    releaseGroup?: string;
+    edition?: string;
+    indexerFlags?: number;
+    mediaInfo: {
+      id: number;
+      audioBitrate: number;
+      audioChannels: number;
+      audioCodec?: string;
+      audioLanguages?: string;
+      audioStreamCount: number;
+      videoBitDepth: number;
+      videoBitrate: number;
+      videoCodec?: string;
+      videoFps: number;
+      videoDynamicRange?: string;
+      videoDynamicRangeType?: string;
+      resolution?: string;
+      runTime?: string;
+      scanType?: string;
+      subtitles?: string;
+    };
+    originalFilePath?: string;
+    qualityCutoffNotMet: boolean;
+  };
 }
 
 class RadarrAPI extends ServarrBase<{ movieId: number }> {

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -747,7 +747,11 @@ class AvailabilitySync {
         }
 
         if (radarr && radarr.hasFile) {
-          existsInRadarr = true;
+          const resolution =
+            radarr?.movieFile?.mediaInfo?.resolution?.split('x');
+          const is4kMovie =
+            resolution?.length === 2 && Number(resolution[0]) >= 2000;
+          existsInRadarr = is4k ? is4kMovie : !is4kMovie;
         }
       } catch (ex) {
         if (!ex.message.includes('404')) {


### PR DESCRIPTION
#### Description

This PR fixes a bug where the avaibility sync job was not removing properly 4k items when the same Radarr server was used for both non-4k and 4k media.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)