### PR TITLE
fix(proxy): initialize image proxies after the proxy is set up

### DIFF
--- a/server/routes/imageproxy.ts
+++ b/server/routes/imageproxy.ts
@@ -4,27 +4,40 @@ import { Router } from 'express';
 
 const router = Router();
 
-const tmdbImageProxy = new ImageProxy('tmdb', 'https://image.tmdb.org', {
-  rateLimitOptions: {
-    maxRequests: 20,
-    maxRPS: 50,
-  },
-});
-const tvdbImageProxy = new ImageProxy('tvdb', 'https://artworks.thetvdb.com', {
-  rateLimitOptions: {
-    maxRequests: 20,
-    maxRPS: 50,
-  },
-});
+// Delay the initialization of ImageProxy instances until the proxy (if any) is properly configured
+let _tmdbImageProxy: ImageProxy;
+function initTmdbImageProxy() {
+  if (!_tmdbImageProxy) {
+    _tmdbImageProxy = new ImageProxy('tmdb', 'https://image.tmdb.org', {
+      rateLimitOptions: {
+        maxRequests: 20,
+        maxRPS: 50,
+      },
+    });
+  }
+  return _tmdbImageProxy;
+}
+let _tvdbImageProxy: ImageProxy;
+function initTvdbImageProxy() {
+  if (!_tvdbImageProxy) {
+    _tvdbImageProxy = new ImageProxy('tvdb', 'https://artworks.thetvdb.com', {
+      rateLimitOptions: {
+        maxRequests: 20,
+        maxRPS: 50,
+      },
+    });
+  }
+  return _tvdbImageProxy;
+}
 
 router.get('/:type/*', async (req, res) => {
   const imagePath = req.path.replace(/^\/\w+/, '');
   try {
     let imageData;
     if (req.params.type === 'tmdb') {
-      imageData = await tmdbImageProxy.getImage(imagePath);
+      imageData = await initTmdbImageProxy().getImage(imagePath);
     } else if (req.params.type === 'tvdb') {
-      imageData = await tvdbImageProxy.getImage(imagePath);
+      imageData = await initTvdbImageProxy().getImage(imagePath);
     } else {
       logger.error('Unsupported image type', {
         imagePath,


### PR DESCRIPTION
#### Description

The ImageProxy for TMDB and TheTVDB were initialized before the proxy settings were set up, so they were ignoring the proxy settings.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1787

