### PR TITLE
feat: sort quality profiles ASC in request and service configuration

### DIFF
--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -368,8 +368,12 @@ const AdvancedRequester = ({
                   {!isValidating &&
                     serverData &&
                     serverData.profiles
-                      .slice()
-                      .sort((a, b) => a.name.localeCompare(b.name))
+                      .toSorted((a, b) =>
+                        a.name.localeCompare(b.name, intl.locale, {
+                          numeric: true,
+                          sensitivity: 'base',
+                        })
+                      )
                       .map((profile) => (
                         <option
                           key={`profile-list${profile.id}`}

--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -367,24 +367,27 @@ const AdvancedRequester = ({
                   )}
                   {!isValidating &&
                     serverData &&
-                    serverData.profiles.map((profile) => (
-                      <option
-                        key={`profile-list${profile.id}`}
-                        value={profile.id}
-                      >
-                        {isAnime &&
-                        serverData.server.activeAnimeProfileId === profile.id
-                          ? intl.formatMessage(messages.default, {
-                              name: profile.name,
-                            })
-                          : !isAnime &&
-                              serverData.server.activeProfileId === profile.id
+                    serverData.profiles
+                      .slice()
+                      .sort((a, b) => a.name.localeCompare(b.name))
+                      .map((profile) => (
+                        <option
+                          key={`profile-list${profile.id}`}
+                          value={profile.id}
+                        >
+                          {isAnime &&
+                          serverData.server.activeAnimeProfileId === profile.id
                             ? intl.formatMessage(messages.default, {
                                 name: profile.name,
                               })
-                            : profile.name}
-                      </option>
-                    ))}
+                            : !isAnime &&
+                                serverData.server.activeProfileId === profile.id
+                              ? intl.formatMessage(messages.default, {
+                                  name: profile.name,
+                                })
+                              : profile.name}
+                        </option>
+                      ))}
                 </select>
               </div>
             )}

--- a/src/components/Settings/RadarrModal/index.tsx
+++ b/src/components/Settings/RadarrModal/index.tsx
@@ -526,14 +526,17 @@ const RadarrModal = ({ onClose, radarr, onSave }: RadarrModalProps) => {
                                 )}
                         </option>
                         {testResponse.profiles.length > 0 &&
-                          testResponse.profiles.map((profile) => (
-                            <option
-                              key={`loaded-profile-${profile.id}`}
-                              value={profile.id}
-                            >
-                              {profile.name}
-                            </option>
-                          ))}
+                          testResponse.profiles
+                            .slice()
+                            .sort((a, b) => a.name.localeCompare(b.name))
+                            .map((profile) => (
+                              <option
+                                key={`loaded-profile-${profile.id}`}
+                                value={profile.id}
+                              >
+                                {profile.name}
+                              </option>
+                            ))}
                       </Field>
                     </div>
                     {errors.activeProfileId &&

--- a/src/components/Settings/RadarrModal/index.tsx
+++ b/src/components/Settings/RadarrModal/index.tsx
@@ -527,8 +527,12 @@ const RadarrModal = ({ onClose, radarr, onSave }: RadarrModalProps) => {
                         </option>
                         {testResponse.profiles.length > 0 &&
                           testResponse.profiles
-                            .slice()
-                            .sort((a, b) => a.name.localeCompare(b.name))
+                            .toSorted((a, b) =>
+                              a.name.localeCompare(b.name, intl.locale, {
+                                numeric: true,
+                                sensitivity: 'base',
+                              })
+                            )
                             .map((profile) => (
                               <option
                                 key={`loaded-profile-${profile.id}`}

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -583,14 +583,17 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                                 )}
                         </option>
                         {testResponse.profiles.length > 0 &&
-                          testResponse.profiles.map((profile) => (
-                            <option
-                              key={`loaded-profile-${profile.id}`}
-                              value={profile.id}
-                            >
-                              {profile.name}
-                            </option>
-                          ))}
+                          testResponse.profiles
+                            .slice()
+                            .sort((a, b) => a.name.localeCompare(b.name))
+                            .map((profile) => (
+                              <option
+                                key={`loaded-profile-${profile.id}`}
+                                value={profile.id}
+                              >
+                                {profile.name}
+                              </option>
+                            ))}
                       </Field>
                     </div>
                     {errors.activeProfileId &&
@@ -795,14 +798,17 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                                 )}
                         </option>
                         {testResponse.profiles.length > 0 &&
-                          testResponse.profiles.map((profile) => (
-                            <option
-                              key={`loaded-profile-${profile.id}`}
-                              value={profile.id}
-                            >
-                              {profile.name}
-                            </option>
-                          ))}
+                          testResponse.profiles
+                            .slice()
+                            .sort((a, b) => a.name.localeCompare(b.name))
+                            .map((profile) => (
+                              <option
+                                key={`loaded-profile-anime-${profile.id}`}
+                                value={profile.id}
+                              >
+                                {profile.name}
+                              </option>
+                            ))}
                       </Field>
                     </div>
                     {errors.activeAnimeProfileId &&

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -584,8 +584,12 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                         </option>
                         {testResponse.profiles.length > 0 &&
                           testResponse.profiles
-                            .slice()
-                            .sort((a, b) => a.name.localeCompare(b.name))
+                            .toSorted((a, b) =>
+                              a.name.localeCompare(b.name, intl.locale, {
+                                numeric: true,
+                                sensitivity: 'base',
+                              })
+                            )
                             .map((profile) => (
                               <option
                                 key={`loaded-profile-${profile.id}`}
@@ -799,8 +803,12 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                         </option>
                         {testResponse.profiles.length > 0 &&
                           testResponse.profiles
-                            .slice()
-                            .sort((a, b) => a.name.localeCompare(b.name))
+                            .toSorted((a, b) =>
+                              a.name.localeCompare(b.name, intl.locale, {
+                                numeric: true,
+                                sensitivity: 'base',
+                              })
+                            )
                             .map((profile) => (
                               <option
                                 key={`loaded-profile-anime-${profile.id}`}


### PR DESCRIPTION
## Description
This PR add proper *arr profiles natural (ASC) sorting.
Covers both Advanced Requests and Services configuration. 

## How Has This Been Tested?


## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1778


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile dropdown in the request modal now lists profiles in a deterministic, locale-aware alphabetical order.
  * Quality profile menus in Radarr settings now present options sorted alphabetically for easier selection.
  * Sonarr quality profile lists (standard and anime) are consistently sorted alphabetically for improved navigation and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->