### PR TITLE
fix(usediscover hook): detect end of pagination when totalSize is a multiple of pageSize

### DIFF
--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -138,6 +138,7 @@ const useDiscover = <
   const isReachingEnd =
     isEmpty ||
     (!!data && (data[data?.length - 1]?.results.length ?? 0) < 20) ||
+    (!!data && (data[data?.length - 1]?.totalResults ?? 0) <= size * 20) ||
     (!!data && (data[data?.length - 1]?.totalResults ?? 0) < 41);
 
   return {


### PR DESCRIPTION
#### Description

Fixes a crash on the `/discover/watchlist` page that occurred when the number of items was exactly a multiple of the page size (e.g., 80, 100, 120). The issue was caused by incorrect end-of-pagination detection, leading to infinite data fetching. This update adjusts the `isReachingEnd` condition to correctly handle these edge cases by checking if `totalResults` is less than or equal to the expected total based on `size * pageSize`.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1623
