### PR TITLE
fix(usersettings): exclude current user when checking for existing email

### DIFF
--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -18,6 +18,7 @@ import { ApiError } from '@server/types/error';
 import { getHostname } from '@server/utils/getHostname';
 import { Router } from 'express';
 import net from 'net';
+import { Not } from 'typeorm';
 import { canMakePermissionsChange } from '.';
 
 const isOwnProfile = (): Middleware => {
@@ -125,8 +126,9 @@ userSettingsRoutes.post<
     }
 
     const existingUser = await userRepository.findOne({
-      where: { email: user.email },
+      where: { email: user.email, id: Not(user.id) },
     });
+
     if (oldEmail !== user.email && existingUser) {
       throw new ApiError(400, ApiErrorCode.InvalidEmail);
     }


### PR DESCRIPTION
#### Description
This update modifies the user settings endpoint so that, when validating email uniqueness, the query excludes the current user’s own record. As a result, clearing or changing an email no longer triggers a false “InvalidEmail” error. Only genuinely conflicting emails on other users will be rejected.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
