### PR TITLE
fix(api): add missing user settings' api docs

### DIFF
--- a/jellyseerr-api.yml
+++ b/jellyseerr-api.yml
@@ -141,14 +141,82 @@ components:
     UserSettings:
       type: object
       properties:
+        username:
+          type: string
+          example: 'Mr User'
+        email:
+          type: string
+          example: 'user@example.com'
+        discordId:
+          type: string
+          nullable: true
+          example: '123456789'
         locale:
           type: string
+          nullable: true
+          example: 'en'
         discoverRegion:
           type: string
-        originalLanguage:
-          type: string
+          nullable: true
+          example: 'US'
         streamingRegion:
           type: string
+          nullable: true
+          example: 'US'
+        originalLanguage:
+          type: string
+          nullable: true
+          example: 'en'
+        movieQuotaLimit:
+          type: number
+          nullable: true
+          description: 'Maximum number of movie requests allowed'
+          example: 10
+        movieQuotaDays:
+          type: number
+          nullable: true
+          description: 'Time period in days for movie quota'
+          example: 30
+        tvQuotaLimit:
+          type: number
+          nullable: true
+          description: 'Maximum number of TV requests allowed'
+          example: 5
+        tvQuotaDays:
+          type: number
+          nullable: true
+          description: 'Time period in days for TV quota'
+          example: 14
+        globalMovieQuotaDays:
+          type: number
+          nullable: true
+          description: 'Global movie quota days setting'
+          example: 30
+        globalMovieQuotaLimit:
+          type: number
+          nullable: true
+          description: 'Global movie quota limit setting'
+          example: 10
+        globalTvQuotaLimit:
+          type: number
+          nullable: true
+          description: 'Global TV quota limit setting'
+          example: 5
+        globalTvQuotaDays:
+          type: number
+          nullable: true
+          description: 'Global TV quota days setting'
+          example: 14
+        watchlistSyncMovies:
+          type: boolean
+          nullable: true
+          description: 'Enable watchlist sync for movies'
+          example: true
+        watchlistSyncTv:
+          type: boolean
+          nullable: true
+          description: 'Enable watchlist sync for TV'
+          example: false
     MainSettings:
       type: object
       properties:
@@ -4469,11 +4537,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  username:
-                    type: string
-                    example: 'Mr User'
+                $ref: '#/components/schemas/UserSettings'
     post:
       summary: Update general settings for a user
       description: Updates and returns general settings for a specific user. Requires `MANAGE_USERS` permission if editing other users.
@@ -4490,22 +4554,14 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                username:
-                  type: string
-                  nullable: true
+              $ref: '#/components/schemas/UserSettings'
       responses:
         '200':
           description: Updated user general settings returned
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  username:
-                    type: string
-                    example: 'Mr User'
+                $ref: '#/components/schemas/UserSettings'
   /user/{userId}/settings/password:
     get:
       summary: Get password page informatiom


### PR DESCRIPTION
#### Description
This PR adds new fields to the UserSettings schema, including username, email, discordId, and various quota limits for movies and TV shows.

It also updates API paths to reference the new UserSettings schema.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
