### PR TITLE
fix(ui): make person media type filter consistent on mobile

### DIFF
--- a/src/components/PersonDetails/index.tsx
+++ b/src/components/PersonDetails/index.tsx
@@ -271,9 +271,11 @@ const PersonDetails = () => {
           </div>
         )}
         <div className="w-full text-center text-gray-300 lg:text-left">
-          <div className="flex w-full items-center justify-between">
+          <div className="flex w-full items-center justify-center lg:justify-between">
             <h1 className="text-3xl text-white lg:text-4xl">{data.name}</h1>
-            <div className="flex-shrink-0">{mediaTypePicker}</div>
+            <div className="hidden flex-shrink-0 lg:block">
+              {mediaTypePicker}
+            </div>
           </div>
           <div className="mt-1 mb-2 space-y-1 text-xs text-white sm:text-sm lg:text-base">
             <div>{personAttributes.join(' | ')}</div>
@@ -312,6 +314,7 @@ const PersonDetails = () => {
           )}
         </div>
       </div>
+      <div className="lg:hidden">{mediaTypePicker}</div>
       {data.knownForDepartment === 'Acting' ? [cast, crew] : [crew, cast]}
       {isLoading && <LoadingSpinner />}
     </>


### PR DESCRIPTION
#### Description

This PR fixes the media type filter on mobile

#### Screenshot (if UI-related)

Before:
![image](https://github.com/user-attachments/assets/e3b31a5c-f5c8-4396-ad3f-2d6207bf18e7)

After:
![image](https://github.com/user-attachments/assets/f951c9e8-57ae-4ccb-a064-657f9633b086)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
