### PR TITLE
Fix episode images url not allowed

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,7 @@ module.exports = {
   images: {
     remotePatterns: [
       { hostname: 'gravatar.com' },
-      { protocol: 'https', hostname: 'image.tmdb.org', pathname: '**' },
+      { hostname: 'image.tmdb.org' },
       { hostname: 'artworks.thetvdb.com' },
       { hostname: 'plex.tv' },
     ],

--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,7 @@ module.exports = {
   images: {
     remotePatterns: [
       { hostname: 'gravatar.com' },
-      { hostname: 'image.tmdb.org' },
+      { protocol: 'https', hostname: 'image.tmdb.org', pathname: '**' },
       { hostname: 'artworks.thetvdb.com' },
       { hostname: 'plex.tv' },
     ],

--- a/src/components/TvDetails/Season/index.tsx
+++ b/src/components/TvDetails/Season/index.tsx
@@ -1,8 +1,8 @@
 import AirDateBadge from '@app/components/AirDateBadge';
+import CachedImage from '@app/components/Common/CachedImage';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import defineMessages from '@app/utils/defineMessages';
 import type { SeasonWithEpisodes } from '@server/models/Tv';
-import Image from 'next/image';
 import { useIntl } from 'react-intl';
 import useSWR from 'swr';
 
@@ -29,6 +29,7 @@ const Season = ({ seasonNumber, tvId }: SeasonProps) => {
   if (!data) {
     return <div>{intl.formatMessage(messages.somethingwentwrong)}</div>;
   }
+  console.log(data.episodes.map((e) => e.stillPath));
 
   return (
     <div className="flex flex-col justify-center divide-y divide-gray-700">
@@ -57,7 +58,8 @@ const Season = ({ seasonNumber, tvId }: SeasonProps) => {
                 </div>
                 {episode.stillPath && (
                   <div className="relative aspect-video xl:h-32">
-                    <Image
+                    <CachedImage
+                      type="tmdb"
                       className="rounded-lg object-contain"
                       src={`https://image.tmdb.org/t/p/original/${episode.stillPath}`}
                       alt=""

--- a/src/components/TvDetails/Season/index.tsx
+++ b/src/components/TvDetails/Season/index.tsx
@@ -29,7 +29,6 @@ const Season = ({ seasonNumber, tvId }: SeasonProps) => {
   if (!data) {
     return <div>{intl.formatMessage(messages.somethingwentwrong)}</div>;
   }
-  console.log(data.episodes.map((e) => e.stillPath));
 
   return (
     <div className="flex flex-col justify-center divide-y divide-gray-700">


### PR DESCRIPTION
#### Description
This fixes an issue where episode images get `url parameter not allowed` when accessing the episode images.

#### Screenshot (if UI-related)
Before:
![image](https://github.com/user-attachments/assets/7dd9ce2f-67a2-46a4-8cc0-a9693164647b)

Now:
It actually works
#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
