### PR TITLE
fix(gotify): notifications blocked when priority set to 0

### DIFF
--- a/server/lib/notifications/agents/gotify.ts
+++ b/server/lib/notifications/agents/gotify.ts
@@ -35,7 +35,7 @@ class GotifyAgent
       settings.enabled &&
       settings.options.url &&
       settings.options.token &&
-      settings.options.priority
+      settings.options.priority !== undefined
     ) {
       return true;
     }


### PR DESCRIPTION
#### Description
This PR fixes an issue where Gotify notifications would not be sent when the priority was configured to 0.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1754
