### PR TITLE
fix(issuecomment): fix issue display lists in IssueComment

### DIFF
--- a/src/components/IssueDetails/IssueComment/index.tsx
+++ b/src/components/IssueDetails/IssueComment/index.tsx
@@ -223,7 +223,9 @@ const IssueComment = ({
               </Formik>
             ) : (
               <div className="prose w-full max-w-full">
-                <ReactMarkdown skipHtml>{comment.message}</ReactMarkdown>
+                <ReactMarkdown skipHtml allowedElements={['p', 'em', 'strong', 'ul', 'ol', 'li']}>
+                  {comment.message}
+                </ReactMarkdown>
               </div>
             )}
           </div>

--- a/src/components/IssueDetails/IssueComment/index.tsx
+++ b/src/components/IssueDetails/IssueComment/index.tsx
@@ -223,7 +223,10 @@ const IssueComment = ({
               </Formik>
             ) : (
               <div className="prose w-full max-w-full">
-                <ReactMarkdown skipHtml allowedElements={['p', 'em', 'strong', 'ul', 'ol', 'li']}>
+                <ReactMarkdown
+                  skipHtml
+                  allowedElements={['p', 'em', 'strong', 'ul', 'ol', 'li']}
+                >
                   {comment.message}
                 </ReactMarkdown>
               </div>

--- a/src/components/IssueDetails/IssueComment/index.tsx
+++ b/src/components/IssueDetails/IssueComment/index.tsx
@@ -223,9 +223,7 @@ const IssueComment = ({
               </Formik>
             ) : (
               <div className="prose w-full max-w-full">
-                <ReactMarkdown skipHtml allowedElements={['p', 'em', 'strong']}>
-                  {comment.message}
-                </ReactMarkdown>
+                <ReactMarkdown skipHtml>{comment.message}</ReactMarkdown>
               </div>
             )}
           </div>


### PR DESCRIPTION
The IssueComment module was not displaying markdown list's ordered or unorderd.  Removing the allowed elements so all markdowns are allowed seems to fix this issue and work similar to github's comment  control with lists and markdown.

fix #1328

#### Description

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1328
