### PR TITLE
fix(blacklist): hide items from MediaSliders when hideBlacklisted is enabled

### DIFF
--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -74,6 +74,14 @@ const MediaSlider = ({
     );
   }
 
+  if (settings.currentSettings.hideBlacklisted) {
+    titles = titles.filter(
+      (i) =>
+        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
+        i.mediaInfo?.status !== MediaStatus.BLACKLISTED
+    );
+  }
+
   useEffect(() => {
     if (
       titles.length < 24 &&


### PR DESCRIPTION
#### Description

This PR hides the blacklisted items from the MediaSliders appearing on the homepage when the hideBlacklisted is enabled.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Re #1601