### PR TITLE
fix(url validation): correct URL validation for empty fields

### DIFF
--- a/src/utils/urlValidationHelper.ts
+++ b/src/utils/urlValidationHelper.ts
@@ -1,7 +1,9 @@
 export function isValidURL(value: unknown) {
   try {
     let url: URL;
-    if (typeof value === 'string') {
+    if (value === undefined || value === null || value === '') {
+      return true;
+    } else if (typeof value === 'string') {
       url = new URL(value);
     } else if (value instanceof URL) {
       url = value;


### PR DESCRIPTION
#### Description

The `isValidURL` function was returning `false` when the provided value was undefined/null/empty, but needs to return `true` instead so it doesn't interfere with Yup validation.

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
