### PR TITLE
feat(notifications): adds a NEW_EPISODE notification for Jellyfin

### DIFF
--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -138,6 +138,10 @@ class DiscordAgent
           color = EmbedColors.GREEN;
           status = 'Available';
           break;
+        case Notification.EPISODE_AVAILABLE:
+          color = EmbedColors.BLUE;
+          status = 'New Episode Available';
+          break;
         case Notification.MEDIA_DECLINED:
           color = EmbedColors.RED;
           status = 'Declined';

--- a/server/lib/notifications/agents/email.ts
+++ b/server/lib/notifications/agents/email.ts
@@ -102,6 +102,11 @@ class EmailAgent
             is4k ? 'in 4K ' : ''
           }is now available:`;
           break;
+        case Notification.EPISODE_AVAILABLE:
+          body = `A new episode of the following ${mediaType} ${
+            is4k ? 'in 4K ' : ''
+          }is now available:`;
+          break;
         case Notification.MEDIA_DECLINED:
           body = `Your request for the following ${mediaType} ${
             is4k ? 'in 4K ' : ''

--- a/server/lib/notifications/agents/gotify.ts
+++ b/server/lib/notifications/agents/gotify.ts
@@ -72,6 +72,9 @@ class GotifyAgent
         case Notification.MEDIA_AVAILABLE:
           status = 'Available';
           break;
+        case Notification.EPISODE_AVAILABLE:
+          status = 'New Episode Available';
+          break;
         case Notification.MEDIA_DECLINED:
           status = 'Declined';
           break;

--- a/server/lib/notifications/agents/pushbullet.ts
+++ b/server/lib/notifications/agents/pushbullet.ts
@@ -69,6 +69,9 @@ class PushbulletAgent
         case Notification.MEDIA_AVAILABLE:
           status = 'Available';
           break;
+        case Notification.EPISODE_AVAILABLE:
+          status = 'New Episode Available';
+          break;
         case Notification.MEDIA_DECLINED:
           status = 'Declined';
           break;

--- a/server/lib/notifications/agents/pushover.ts
+++ b/server/lib/notifications/agents/pushover.ts
@@ -109,6 +109,9 @@ class PushoverAgent
         case Notification.MEDIA_AVAILABLE:
           status = 'Available';
           break;
+        case Notification.EPISODE_AVAILABLE:
+          status = 'New Episode Available';
+          break;
         case Notification.MEDIA_DECLINED:
           status = 'Declined';
           priority = 1;

--- a/server/lib/notifications/agents/slack.ts
+++ b/server/lib/notifications/agents/slack.ts
@@ -85,6 +85,9 @@ class SlackAgent
         case Notification.MEDIA_AVAILABLE:
           status = 'Available';
           break;
+        case Notification.EPISODE_AVAILABLE:
+          status = 'New Episode Available';
+          break;
         case Notification.MEDIA_DECLINED:
           status = 'Declined';
           break;

--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -98,6 +98,9 @@ class TelegramAgent
         case Notification.MEDIA_AVAILABLE:
           status = 'Available';
           break;
+        case Notification.EPISODE_AVAILABLE:
+          status = 'New Episode Available';
+          break;
         case Notification.MEDIA_DECLINED:
           status = 'Declined';
           break;

--- a/server/lib/notifications/agents/webpush.ts
+++ b/server/lib/notifications/agents/webpush.ts
@@ -82,6 +82,11 @@ class WebPushAgent
           is4k ? '4K ' : ''
         }${mediaType} request is now available!`;
         break;
+      case Notification.EPISODE_AVAILABLE:
+        message = `A new episode of your ${
+          is4k ? '4K ' : ''
+        }${mediaType} request is now available!`;
+        break;
       case Notification.MEDIA_DECLINED:
         message = `Your ${is4k ? '4K ' : ''}${mediaType} request was declined.`;
         break;

--- a/server/lib/notifications/index.ts
+++ b/server/lib/notifications/index.ts
@@ -17,6 +17,7 @@ export enum Notification {
   ISSUE_RESOLVED = 1024,
   ISSUE_REOPENED = 2048,
   MEDIA_AUTO_REQUESTED = 4096,
+  EPISODE_AVAILABLE = 8192,
 }
 
 export const hasNotificationType = (

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -174,6 +174,183 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
     }
   }
 
+  private async notifyNewEpisodes(
+    entity: Media,
+    dbEntity: Media,
+    is4k: boolean
+  ) {
+    // Only proceed if this is a TV show
+    if (entity.mediaType !== MediaType.TV) {
+      logger.debug('Skipping episode notification - not a TV show', {
+        label: 'Notifications',
+        mediaId: entity.id,
+        mediaType: entity.mediaType,
+      });
+      return;
+    }
+
+    logger.debug('Checking for new episodes', {
+      label: 'Notifications',
+      mediaId: entity.id,
+      is4k,
+    });
+
+    const requestRepository = getRepository(MediaRequest);
+
+    // Get seasons that are partially available in the updated entity
+    const partiallyAvailableSeasons = entity.seasons
+      .filter(
+        (season: Season) =>
+          season[is4k ? 'status4k' : 'status'] ===
+          MediaStatus.PARTIALLY_AVAILABLE
+      )
+      .map((season: Season) => season.seasonNumber);
+
+    logger.debug('Partially available seasons', {
+      label: 'Notifications',
+      mediaId: entity.id,
+      is4k,
+      partiallyAvailableSeasons,
+    });
+
+    // If we have partially available seasons, see if they were updated
+    if (partiallyAvailableSeasons.length > 0) {
+      // Check if the lastSeasonChange was updated (indicates new episodes)
+      if (
+        entity.lastSeasonChange &&
+        dbEntity.lastSeasonChange &&
+        entity.lastSeasonChange.getTime() > dbEntity.lastSeasonChange.getTime()
+      ) {
+        logger.debug('Detected lastSeasonChange update', {
+          label: 'Notifications',
+          mediaId: entity.id,
+          is4k,
+          oldTimestamp: dbEntity.lastSeasonChange.toISOString(),
+          newTimestamp: entity.lastSeasonChange.toISOString(),
+        });
+
+        // Find relevant requests for this media
+        const requests = await requestRepository.find({
+          where: {
+            media: {
+              id: entity.id,
+            },
+            is4k,
+            status: Not(MediaRequestStatus.DECLINED),
+          },
+        });
+
+        logger.debug('Found requests for media', {
+          label: 'Notifications',
+          mediaId: entity.id,
+          is4k,
+          requestCount: requests.length,
+          requestIds: requests.map((req) => req.id),
+        });
+
+        if (requests.length > 0) {
+          const tmdb = new TheMovieDb();
+
+          try {
+            const tv = await tmdb.getTvShow({ tvId: entity.tmdbId });
+
+            // Send notifications to requesters of this show
+            for (const request of requests) {
+              // Check if the request has any seasons that are partially available
+              const hasRequestedPartialSeasons = request.seasons.some(
+                (season) =>
+                  partiallyAvailableSeasons.includes(season.seasonNumber)
+              );
+
+              const requestSeasons = request.seasons.map((s) => s.seasonNumber);
+              logger.debug('Checking request for matching seasons', {
+                label: 'Notifications',
+                mediaId: entity.id,
+                is4k,
+                requestId: request.id,
+                requestedSeasons: requestSeasons,
+                partiallyAvailableSeasons,
+                matchFound: hasRequestedPartialSeasons,
+              });
+
+              if (hasRequestedPartialSeasons) {
+                logger.info('Sending new episode notification', {
+                  label: 'Notifications',
+                  mediaId: entity.id,
+                  is4k,
+                  requestId: request.id,
+                  userId: request.requestedBy.id,
+                  seasons: partiallyAvailableSeasons,
+                });
+
+                notificationManager.sendNotification(
+                  Notification.EPISODE_AVAILABLE,
+                  {
+                    event: `${is4k ? '4K ' : ''}New Episode Available`,
+                    subject: `${tv.name}${
+                      tv.first_air_date
+                        ? ` (${tv.first_air_date.slice(0, 4)})`
+                        : ''
+                    }`,
+                    message: truncate(tv.overview, {
+                      length: 500,
+                      separator: /\s/,
+                      omission: '…',
+                    }),
+                    notifyAdmin: false,
+                    notifySystem: true,
+                    notifyUser: request.requestedBy,
+                    image: `https://image.tmdb.org/t/p/w600_and_h900_bestv2${tv.poster_path}`,
+                    media: entity,
+                    extra: [
+                      {
+                        name: 'Affected Seasons',
+                        value: partiallyAvailableSeasons.join(', '),
+                      },
+                    ],
+                    request,
+                  }
+                );
+              }
+            }
+          } catch (e) {
+            logger.error(
+              'Something went wrong sending episode notification(s)',
+              {
+                label: 'Notifications',
+                errorMessage: e.message,
+                mediaId: entity.id,
+              }
+            );
+          }
+        } else {
+          logger.debug('No matching requests found for episode notification', {
+            label: 'Notifications',
+            mediaId: entity.id,
+            is4k,
+          });
+        }
+      } else {
+        logger.debug('No lastSeasonChange update detected', {
+          label: 'Notifications',
+          mediaId: entity.id,
+          is4k,
+          hasOldTimestamp: !!dbEntity.lastSeasonChange,
+          hasNewTimestamp: !!entity.lastSeasonChange,
+          oldTimestamp: dbEntity.lastSeasonChange?.toISOString(),
+          newTimestamp: entity.lastSeasonChange?.toISOString(),
+        });
+      }
+    } else {
+      logger.debug('No partially available seasons found', {
+        label: 'Notifications',
+        mediaId: entity.id,
+        is4k,
+        seasonCount: entity.seasons.length,
+      });
+    }
+  }
+
   private async updateChildRequestStatus(event: Media, is4k: boolean) {
     const requestRepository = getRepository(MediaRequest);
 
@@ -229,6 +406,20 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
         event.databaseEntity,
         false
       );
