### PR TITLE
fix(imagecache): fix avatar cache folder creation

### DIFF
--- a/server/lib/imageproxy.ts
+++ b/server/lib/imageproxy.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import rateLimit, { type rateLimitOptions } from 'axios-rate-limit';
 import { createHash } from 'crypto';
 import { promises } from 'fs';
+import mime from 'mime/lite';
 import path, { join } from 'path';
 
 type ImageResponse = {
@@ -269,7 +270,10 @@ class ImageProxy {
       });
 
       const buffer = Buffer.from(response.data, 'binary');
-      const extension = path.split('.').pop() ?? '';
+
+      const contentType = response.headers['content-type'] || '';
+      const extension = mime.getExtension(contentType) || '';
+
       let maxAge = Number(
         (response.headers['cache-control'] ?? '0').split('=')[1]
       );


### PR DESCRIPTION
#### Description
This fixes a regression caused by #1520 which broke the file extension detection thereby breaking avatars. 

Previously, the image caching code derived the file extension using the URL (by splitting on a dot). This worked correctly when using the native fetch API, as the URLs contained proper extensions. However, when switching to axios, some image URLs (especially ones with query parameters) no longer produced a valid extension. For example, URLs for avatar images started returning parts like "com:443/UserImage?UserId=…" as the extension, causing cache file paths to be invalid (leading to ENOENT errors when reading or writing files).

#### Screenshot (if UI-related)


#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
