### PR TITLE
fix(pushover notificatons): the sound setting will now be stored correctly

### DIFF
--- a/src/components/Settings/Notifications/NotificationsPushover/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsPushover/index.tsx
@@ -100,6 +100,7 @@ const NotificationsPushover = () => {
             options: {
               accessToken: values.accessToken,
               userToken: values.userToken,
+              sound: values.sound,
             },
           });
           addToast(intl.formatMessage(messages.pushoversettingssaved), {


### PR DESCRIPTION
the sound setting will now be stored correctly

fix #1614

#### Description

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1614
