### PR TITLE
docs: remove obsolete JELLYFIN_TYPE mentions

### DIFF
--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -39,11 +39,6 @@ docker run -d \
   --restart unless-stopped \
   ghcr.io/fallenbagel/jellyseerr
 ```
-:::tip
-If you are using emby, make sure to set the `JELLYFIN_TYPE` environment variable to `emby`.
-
-`-e JELLYFIN_TYPE=emby`
-:::
 
 To run the container as a specific user/group, you may optionally add `--user=[ user | user:group | uid | uid:gid | user:gid | uid:group ]` to the above command.
 
@@ -90,9 +85,6 @@ services:
       - /path/to/appdata/config:/app/config
     restart: unless-stopped
 ```
-:::tip
-If you are using emby, make sure to set the `JELLYFIN_TYPE` environment variable to `emby`.
-:::
 
 Then, start all services defined in the Compose file:
 ```bash
@@ -121,8 +113,7 @@ You may alternatively use a third-party mechanism like [dockge](https://github.c
 2. Inside the **Community Applications** app store, search for **Jellyseerr**.
 3. Click the **Install Button**.
 4. On the following **Add Container** screen, make changes to the **Host Port** and **Host Path 1** \(Appdata\) as needed.
-5. If you want to use emby, make sure to set the `JELLYFIN_TYPE` environment variable to `emby`. Otherwise, remove the variable.
-6. Click apply and access "Jellyseerr" at your `<ServerIP:HostPort>` in a web browser.
+5. Click apply and access "Jellyseerr" at your `<ServerIP:HostPort>` in a web browser.
 
 ## Windows
 
@@ -192,12 +183,6 @@ docker compose up -d
 ```
   </TabItem>
 </Tabs>
-
-:::tip
-If you are using a named volume, then you can safely **ignore** the warning about the `/app/config` folder being incorrectly mounted.
-
-If you are using emby, make sure to set the `JELLYFIN_TYPE` environment variable to `emby`.
-:::
 
 To access the files inside the volume created above, navigate to `\\wsl$\docker-desktop-data\version-pack-data\community\docker\volumes\jellyseerr-data\_data` using File Explorer.
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -511,7 +511,9 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       case ApiErrorCode.InvalidUrl:
         logger.error(
           `The provided ${
-            process.env.JELLYFIN_TYPE == 'emby' ? 'Emby' : 'Jellyfin'
+            settings.main.mediaServerType === MediaServerType.JELLYFIN
+              ? ServerType.JELLYFIN
+              : ServerType.EMBY
           } is invalid or the server is not reachable.`,
           {
             label: 'Auth',


### PR DESCRIPTION
#### Description

This PR removes some remaining mentions of `JELLYFIN_TYPE`, removed in #685

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
