### PR TITLE
feat: make chart probes configurable

### DIFF
--- a/charts/jellyseerr-chart/Chart.yaml
+++ b/charts/jellyseerr-chart/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.23.0-0"
 name: jellyseerr-chart
 description: Jellyseerr helm chart for Kubernetes
 type: application
-version: 2.3.3
+version: 2.3.4
 appVersion: "2.5.2"
 maintainers:
   - name: Jellyseerr

--- a/charts/jellyseerr-chart/Chart.yaml
+++ b/charts/jellyseerr-chart/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.23.0-0"
 name: jellyseerr-chart
 description: Jellyseerr helm chart for Kubernetes
 type: application
-version: 2.3.4
+version: 2.4.0
 appVersion: "2.5.2"
 maintainers:
   - name: Jellyseerr

--- a/charts/jellyseerr-chart/README.md
+++ b/charts/jellyseerr-chart/README.md
@@ -1,6 +1,6 @@
 # jellyseerr-chart
 
-![Version: 2.3.4](https://img.shields.io/badge/Version-2.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.2](https://img.shields.io/badge/AppVersion-2.5.2-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.2](https://img.shields.io/badge/AppVersion-2.5.2-informational?style=flat-square)
 
 Jellyseerr helm chart for Kubernetes
 
@@ -52,8 +52,8 @@ Kubernetes: `>=1.23.0-0`
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| probes.livenessProbe | object | `{"httpGet":{"path":"/","port":"http"},"initialDelaySeconds":60}` | Configure liveness probe (set to null to disable) |
-| probes.readinessProbe | object | `{"enabled":true,"httpGet":{"path":"/","port":"http"}}` | Configure readiness probe (set to null to disable) |
+| probes.livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Configure liveness probe (set to null to disable) |
+| probes.readinessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Configure readiness probe (set to null to disable) |
 | probes.startupProbe | string | `nil` | Configure startup probe |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |

--- a/charts/jellyseerr-chart/README.md
+++ b/charts/jellyseerr-chart/README.md
@@ -1,6 +1,6 @@
 # jellyseerr-chart
 
-![Version: 2.3.3](https://img.shields.io/badge/Version-2.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.2](https://img.shields.io/badge/AppVersion-2.5.2-informational?style=flat-square)
+![Version: 2.3.4](https://img.shields.io/badge/Version-2.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.2](https://img.shields.io/badge/AppVersion-2.5.2-informational?style=flat-square)
 
 Jellyseerr helm chart for Kubernetes
 
@@ -52,6 +52,9 @@ Kubernetes: `>=1.23.0-0`
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
+| probes.livenessProbe | object | `{"httpGet":{"path":"/","port":"http"},"initialDelaySeconds":60}` | Configure liveness probe (set to null to disable) |
+| probes.readinessProbe | object | `{"enabled":true,"httpGet":{"path":"/","port":"http"}}` | Configure readiness probe (set to null to disable) |
+| probes.startupProbe | string | `nil` | Configure startup probe |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |

--- a/charts/jellyseerr-chart/README.md
+++ b/charts/jellyseerr-chart/README.md
@@ -52,8 +52,8 @@ Kubernetes: `>=1.23.0-0`
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| probes.livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Configure liveness probe (set to null to disable) |
-| probes.readinessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Configure readiness probe (set to null to disable) |
+| probes.livenessProbe | object | `{}` | Configure liveness probe |
+| probes.readinessProbe | object | `{}` | Configure readiness probe |
 | probes.startupProbe | string | `nil` | Configure startup probe |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |

--- a/charts/jellyseerr-chart/templates/deployment.yaml
+++ b/charts/jellyseerr-chart/templates/deployment.yaml
@@ -44,14 +44,44 @@ spec:
             - name: http
               containerPort: 5055
               protocol: TCP
-          {{- if .Values.probes.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.probes.livenessProbe | nindent 12 }}
-          {{- end }}
-          {{- if .Values.probes.readinessProbe }}
+            httpGet:
+              path: /
+              port: http
+            {{- if .Values.probes.livenessProbe.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            {{- end }}
+            {{- if .Values.probes.livenessProbe.periodSeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            {{- end }}
+            {{- if .Values.probes.livenessProbe.timeoutSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if .Values.probes.livenessProbe.successThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if .Values.probes.livenessProbe.failureThreshold }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            {{- end }}
           readinessProbe:
-            {{- toYaml .Values.probes.readinessProbe | nindent 12 }}
-          {{- end }}
+            httpGet:
+              path: /
+              port: http
+            {{- if .Values.probes.readinessProbe.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            {{- end }}
+            {{- if .Values.probes.readinessProbe.periodSeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            {{- end }}
+            {{- if .Values.probes.readinessProbe.timeoutSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if .Values.probes.readinessProbe.successThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if .Values.probes.readinessProbe.failureThreshold }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            {{- end }}
           {{- if .Values.probes.startupProbe }}
           startupProbe:
             {{- toYaml .Values.probes.startupProbe | nindent 12 }}

--- a/charts/jellyseerr-chart/templates/deployment.yaml
+++ b/charts/jellyseerr-chart/templates/deployment.yaml
@@ -44,14 +44,18 @@ spec:
             - name: http
               containerPort: 5055
               protocol: TCP
+          {{- if .Values.probes.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml .Values.probes.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml .Values.probes.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.startupProbe }}
+          startupProbe:
+            {{- toYaml .Values.probes.startupProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.extraEnv }}

--- a/charts/jellyseerr-chart/values.yaml
+++ b/charts/jellyseerr-chart/values.yaml
@@ -23,10 +23,8 @@ probes:
     httpGet:
       path: /
       port: http
-    initialDelaySeconds: 60
   # -- Configure readiness probe (set to null to disable)
   readinessProbe:
-    enabled: true
     httpGet:
       path: /
       port: http

--- a/charts/jellyseerr-chart/values.yaml
+++ b/charts/jellyseerr-chart/values.yaml
@@ -18,16 +18,20 @@ strategy:
 
 # Liveness / Readiness / Startup Probes
 probes:
-  # -- Configure liveness probe (set to null to disable)
-  livenessProbe:
-    httpGet:
-      path: /
-      port: http
-  # -- Configure readiness probe (set to null to disable)
-  readinessProbe:
-    httpGet:
-      path: /
-      port: http
+  # -- Configure liveness probe
+  livenessProbe: {}
+  # initialDelaySeconds: 60
+  # periodSeconds: 30
+  # timeoutSeconds: 5
+  # successThreshold: 1
+  # failureThreshold: 5
+  # -- Configure readiness probe
+  readinessProbe: {}
+  # initialDelaySeconds: 60
+  # periodSeconds: 30
+  # timeoutSeconds: 5
+  # successThreshold: 1
+  # failureThreshold: 5
   # -- Configure startup probe
   startupProbe: null
   #  tcpSocket:

--- a/charts/jellyseerr-chart/values.yaml
+++ b/charts/jellyseerr-chart/values.yaml
@@ -16,6 +16,25 @@ fullnameOverride: ""
 strategy:
   type: Recreate
 
+# Liveness / Readiness / Startup Probes
+probes:
+  # -- Configure liveness probe (set to null to disable)
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+    initialDelaySeconds: 60
+  # -- Configure readiness probe (set to null to disable)
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /
+      port: http
+  # -- Configure startup probe
+  startupProbe: null
+  #  tcpSocket:
+  #    port: http
+
 # -- Environment variables to add to the jellyseerr pods
 extraEnv: []
 # -- Environment variables from secrets or configmaps to add to the jellyseerr pods
@@ -36,15 +55,15 @@ podAnnotations: {}
 podLabels: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000
+# fsGroup: 2000
 
 securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
 
 service:
   type: ClusterIP
@@ -70,8 +89,8 @@ ingress:
   enabled: false
   ingressClassName: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  #  kubernetes.io/ingress.class: nginx
+  #  kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
@@ -83,16 +102,16 @@ ingress:
   #      - chart-example.local
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
 
 # -- Additional volumes on the output Deployment definition.
 volumes: []


### PR DESCRIPTION
#### Description

Allow to configure liveness/readiness probes + Add optional startup probe

Additional comment fixes on values.yaml so autostyle is properly working

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
