### PR TITLE
fix(filters): display the right value when resetting the filter options

### DIFF
--- a/src/components/Discover/DiscoverMovies/index.tsx
+++ b/src/components/Discover/DiscoverMovies/index.tsx
@@ -51,6 +51,8 @@ const DiscoverMovies = () => {
 
   const preparedFilters = prepareFilterValues(router.query);
 
+  console.log('DiscoverMovies preparedFilters:', preparedFilters);
+
   const {
     isLoadingInitialData,
     isEmpty,
@@ -85,7 +87,7 @@ const DiscoverMovies = () => {
               id="sortBy"
               name="sortBy"
               className="rounded-r-only"
-              value={preparedFilters.sortBy}
+              value={preparedFilters.sortBy || SortOptions.PopularityDesc}
               onChange={(e) => updateQueryParams('sortBy', e.target.value)}
             >
               <option value={SortOptions.PopularityDesc}>

--- a/src/components/Discover/DiscoverTv/index.tsx
+++ b/src/components/Discover/DiscoverTv/index.tsx
@@ -83,7 +83,7 @@ const DiscoverTv = () => {
               id="sortBy"
               name="sortBy"
               className="rounded-r-only"
-              value={preparedFilters.sortBy}
+              value={preparedFilters.sortBy || SortOptions.PopularityDesc}
               onChange={(e) => updateQueryParams('sortBy', e.target.value)}
             >
               <option value={SortOptions.PopularityDesc}>


### PR DESCRIPTION
#### Description

When clearing the filters everything is reset but the sort option still display the previous value, while the content has now the default value.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1693
