### PR TITLE
fix(proxy): modify the registration of the axios interceptors

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -1,3 +1,4 @@
+import { requestInterceptorFunction } from '@server/utils/customProxyAgent';
 import type { AxiosInstance, AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import rateLimit from 'axios-rate-limit';
@@ -37,8 +38,7 @@ class ExternalAPI {
         ...options.headers,
       },
     });
-    this.axios.interceptors.request = axios.interceptors.request;
-    this.axios.interceptors.response = axios.interceptors.response;
+    this.axios.interceptors.request.use(requestInterceptorFunction);
 
     if (options.rateLimit) {
       this.axios = rateLimit(this.axios, {

--- a/server/api/tautulli.ts
+++ b/server/api/tautulli.ts
@@ -1,6 +1,7 @@
 import type { User } from '@server/entity/User';
 import type { TautulliSettings } from '@server/lib/settings';
 import logger from '@server/logger';
+import { requestInterceptorFunction } from '@server/utils/customProxyAgent';
 import type { AxiosInstance } from 'axios';
 import axios from 'axios';
 import { uniqWith } from 'lodash';
@@ -123,8 +124,7 @@ class TautulliAPI {
       }${settings.urlBase ?? ''}`,
       params: { apikey: settings.apiKey },
     });
-    this.axios.interceptors.request = axios.interceptors.request;
-    this.axios.interceptors.response = axios.interceptors.response;
+    this.axios.interceptors.request.use(requestInterceptorFunction);
   }
 
   public async getInfo(): Promise<TautulliInfo> {

--- a/server/lib/imageproxy.ts
+++ b/server/lib/imageproxy.ts
@@ -1,4 +1,5 @@
 import logger from '@server/logger';
+import { requestInterceptorFunction } from '@server/utils/customProxyAgent';
 import axios from 'axios';
 import rateLimit, { type rateLimitOptions } from 'axios-rate-limit';
 import { createHash } from 'crypto';
@@ -150,8 +151,7 @@ class ImageProxy {
       baseURL: baseUrl,
       headers: options.headers,
     });
-    this.axios.interceptors.request = axios.interceptors.request;
-    this.axios.interceptors.response = axios.interceptors.response;
+    this.axios.interceptors.request.use(requestInterceptorFunction);
 
     if (options.rateLimitOptions) {
       this.axios = rateLimit(this.axios, options.rateLimitOptions);

--- a/server/utils/customProxyAgent.ts
+++ b/server/utils/customProxyAgent.ts
@@ -1,10 +1,14 @@
 import type { ProxySettings } from '@server/lib/settings';
 import logger from '@server/logger';
-import axios from 'axios';
+import axios, { type InternalAxiosRequestConfig } from 'axios';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import type { Dispatcher } from 'undici';
 import { Agent, ProxyAgent, setGlobalDispatcher } from 'undici';
+
+export let requestInterceptorFunction: (
+  config: InternalAxiosRequestConfig
+) => InternalAxiosRequestConfig;
 
 export default async function createCustomProxyAgent(
   proxySettings: ProxySettings
@@ -73,7 +77,8 @@ export default async function createCustomProxyAgent(
     axios.defaults.httpsAgent = new HttpsProxyAgent(proxyUrl, {
       headers: token ? { 'proxy-authorization': token } : undefined,
     });
-    axios.interceptors.request.use((config) => {
+
+    requestInterceptorFunction = (config) => {
       const url = config.baseURL
         ? new URL(config.baseURL + (config.url || ''))
         : config.url;
@@ -82,7 +87,8 @@ export default async function createCustomProxyAgent(
         config.httpsAgent = false;
       }
       return config;
-    });
+    };
+    axios.interceptors.request.use(requestInterceptorFunction);
   } catch (e) {
     logger.error('Failed to connect to the proxy: ' + e.message, {
       label: 'Proxy',


### PR DESCRIPTION
#### Description

The previous way of adding Axios interceptors added a new interceptor each time, causing lags after a while because of all the duplicate interceptors added.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1787
