### PR TITLE
fix(ui): correct seasons badge order

### DIFF
--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -120,7 +120,7 @@ const TvRequestModal = ({
           languageProfileId: requestOverrides?.language,
           userId: requestOverrides?.user?.id,
           tags: requestOverrides?.tags,
-          seasons: selectedSeasons,
+          seasons: selectedSeasons.sort((a, b) => a - b),
         });
 
         if (alsoApproveRequest) {


### PR DESCRIPTION
#### Description

This PR corrects the order of the seasons displayed on the request card, because it was not always ordered if the pending request was edited with random clicks.

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Related to #1485