### PR TITLE
fix(requestlist): remove unnecessary semicolon

### DIFF
--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -192,7 +192,6 @@ const RequestList = () => {
                 {intl.formatMessage(globalMessages.tvshows)}
               </option>
             </select>
-            ;
           </div>
           <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 lg:flex-grow-0">
             <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">


### PR DESCRIPTION
#### Description

Removed an unnecessary semicolon in the RequestList component.
Initially missed it because I mistook it for a dead pixel on my screen - apologies for the oversight!

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
