### PR TITLE
fix(settings): add a tip for youtube URL setting

### DIFF
--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -66,6 +66,8 @@ const messages = defineMessages('components.Settings.SettingsMain', {
   enableSpecialEpisodes: 'Allow Special Episodes Requests',
   locale: 'Display Language',
   youtubeUrl: 'YouTube URL',
+  youtubeUrlTip:
+    'Base URL for YouTube videos if a self-hosted YouTube instance is used.',
   validationUrl: 'You must provide a valid URL',
   validationUrlTrailingSlash: 'URL must not end in a trailing slash',
 });
@@ -536,6 +538,9 @@ const SettingsMain = () => {
                 <div className="form-row">
                   <label htmlFor="youtubeUrl" className="text-label">
                     {intl.formatMessage(messages.youtubeUrl)}
+                    <span className="label-tip">
+                      {intl.formatMessage(messages.youtubeUrlTip)}
+                    </span>
                   </label>
                   <div className="form-input-area">
                     <div className="form-input-field">


### PR DESCRIPTION
#### Description

This PR adds a tip explaining what is the purpose of the new 'Youtube URL' setting.

#### Screenshot (if UI-related)

![image](https://github.com/user-attachments/assets/207354ca-60da-427c-b6ae-d47285582233)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
