### PR TITLE
fix(blacklist): handle invalid keywords gracefully

### DIFF
--- a/jellyseerr-api.yml
+++ b/jellyseerr-api.yml
@@ -7273,6 +7273,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Keyword'
+        '404':
+          description: Keyword not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'Keyword not found'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'Unable to retrieve keyword data.'
   /watchproviders/regions:
     get:
       summary: Get watch provider regions

--- a/jellyseerr-api.yml
+++ b/jellyseerr-api.yml
@@ -7268,21 +7268,12 @@ paths:
             example: 1
       responses:
         '200':
-          description: Keyword returned
+          description: Keyword returned (null if not found)
           content:
             application/json:
               schema:
+                nullable: true
                 $ref: '#/components/schemas/Keyword'
-        '404':
-          description: Keyword not found
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    example: 'Keyword not found'
         '500':
           description: Internal server error
           content:

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -1054,7 +1054,7 @@ class TheMovieDb extends ExternalAPI {
     keywordId,
   }: {
     keywordId: number;
-  }): Promise<TmdbKeyword> {
+  }): Promise<TmdbKeyword | null> {
     try {
       const data = await this.get<TmdbKeyword>(
         `/keyword/${keywordId}`,
@@ -1065,7 +1065,7 @@ class TheMovieDb extends ExternalAPI {
       return data;
     } catch (e) {
       if (e.response?.status === 404) {
-        throw e;
+        return null;
       }
       throw new Error(`[TMDB] Failed to fetch keyword: ${e.message}`);
     }

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -1064,6 +1064,9 @@ class TheMovieDb extends ExternalAPI {
 
       return data;
     } catch (e) {
+      if (e.response?.status === 404) {
+        throw e;
+      }
       throw new Error(`[TMDB] Failed to fetch keyword: ${e.message}`);
     }
   }

--- a/server/job/blacklistedTagsProcessor.ts
+++ b/server/job/blacklistedTagsProcessor.ts
@@ -72,6 +72,7 @@ class BlacklistedTagProcessor implements RunnableScanner<StatusBase> {
     const blacklistedTagsArr = blacklistedTags.split(',');
 
     const pageLimit = settings.main.blacklistedTagsLimit;
+    const invalidKeywords = new Set<string>();
 
     if (blacklistedTags.length === 0) {
       return;
@@ -87,6 +88,17 @@ class BlacklistedTagProcessor implements RunnableScanner<StatusBase> {
 
       // Iterate for each tag
       for (const tag of blacklistedTagsArr) {
+        try {
+          await tmdb.getKeywordDetails({ keywordId: Number(tag) });
+        } catch (error) {
+          logger.warn('Skipping invalid keyword in blacklisted tags', {
+            label: 'Blacklisted Tags Processor',
+            keywordId: tag,
+          });
+          invalidKeywords.add(tag);
+          continue;
+        }
+
         let queryMax = pageLimit * SortOptionsIterable.length;
         let fixedSortMode = false; // Set to true when the page limit allows for getting every page of tag
 
@@ -102,22 +114,49 @@ class BlacklistedTagProcessor implements RunnableScanner<StatusBase> {
             throw new AbortTransaction();
           }
 
-          const response = await getDiscover({
-            page,
-            sortBy,
-            keywords: tag,
-          });
-          await this.processResults(response, tag, type, em);
-          await new Promise((res) => setTimeout(res, TMDB_API_DELAY_MS));
+          try {
+            const response = await getDiscover({
+              page,
+              sortBy,
+              keywords: tag,
+            });
 
-          this.progress++;
-          if (page === 1 && response.total_pages <= queryMax) {
-            // We will finish the tag with less queries than expected, move progress accordingly
-            this.progress += queryMax - response.total_pages;
-            fixedSortMode = true;
-            queryMax = response.total_pages;
+            await this.processResults(response, tag, type, em);
+            await new Promise((res) => setTimeout(res, TMDB_API_DELAY_MS));
+
+            this.progress++;
+            if (page === 1 && response.total_pages <= queryMax) {
+              // We will finish the tag with less queries than expected, move progress accordingly
+              this.progress += queryMax - response.total_pages;
+              fixedSortMode = true;
+              queryMax = response.total_pages;
+            }
+          } catch (error) {
+            logger.error('Error processing keyword in blacklisted tags', {
+              label: 'Blacklisted Tags Processor',
+              keywordId: tag,
+              errorMessage: error.message,
+            });
           }
         }
+      }
+    }
+
+    if (invalidKeywords.size > 0) {
+      const currentTags = blacklistedTagsArr.filter(
+        (tag) => !invalidKeywords.has(tag)
+      );
+      const cleanedTags = currentTags.join(',');
+
+      if (cleanedTags !== blacklistedTags) {
+        settings.main.blacklistedTags = cleanedTags;
+        await settings.save();
+
+        logger.info('Cleaned up invalid keywords from settings', {
+          label: 'Blacklisted Tags Processor',
+          removedKeywords: Array.from(invalidKeywords),
+          newBlacklistedTags: cleanedTags,
+        });
       }
     }
   }

--- a/server/job/blacklistedTagsProcessor.ts
+++ b/server/job/blacklistedTagsProcessor.ts
@@ -88,24 +88,17 @@ class BlacklistedTagProcessor implements RunnableScanner<StatusBase> {
 
       // Iterate for each tag
       for (const tag of blacklistedTagsArr) {
-        try {
-          await tmdb.getKeywordDetails({ keywordId: Number(tag) });
-        } catch (error) {
-          if (error.response?.status === 404) {
-            logger.warn('Skipping invalid keyword in blacklisted tags', {
-              label: 'Blacklisted Tags Processor',
-              keywordId: tag,
-            });
-            invalidKeywords.add(tag);
-            continue;
-          } else {
-            // Might be temporary service issues so do nothing
-            logger.error('Error checking keyword validity', {
-              label: 'Blacklisted Tags Processor',
-              keywordId: tag,
-              errorMessage: error.message,
-            });
-          }
+        const keywordDetails = await tmdb.getKeywordDetails({
+          keywordId: Number(tag),
+        });
+
+        if (keywordDetails === null) {
+          logger.warn('Skipping invalid keyword in blacklisted tags', {
+            label: 'Blacklisted Tags Processor',
+            keywordId: tag,
+          });
+          invalidKeywords.add(tag);
+          continue;
         }
 
         let queryMax = pageLimit * SortOptionsIterable.length;

--- a/server/job/blacklistedTagsProcessor.ts
+++ b/server/job/blacklistedTagsProcessor.ts
@@ -91,12 +91,21 @@ class BlacklistedTagProcessor implements RunnableScanner<StatusBase> {
         try {
           await tmdb.getKeywordDetails({ keywordId: Number(tag) });
         } catch (error) {
-          logger.warn('Skipping invalid keyword in blacklisted tags', {
-            label: 'Blacklisted Tags Processor',
-            keywordId: tag,
-          });
-          invalidKeywords.add(tag);
-          continue;
+          if (error.response?.status === 404) {
+            logger.warn('Skipping invalid keyword in blacklisted tags', {
+              label: 'Blacklisted Tags Processor',
+              keywordId: tag,
+            });
+            invalidKeywords.add(tag);
+            continue;
+          } else {
+            // Might be temporary service issues so do nothing
+            logger.error('Error checking keyword validity', {
+              label: 'Blacklisted Tags Processor',
+              keywordId: tag,
+              errorMessage: error.message,
+            });
+          }
         }
 
         let queryMax = pageLimit * SortOptionsIterable.length;

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -128,10 +128,14 @@ discoverRoutes.get('/movies', async (req, res, next) => {
     if (keywords) {
       const splitKeywords = keywords.split(',');
 
-      keywordData = await Promise.all(
+      const keywordResults = await Promise.all(
         splitKeywords.map(async (keywordId) => {
           return await tmdb.getKeywordDetails({ keywordId: Number(keywordId) });
         })
+      );
+
+      keywordData = keywordResults.filter(
+        (keyword): keyword is TmdbKeyword => keyword !== null
       );
     }
 
@@ -415,10 +419,14 @@ discoverRoutes.get('/tv', async (req, res, next) => {
     if (keywords) {
       const splitKeywords = keywords.split(',');
 
-      keywordData = await Promise.all(
+      const keywordResults = await Promise.all(
         splitKeywords.map(async (keywordId) => {
           return await tmdb.getKeywordDetails({ keywordId: Number(keywordId) });
         })
+      );
+
+      keywordData = keywordResults.filter(
+        (keyword): keyword is TmdbKeyword => keyword !== null
       );
     }
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -330,6 +330,10 @@ router.get('/keyword/:keywordId', async (req, res, next) => {
 
     return res.status(200).json(result);
   } catch (e) {
+    if (e.response?.status === 404) {
+      return res.status(404).json({ message: 'Keyword not found' });
+    }
+
     logger.debug('Something went wrong retrieving keyword data', {
       label: 'API',
       errorMessage: e.message,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -330,10 +330,6 @@ router.get('/keyword/:keywordId', async (req, res, next) => {
 
     return res.status(200).json(result);
   } catch (e) {
-    if (e.response?.status === 404) {
-      return res.status(404).json({ message: 'Keyword not found' });
-    }
-
     logger.debug('Something went wrong retrieving keyword data', {
       label: 'API',
       errorMessage: e.message,

--- a/src/components/BlacklistedTagsBadge/index.tsx
+++ b/src/components/BlacklistedTagsBadge/index.tsx
@@ -29,21 +29,13 @@ const BlacklistedTagsBadge = ({ data }: BlacklistedTagsBadgeProps) => {
     const keywordIds = data.blacklistedTags.slice(1, -1).split(',');
     Promise.all(
       keywordIds.map(async (keywordId) => {
-        try {
-          const { data } = await axios.get<Keyword>(
-            `/api/v1/keyword/${keywordId}`
-          );
-          return data.name;
-        } catch (err) {
-          if (err.response?.status === 404) {
-            return `[Invalid: ${keywordId}]`;
-          }
-          return '';
-        }
+        const { data } = await axios.get<Keyword | null>(
+          `/api/v1/keyword/${keywordId}`
+        );
+        return data?.name || `[Invalid: ${keywordId}]`;
       })
     ).then((keywords) => {
-      const validKeywords = keywords.filter((name) => name !== '');
-      setTagNamesBlacklistedFor(validKeywords.join(', '));
+      setTagNamesBlacklistedFor(keywords.join(', '));
     });
   }, [data.blacklistedTags]);
 

--- a/src/components/BlacklistedTagsBadge/index.tsx
+++ b/src/components/BlacklistedTagsBadge/index.tsx
@@ -35,11 +35,15 @@ const BlacklistedTagsBadge = ({ data }: BlacklistedTagsBadgeProps) => {
           );
           return data.name;
         } catch (err) {
+          if (err.response?.status === 404) {
+            return `[Invalid: ${keywordId}]`;
+          }
           return '';
         }
       })
     ).then((keywords) => {
-      setTagNamesBlacklistedFor(keywords.join(', '));
+      const validKeywords = keywords.filter((name) => name !== '');
+      setTagNamesBlacklistedFor(validKeywords.join(', '));
     });
   }, [data.blacklistedTags]);
 

--- a/src/components/BlacklistedTagsSelector/index.tsx
+++ b/src/components/BlacklistedTagsSelector/index.tsx
@@ -5,7 +5,10 @@ import { encodeURIExtraParams } from '@app/hooks/useDiscover';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import { ArrowDownIcon } from '@heroicons/react/24/solid';
-import type { TmdbKeywordSearchResponse } from '@server/api/themoviedb/interfaces';
+import type {
+  TmdbKeyword,
+  TmdbKeywordSearchResponse,
+} from '@server/api/themoviedb/interfaces';
 import type { Keyword } from '@server/models/common';
 import axios from 'axios';
 import { useFormikContext } from 'formik';
@@ -135,12 +138,14 @@ const ControlledKeywordSelector = ({
         })
       );
 
-      const validKeywords = keywords.filter((keyword) => keyword !== null);
+      const validKeywords: TmdbKeyword[] = keywords.filter(
+        (keyword) => keyword !== null
+      );
 
       onChange(
         validKeywords.map((keyword) => ({
-          label: keyword!.name,
-          value: keyword!.id,
+          label: keyword.name,
+          value: keyword.id,
         }))
       );
     };

--- a/src/components/BlacklistedTagsSelector/index.tsx
+++ b/src/components/BlacklistedTagsSelector/index.tsx
@@ -131,7 +131,7 @@ const ControlledKeywordSelector = ({
         })
       );
 
-      const validKeywords = keywords.filter(
+      const validKeywords: TmdbKeyword[] = keywords.filter(
         (keyword): keyword is Keyword => keyword !== null
       );
 

--- a/src/components/BlacklistedTagsSelector/index.tsx
+++ b/src/components/BlacklistedTagsSelector/index.tsx
@@ -5,10 +5,7 @@ import { encodeURIExtraParams } from '@app/hooks/useDiscover';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import { ArrowDownIcon } from '@heroicons/react/24/solid';
-import type {
-  TmdbKeyword,
-  TmdbKeywordSearchResponse,
-} from '@server/api/themoviedb/interfaces';
+import type { TmdbKeywordSearchResponse } from '@server/api/themoviedb/interfaces';
 import type { Keyword } from '@server/models/common';
 import axios from 'axios';
 import { useFormikContext } from 'formik';
@@ -127,19 +124,15 @@ const ControlledKeywordSelector = ({
 
       const keywords = await Promise.all(
         defaultValue.split(',').map(async (keywordId) => {
-          try {
-            const { data } = await axios.get<Keyword>(
-              `/api/v1/keyword/${keywordId}`
-            );
-            return data;
-          } catch (error) {
-            return null;
-          }
+          const { data } = await axios.get<Keyword | null>(
+            `/api/v1/keyword/${keywordId}`
+          );
+          return data;
         })
       );
 
-      const validKeywords: TmdbKeyword[] = keywords.filter(
-        (keyword) => keyword !== null
+      const validKeywords = keywords.filter(
+        (keyword): keyword is Keyword => keyword !== null
       );
 
       onChange(

--- a/src/components/BlacklistedTagsSelector/index.tsx
+++ b/src/components/BlacklistedTagsSelector/index.tsx
@@ -5,7 +5,10 @@ import { encodeURIExtraParams } from '@app/hooks/useDiscover';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import { ArrowDownIcon } from '@heroicons/react/24/solid';
-import type { TmdbKeywordSearchResponse } from '@server/api/themoviedb/interfaces';
+import type {
+  TmdbKeyword,
+  TmdbKeywordSearchResponse,
+} from '@server/api/themoviedb/interfaces';
 import type { Keyword } from '@server/models/common';
 import axios from 'axios';
 import { useFormikContext } from 'formik';
@@ -132,7 +135,7 @@ const ControlledKeywordSelector = ({
       );
 
       const validKeywords: TmdbKeyword[] = keywords.filter(
-        (keyword): keyword is Keyword => keyword !== null
+        (keyword): keyword is TmdbKeyword => keyword !== null
       );
 
       onChange(

--- a/src/components/BlacklistedTagsSelector/index.tsx
+++ b/src/components/BlacklistedTagsSelector/index.tsx
@@ -124,17 +124,23 @@ const ControlledKeywordSelector = ({
 
       const keywords = await Promise.all(
         defaultValue.split(',').map(async (keywordId) => {
-          const { data } = await axios.get<Keyword>(
-            `/api/v1/keyword/${keywordId}`
-          );
-          return data;
+          try {
+            const { data } = await axios.get<Keyword>(
+              `/api/v1/keyword/${keywordId}`
+            );
+            return data;
+          } catch (error) {
+            return null;
+          }
         })
       );
 
+      const validKeywords = keywords.filter((keyword) => keyword !== null);
+
       onChange(
-        keywords.map((keyword) => ({
-          label: keyword.name,
-          value: keyword.id,
+        validKeywords.map((keyword) => ({
+          label: keyword!.name,
+          value: keyword!.id,
         }))
       );
     };

--- a/src/components/Discover/CreateSlider/index.tsx
+++ b/src/components/Discover/CreateSlider/index.tsx
@@ -84,7 +84,7 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
           })
         );
 
-        const validKeywords = keywords.filter(
+        const validKeywords: Keyword[] = keywords.filter(
           (keyword): keyword is Keyword => keyword !== null
         );
 

--- a/src/components/Discover/CreateSlider/index.tsx
+++ b/src/components/Discover/CreateSlider/index.tsx
@@ -77,16 +77,19 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
 
         const keywords = await Promise.all(
           slider.data.split(',').map(async (keywordId) => {
-            const keyword = await axios.get<Keyword>(
+            const keyword = await axios.get<Keyword | null>(
               `/api/v1/keyword/${keywordId}`
             );
-
             return keyword.data;
           })
         );
 
+        const validKeywords = keywords.filter(
+          (keyword): keyword is Keyword => keyword !== null
+        );
+
         setDefaultDataValue(
-          keywords.map((keyword) => ({
+          validKeywords.map((keyword) => ({
             label: keyword.name,
             value: keyword.id,
           }))

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -316,7 +316,7 @@ export const KeywordSelector = ({
         })
       );
 
-      const validKeywords: TmdbKeyword[] = keywords.filter(
+      const validKeywords: Keyword[] = keywords.filter(
         (keyword): keyword is Keyword => keyword !== null
       );
 

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -309,16 +309,19 @@ export const KeywordSelector = ({
 
       const keywords = await Promise.all(
         defaultValue.split(',').map(async (keywordId) => {
-          const keyword = await axios.get<Keyword>(
+          const keyword = await axios.get<Keyword | null>(
             `/api/v1/keyword/${keywordId}`
           );
-
           return keyword.data;
         })
       );
 
+      const validKeywords = keywords.filter(
+        (keyword): keyword is Keyword => keyword !== null
+      );
+
       setDefaultDataValue(
-        keywords.map((keyword) => ({
+        validKeywords.map((keyword) => ({
           label: keyword.name,
           value: keyword.id,
         }))

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -316,7 +316,7 @@ export const KeywordSelector = ({
         })
       );
 
-      const validKeywords = keywords.filter(
+      const validKeywords: TmdbKeyword[] = keywords.filter(
         (keyword): keyword is Keyword => keyword !== null
       );
 

--- a/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
+++ b/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
@@ -119,7 +119,7 @@ const OverrideRuleTiles = ({
             return response.data;
           })
       );
-      const validKeywords = keywords.filter(
+      const validKeywords: Keyword[] = keywords.filter(
         (keyword): keyword is Keyword => keyword !== null
       );
       setKeywords(validKeywords);

--- a/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
+++ b/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
@@ -113,12 +113,16 @@ const OverrideRuleTiles = ({
           .flat()
           .filter((keywordId) => keywordId)
           .map(async (keywordId) => {
-            const response = await axios.get(`/api/v1/keyword/${keywordId}`);
-            const keyword: Keyword = response.data;
-            return keyword;
+            const response = await axios.get<Keyword | null>(
+              `/api/v1/keyword/${keywordId}`
+            );
+            return response.data;
           })
       );
-      setKeywords(keywords);
+      const validKeywords = keywords.filter(
+        (keyword): keyword is Keyword => keyword !== null
+      );
+      setKeywords(validKeywords);
       const allUsersFromRules = rules
         .map((rule) => rule.users)
         .filter((users) => users)


### PR DESCRIPTION
#### Description

This PR fixes an issue where tag-based blacklisting would break if a previously valid TMDB keyword became invalid, causing the settings page to crash and jobs to fail with 404 errors.

API routes now return proper 404 statuses for invalid keywords. Keyword validity is checked before processing, and invalid keywords are automatically removed from settings.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1814
