### PR TITLE
fix(mediarequests): properly sort season numbers in media requests

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -17,6 +17,7 @@ import { DbAwareColumn } from '@server/utils/DbColumnHelper';
 import { truncate } from 'lodash';
 import {
   AfterInsert,
+  AfterLoad,
   AfterUpdate,
   Column,
   Entity,
@@ -698,6 +699,13 @@ export class MediaRequest {
   public async autoapprovalNotification(): Promise<void> {
     if (this.status === MediaRequestStatus.APPROVED) {
       this.notifyApprovedOrDeclined(true);
+    }
+  }
+
+  @AfterLoad()
+  private sortSeasons() {
+    if (Array.isArray(this.seasons)) {
+      this.seasons.sort((a, b) => a.id - b.id);
     }
   }
 


### PR DESCRIPTION
#### Description
Added an `@AfterLoad()` hook in MediaRequest to ensure seasons are always ordered by their ID. Previously, `joinedseasons` could appear in arbitrary database order, leading to jumbled UI displays. With this change,the seasons list is automatically re-sorted in ascending order as soon as TypeORM hydrates the entity.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1336
