### PR TITLE
fix: closing an issue with a comment the data sent out for notifications did not contain the comment

### DIFF
--- a/server/routes/issue.ts
+++ b/server/routes/issue.ts
@@ -333,6 +333,15 @@ issueRoutes.post<{ issueId: string; status: string }, Issue>(
         });
       }
 
+      if (req.body.message !== undefined) {
+        const comment = new IssueComment({
+          message: req.body.message,
+          user: req.user,
+        });
+
+        issue.comments = [...issue.comments, comment];
+      }
+
       let newStatus: IssueStatus | undefined;
 
       switch (req.params.status) {

--- a/server/subscriber/IssueSubscriber.ts
+++ b/server/subscriber/IssueSubscriber.ts
@@ -42,6 +42,8 @@ export class IssueSubscriber implements EntitySubscriberInterface<Issue> {
       }
 
       const [firstComment] = sortBy(entity.comments, 'id');
+      const lastComment = entity.comments.at(-1);
+
       const extra: { name: string; value: string }[] = [];
 
       if (entity.media.mediaType === MediaType.TV && entity.problemSeason > 0) {
@@ -80,6 +82,7 @@ export class IssueSubscriber implements EntitySubscriberInterface<Issue> {
         subject: title,
         message: firstComment.message,
         issue: entity,
+        comment: lastComment,
         media: entity.media,
         image,
         extra,

--- a/src/components/IssueDetails/index.tsx
+++ b/src/components/IssueDetails/index.tsx
@@ -139,9 +139,18 @@ const IssueDetails = () => {
     }
   };
 
-  const updateIssueStatus = async (newStatus: 'open' | 'resolved') => {
+  const updateIssueStatus = async (
+    newStatus: 'open' | 'resolved',
+    newMessage?: string
+  ) => {
     try {
-      await axios.post(`/api/v1/issue/${issueData.id}/${newStatus}`);
+      if (newMessage !== undefined) {
+        await axios.post(`/api/v1/issue/${issueData.id}/${newStatus}`, {
+          message: newMessage,
+        });
+      } else {
+        await axios.post(`/api/v1/issue/${issueData.id}/${newStatus}`);
+      }
 
       addToast(intl.formatMessage(messages.toaststatusupdated), {
         appearance: 'success',
@@ -523,11 +532,12 @@ const IssueDetails = () => {
                                   type="button"
                                   buttonType="danger"
                                   onClick={async () => {
-                                    await updateIssueStatus('resolved');
-
-                                    if (values.message) {
-                                      handleSubmit();
-                                    }
+                                    values.message
+                                      ? updateIssueStatus(
+                                          'resolved',
+                                          values.message
+                                        )
+                                      : updateIssueStatus('resolved');
                                   }}
                                 >
                                   <CheckCircleIcon />


### PR DESCRIPTION


When closing an issue with a comment the data did not contain the comment for notifications.  Now it will and the additional ISSUE_COMMENT notification will go out too as it did before.

#### Description

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1474
