### PR TITLE
fix(jellyfin): clean up Jellyfin sessions on Jellyseerr logout

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -97,24 +97,6 @@ class ExternalAPI {
     return response.data;
   }
 
-  protected async delete<T>(
-    endpoint: string,
-    config?: AxiosRequestConfig
-  ): Promise<T> {
-    const cacheKey = this.serializeCacheKey(endpoint, {
-      ...config?.params,
-      headers: config?.headers,
-    });
-
-    const cachedItem = this.cache?.get<T>(cacheKey);
-    if (cachedItem) {
-      return cachedItem;
-    }
-
-    const response = await this.axios.delete<T>(endpoint, config);
-    return response.data;
-  }
-
   protected async getRolling<T>(
     endpoint: string,
     config?: AxiosRequestConfig,

--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -97,6 +97,24 @@ class ExternalAPI {
     return response.data;
   }
 
+  protected async delete<T>(
+    endpoint: string,
+    config?: AxiosRequestConfig
+  ): Promise<T> {
+    const cacheKey = this.serializeCacheKey(endpoint, {
+      ...config?.params,
+      headers: config?.headers,
+    });
+
+    const cachedItem = this.cache?.get<T>(cacheKey);
+    if (cachedItem) {
+      return cachedItem;
+    }
+
+    const response = await this.axios.delete<T>(endpoint, config);
+    return response.data;
+  }
+
   protected async getRolling<T>(
     endpoint: string,
     config?: AxiosRequestConfig,

--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -454,51 +454,6 @@ class JellyfinAPI extends ExternalAPI {
       throw new ApiError(e.response?.status, ApiErrorCode.InvalidAuthToken);
     }
   }
-
-  public async deleteUserDevice(
-    userId: string,
-    deviceId: string
-  ): Promise<void> {
-    try {
-      const response = await this.get<JellyfinDevicesResponse>('/Devices', {
-        params: { UserId: userId },
-      });
-
-      logger.debug('Found Jellyfin devices', {
-        label: 'Jellyfin API',
-        deviceCount: response.Items.length,
-        userId,
-      });
-
-      const device = response.Items.find(
-        (item: JellyfinDevice) => item.Id === deviceId
-      );
-      if (!device) {
-        logger.debug('No matching Jellyfin device found', {
-          label: 'Jellyfin API',
-          deviceId,
-          userId,
-        });
-        return;
-      }
-
-      await this.delete('/Devices', { params: { Id: device.Id } });
-      logger.info('Successfully deleted Jellyfin device', {
-        label: 'Jellyfin API',
-        deviceId: device.Id,
-        deviceName: device.Name,
-        userId,
-      });
-    } catch (error) {
-      logger.error('Failed to delete Jellyfin device', {
-        label: 'Jellyfin API',
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId,
-        deviceId,
-      });
-      throw error;
-    }
-  }
 }
 
 export default JellyfinAPI;


### PR DESCRIPTION
#### Description

Currently, when users log out of Jellyseerr (or simply close their browser), their Jellyfin "Device" entries remain active on the Jellyfin server under the name "Jellyseerr."
This means old sessions pile up.
And this can lead to issues when users have a limited number of allowed simultaneous sessions in Jellyfin (e.g., 5 sessions per user), as each new Jellyseerr login creates a new session without cleaning up the old ones.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1572
