### PR TITLE
fix(api): make username field nullable in UserSettings API schema

### DIFF
--- a/jellyseerr-api.yml
+++ b/jellyseerr-api.yml
@@ -143,6 +143,7 @@ components:
       properties:
         username:
           type: string
+          nullable: true
           example: 'Mr User'
         email:
           type: string


### PR DESCRIPTION
#### Description
Fixes validation error when sending null username values.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1834
