### PR TITLE
fix: correct "Remove from *arr" button

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -289,7 +289,7 @@ class ExternalAPI {
     return data;
   }
 
-  protected removeCache(endpoint: string, options?: Record<string, string>) {
+  protected removeCache(endpoint: string, options?: Record<string, unknown>) {
     const cacheKey = this.serializeCacheKey(endpoint, {
       ...this.params,
       ...options,

--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -242,10 +242,13 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
     if (tmdbId) {
       this.removeCache('/movie/lookup', {
         term: `tmdb:${tmdbId}`,
+        headers: this.defaultHeaders,
       });
     }
     if (externalId) {
-      this.removeCache(`/movie/${externalId}`);
+      this.removeCache(`/movie/${externalId}`, {
+        headers: this.defaultHeaders,
+      });
     }
   };
 }

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -368,14 +368,18 @@ class SonarrAPI extends ServarrBase<{
     if (tvdbId) {
       this.removeCache('/series/lookup', {
         term: `tvdb:${tvdbId}`,
+        headers: this.defaultHeaders,
       });
     }
     if (externalId) {
-      this.removeCache(`/series/${externalId}`);
+      this.removeCache(`/series/${externalId}`, {
+        headers: this.defaultHeaders,
+      });
     }
     if (title) {
       this.removeCache('/series/lookup', {
         term: title,
+        headers: this.defaultHeaders,
       });
     }
   };

--- a/server/interfaces/api/requestInterfaces.ts
+++ b/server/interfaces/api/requestInterfaces.ts
@@ -3,7 +3,10 @@ import type { MediaRequest } from '@server/entity/MediaRequest';
 import type { NonFunctionProperties, PaginatedResponse } from './common';
 
 export interface RequestResultsResponse extends PaginatedResponse {
-  results: NonFunctionProperties<MediaRequest>[];
+  results: (NonFunctionProperties<MediaRequest> & {
+    profileName?: string;
+    canRemove?: boolean;
+  })[];
 }
 
 export type MediaRequestBody = {

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -237,19 +237,6 @@ mediaRoutes.delete(
       }
 
       if (isMovie) {
-        // check if the movie exists
-        try {
-          await (service as RadarrAPI).getMovie({
-            id: parseInt(
-              is4k
-                ? (media.externalServiceSlug4k as string)
-                : (media.externalServiceSlug as string)
-            ),
-          });
-        } catch {
-          return res.status(204).send();
-        }
-        // remove the movie
         await (service as RadarrAPI).removeMovie(
           parseInt(
             is4k
@@ -264,13 +251,6 @@ mediaRoutes.delete(
         if (!tvdbId) {
           throw new Error('TVDB ID not found');
         }
-        // check if the series exists
-        try {
-          await (service as SonarrAPI).getSeriesByTvdbId(tvdbId);
-        } catch {
-          return res.status(204).send();
-        }
-        // remove the series
         await (service as SonarrAPI).removeSerie(tvdbId);
       }
 

--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -17,8 +17,6 @@ import {
   FunnelIcon,
 } from '@heroicons/react/24/solid';
 import type { RequestResultsResponse } from '@server/interfaces/api/requestInterfaces';
-import { Permission } from '@server/lib/permissions';
-import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -53,7 +51,7 @@ const RequestList = () => {
   const { user } = useUser({
     id: Number(router.query.userId),
   });
-  const { user: currentUser, hasPermission } = useUser();
+  const { user: currentUser } = useUser();
   const [currentFilter, setCurrentFilter] = useState<Filter>(Filter.PENDING);
   const [currentSort, setCurrentSort] = useState<Sort>('added');
   const [currentSortDirection, setCurrentSortDirection] =
@@ -63,13 +61,6 @@ const RequestList = () => {
   const page = router.query.page ? Number(router.query.page) : 1;
   const pageIndex = page - 1;
   const updateQueryParams = useUpdateQueryParams({ page: page.toString() });
-
-  const { data: radarrData } = useSWR<RadarrSettings[]>(
-    hasPermission(Permission.ADMIN) ? '/api/v1/settings/radarr' : null
-  );
-  const { data: sonarrData } = useSWR<SonarrSettings[]>(
-    hasPermission(Permission.ADMIN) ? '/api/v1/settings/sonarr' : null
-  );
 
   const {
     data,
@@ -254,8 +245,6 @@ const RequestList = () => {
             <RequestItem
               request={request}
               revalidateList={() => revalidate()}
-              radarrData={radarrData}
-              sonarrData={sonarrData}
             />
           </div>
         );


### PR DESCRIPTION
#### Description

This PR fixes the "Delete from *arr" button in the request list.

- It checks from the API whether the *arr server corresponding to the request still exists before displaying the remove button.
- It fixes a cache removal issue that could cause problems when deleting recently added media.
- It also reverts #1476 which introduced problems during removal.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1494
