### PR TITLE
docs: revert image change to dockerhub.io

### DIFF
--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -37,7 +37,7 @@ docker run -d \
   -p 5055:5055 \
   -v /path/to/appdata/config:/app/config \
   --restart unless-stopped \
-  ghcr.io/fallenbagel/jellyseerr
+  fallenbagel/jellyseerr
 ```
 
 To run the container as a specific user/group, you may optionally add `--user=[ user | user:group | uid | uid:gid | user:gid | uid:group ]` to the above command.
@@ -50,7 +50,7 @@ docker stop jellyseerr && docker rm Jellyseerr
 ```
 Pull the latest image:
 ```bash
-docker pull ghcr.io/fallenbagel/jellyseerr
+docker pull fallenbagel/jellyseerr
 ```
 Finally, run the container with the same parameters originally used to create the container:
 ```bash
@@ -73,7 +73,7 @@ Define the `jellyseerr` service in your `compose.yaml` as follows:
 ---
 services:
   jellyseerr:
-    image: ghcr.io/fallenbagel/jellyseerr:latest
+    image: fallenbagel/jellyseerr:latest
     container_name: jellyseerr
     environment:
       - LOG_LEVEL=debug
@@ -137,7 +137,7 @@ Then, create and start the Jellyseerr container:
 <Tabs groupId="docker-methods" queryString>
   <TabItem value="docker-cli" label="Docker CLI">
 ```bash
-docker run -d --name jellyseerr -e LOG_LEVEL=debug -e TZ=Asia/Tashkent -p 5055:5055 -v "jellyseerr-data:/app/config" --restart unless-stopped ghcr.io/fallenbagel/jellyseerr:latest
+docker run -d --name jellyseerr -e LOG_LEVEL=debug -e TZ=Asia/Tashkent -p 5055:5055 -v "jellyseerr-data:/app/config" --restart unless-stopped fallenbagel/jellyseerr:latest
 ```
 
 #### Updating:


### PR DESCRIPTION
#### Description
One of the previous prs changed it to ghcr.io. While we do support it, that's our secondary and dockerhub has always been our primary.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
