### PR TITLE
feat(api): add completed count to request count API

### DIFF
--- a/jellyseerr-api.yml
+++ b/jellyseerr-api.yml
@@ -5943,7 +5943,7 @@ paths:
     get:
       summary: Gets request counts
       description: |
-        Returns the number of pending and approved requests.
+        Returns the number of requests by status including pending, approved, available, and completed requests.
       tags:
         - request
       responses:
@@ -5969,6 +5969,8 @@ paths:
                   processing:
                     type: number
                   available:
+                    type: number
+                  completed:
                     type: number
   /request/{requestId}:
     get:

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -381,6 +381,12 @@ requestRoutes.get('/count', async (_req, res, next) => {
       )
       .getCount();
 
+    const completedCount = await query
+      .where('request.status = :requestStatus', {
+        requestStatus: MediaRequestStatus.COMPLETED,
+      })
+      .getCount();
+
     return res.status(200).json({
       total: totalCount,
       movie: movieCount,
@@ -390,6 +396,7 @@ requestRoutes.get('/count', async (_req, res, next) => {
       declined: declinedCount,
       processing: processingCount,
       available: availableCount,
+      completed: completedCount,
     });
   } catch (e) {
     logger.error('Something went wrong retrieving request counts', {


### PR DESCRIPTION
#### Description
This PR updates the `/api/v1/request/count` endpoint by adding a new completed field, which shows how many requests have been fully fulfilled.

Previously, the endpoint only returned `available: 0`, even though the media had already become available. That’s because requests are automatically marked as `COMPLETED` once the media is available, skipping the `AVAILABLE` state. This caused a mismatch - while the web UI correctly showed fulfilled requests, the API didn’t reflect that.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1817
#1735 
