### PR TITLE
fix: correct typing issue

### DIFF
--- a/src/components/Settings/Notifications/NotificationsNtfy/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsNtfy/index.tsx
@@ -6,6 +6,7 @@ import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
 import { isValidURL } from '@app/utils/urlValidationHelper';
 import { ArrowDownOnSquareIcon, BeakerIcon } from '@heroicons/react/24/outline';
+import type { NotificationAgentNtfy } from '@server/lib/settings';
 import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
 import { useState } from 'react';
@@ -44,7 +45,7 @@ const NotificationsNtfy = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR('/api/v1/settings/notifications/ntfy');
+  } = useSWR<NotificationAgentNtfy>('/api/v1/settings/notifications/ntfy');
 
   const NotificationsNtfySchema = Yup.object().shape({
     url: Yup.string()
@@ -78,15 +79,15 @@ const NotificationsNtfy = () => {
   return (
     <Formik
       initialValues={{
-        enabled: data.enabled,
-        types: data.types,
-        url: data.options.url,
-        topic: data.options.topic,
-        authMethodUsernamePassword: data.options.authMethod,
-        username: data.options.username,
-        password: data.options.password,
-        authMethodToken: data.options.authMethodToken,
-        token: data.options.token,
+        enabled: data?.enabled,
+        types: data?.types,
+        url: data?.options.url,
+        topic: data?.options.topic,
+        authMethodUsernamePassword: data?.options.authMethodUsernamePassword,
+        username: data?.options.username,
+        password: data?.options.password,
+        authMethodToken: data?.options.authMethodToken,
+        token: data?.options.token,
       }}
       validationSchema={NotificationsNtfySchema}
       onSubmit={async (values) => {

--- a/src/components/Settings/Notifications/NotificationsNtfy/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsNtfy/index.tsx
@@ -303,7 +303,7 @@ const NotificationsNtfy = () => {
               </div>
             )}
             <NotificationTypeSelector
-              currentTypes={values.enabled ? values.types : 0}
+              currentTypes={values.enabled ? values.types || 0 : 0}
               onUpdate={(newTypes) => {
                 setFieldValue('types', newTypes);
                 setFieldTouched('types');


### PR DESCRIPTION
#### Description

When using the username/password as auth method, the saved value was not displayed properly because
of a wrong property name introduced by a missing type.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Re #1705