+
+      // Check if lastSeasonChange was updated, which signals new episodes
+      if (
+        event.entity.lastSeasonChange &&
+        event.databaseEntity.lastSeasonChange &&
+        event.entity.lastSeasonChange.getTime() >
+          event.databaseEntity.lastSeasonChange.getTime()
+      ) {
+        this.notifyNewEpisodes(
+          event.entity as Media,
+          event.databaseEntity,
+          false
+        );
+      }
     }
 
     if (
@@ -241,6 +432,20 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
         event.databaseEntity,
         true
       );
+
+      // Check if lastSeasonChange was updated, which signals new episodes for 4K
+      if (
+        event.entity.lastSeasonChange &&
+        event.databaseEntity.lastSeasonChange &&
+        event.entity.lastSeasonChange.getTime() >
+          event.databaseEntity.lastSeasonChange.getTime()
+      ) {
+        this.notifyNewEpisodes(
+          event.entity as Media,
+          event.databaseEntity,
+          true
+        );
+      }
     }
 
     if (

--- a/src/components/NotificationTypeSelector/index.tsx
+++ b/src/components/NotificationTypeSelector/index.tsx
@@ -29,6 +29,11 @@ const messages = defineMessages('components.NotificationTypeSelector', {
     'Send notifications when media requests become available.',
   usermediaavailableDescription:
     'Get notified when your media requests become available.',
+  episodeavailable: 'New Episode in Partially Available Season',
+  episodeavailableDescription:
+    'Send notifications when new episodes of partially available seasons of requested shows become available.',
+  userepisodeavailableDescription:
+    'Get notified when new episodes for partially available seasons of your requested shows become available.',
   mediafailed: 'Request Processing Failed',
   mediafailedDescription:
     'Send notifications when media requests fail to be added to Radarr or Sonarr.',
@@ -106,6 +111,7 @@ export enum Notification {
   ISSUE_RESOLVED = 1024,
   ISSUE_REOPENED = 2048,
   MEDIA_AUTO_REQUESTED = 4096,
+  EPISODE_AVAILABLE = 8192,
 }
 
 export const ALL_NOTIFICATIONS = Object.values(Notification)
@@ -272,6 +278,17 @@ const NotificationTypeSelector = ({
             : messages.mediaavailableDescription
         ),
         value: Notification.MEDIA_AVAILABLE,
+        hasNotifyUser: true,
+      },
+      {
+        id: 'episode-available',
+        name: intl.formatMessage(messages.episodeavailable),
+        description: intl.formatMessage(
+          user
+            ? messages.userepisodeavailableDescription
+            : messages.episodeavailableDescription
+        ),
+        value: Notification.EPISODE_AVAILABLE,
         hasNotifyUser: true,
       },
       {


### PR DESCRIPTION
This feature adds a new NEW_EPISODE notification type and a trigger specifically built for Jellyfin. It fires during the "recently added" scan of Jellyfin when Jellyfin returns an episode in the newly added array. 

 - it will only fire notifications for seasons in the partiall available status that have new episodes 
 - it only detects new episodes that Jellyfin returns as new episodes

re #480

#### Description
 - updates the `MediaSubscriber.ts` class to trigger this new notification type before an update the the Media entity
 - adds the new notification setting in the 

#### Screenshot (if UI-related)
discord example:
<img width="599" alt="image" src="https://github.com/user-attachments/assets/d500845d-91b8-4b78-b47a-e34616fe3bcf" />

example log for the first fire (in dev mode):
```plaintext
2025-04-14T20:10:04.541Z [info][Jellyfin Sync]: Beginning to process recently added for library: TV Shows
2025-04-14T20:10:04.753Z [info][Jellyfin Sync]: New standard episode detected for The Last of Us S2E1
2025-04-14T20:10:04.756Z [debug][Notifications]: Checking for new episodes {"mediaId":47,"is4k":false}
2025-04-14T20:10:04.756Z [debug][Notifications]: Partially available seasons {"mediaId":47,"is4k":false,"partiallyAvailableSeasons":[2]}
2025-04-14T20:10:04.756Z [debug][Notifications]: Detected lastSeasonChange update {"mediaId":47,"is4k":false,"oldTimestamp":"2025-04-14T20:00:04.719Z","newTimestamp":"2025-04-14T20:10:04.753Z"}
2025-04-14T20:10:04.764Z [debug][Notifications]: Found requests for media {"mediaId":47,"is4k":false,"requestCount":1,"requestIds":[3]}
2025-04-14T20:10:04.798Z [debug][Notifications]: Checking request for matching seasons {"mediaId":47,"is4k":false,"requestId":3,"requestedSeasons":[1,2],"partiallyAvailableSeasons":[2],"matchFound":true}
2025-04-14T20:10:04.798Z [info][Notifications]: Sending new episode notification {"mediaId":47,"is4k":false,"requestId":3,"userId":1,"seasons":[2]}
2025-04-14T20:10:04.798Z [info][Notifications]: Sending notification(s) for EPISODE_AVAILABLE {"subject":"The Last of Us (2023)"}
2025-04-14T20:10:04.798Z [debug][Notifications]: Sending Discord notification {"type":"EPISODE_AVAILABLE","subject":"The Last of Us (2023)"}

```

example log if the notification has already been fired:
```plaintext
2025-04-14T20:30:04.497Z [info][Jellyfin Sync]: Beginning to process recently added for library: TV Shows
2025-04-14T20:30:04.608Z [debug][Jellyfin Sync]: Skipping notification - show The Last of Us was recently notified (0 hours ago)
```

#### To-Dos

- [x] fire new episode notification for jellyfin
- [ ] handle full scans?
- [ ] plex

#### Issues Fixed or Closed

- implements #480
