### PR TITLE
fix: cover more content in the blacklisted tags processing job

### DIFF
--- a/server/job/blacklistedTagsProcessor.ts
+++ b/server/job/blacklistedTagsProcessor.ts
@@ -18,7 +18,7 @@ import { createTmdbWithRegionLanguage } from '@server/routes/discover';
 import type { EntityManager } from 'typeorm';
 
 const TMDB_API_DELAY_MS = 250;
-class AbortTransaction extends Error {}
+class AbortTransaction extends Error { }
 
 class BlacklistedTagProcessor implements RunnableScanner<StatusBase> {
   private running = false;
@@ -106,6 +106,8 @@ class BlacklistedTagProcessor implements RunnableScanner<StatusBase> {
             page,
             sortBy,
             keywords: tag,
+            includeAdult: true,
+            includeVideo: true
           });
           await this.processResults(response, tag, type, em);
           await new Promise((res) => setTimeout(res, TMDB_API_DELAY_MS));


### PR DESCRIPTION
#### Description
1. I've modified the newly added “blacklisted tags” job, to include adult & video content, this correctly blacklists more adult films that were **always** missed, even if they had the tag.

Testing for the tag `softcore`
number of results blacklisted before: 3631
number of results blacklisted after: 3855

2. I've also removed video content from tmdb results by default, because it resulted in less incorrectly tagged adult content shown.

#### Screenshot (if UI-related)
Before:
![图片](https://github.com/user-attachments/assets/6e0e5b9f-7f63-465c-bc27-7208077e667c)

After:
![图片](https://github.com/user-attachments/assets/0c368110-be06-45d9-a9e3-754e7fb7dd67)

Notice the one less adult video at the start.

#### To-Dos

- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- N/A