### PR TITLE
fix(job): rename Plex Sync to Jellyfin Sync

### DIFF
--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -65,8 +65,8 @@ class JellyfinScanner {
 
       if (!metadata?.Id) {
         logger.debug('No Id metadata for this title. Skipping', {
-          label: 'Plex Sync',
-          ratingKey: jellyfinitem.Id,
+          label: 'Jellyfin Sync',
+          jellyfinItemId: jellyfinitem.Id,
         });
         return;
       }
@@ -204,8 +204,8 @@ class JellyfinScanner {
 
       if (!metadata?.Id) {
         logger.debug('No Id metadata for this title. Skipping', {
-          label: 'Plex Sync',
-          ratingKey: jellyfinitem.Id,
+          label: 'Jellyfin Sync',
+          jellyfinItemId: jellyfinitem.Id,
         });
         return;
       }


### PR DESCRIPTION
#### Description

Some logs for the Jellyfin scanners were labelled 'Plex Sync' instead of 'Jellyfin Sync', leading to confusion

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
