### PR TITLE
fix: remove console warning

### DIFF
--- a/src/components/Common/SettingsTabs/index.tsx
+++ b/src/components/Common/SettingsTabs/index.tsx
@@ -84,6 +84,7 @@ const SettingsTabs = ({
           Select a Tab
         </label>
         <select
+          id="tabs"
           onChange={(e) => {
             router.push(e.target.value);
           }}

--- a/src/components/PWAHeader/index.tsx
+++ b/src/components/PWAHeader/index.tsx
@@ -152,7 +152,6 @@ const PWAHeader = ({ applicationTitle = 'Jellyseerr' }: PWAHeaderProps) => {
         href="/apple-splash-1136-640.jpg"
         media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"
       />
-      <meta name="apple-mobile-web-app-capable" content="yes" />
       <meta
         name="apple-mobile-web-app-status-bar-style"
         content="black-translucent"


### PR DESCRIPTION
#### Description
Removed the deprecated `<meta name="apple-mobile-web-app-capable" content="yes" />` tag from the PWAHeader component, as recommended by updated browser standards. Kept the modern `<meta name="mobile-web-app-capable" content="yes" />` tag to ensure proper PWA support and resolve browser console warnings. No functional changes to the component.

Added id="tabs" attribute to the `<select>` element so that the associated `<label htmlFor="tabs">` correctly links to it.
This resolves the accessibility error:
“Incorrect use of `<label for=FORM_ELEMENT>` — label’s for attribute doesn't match any element id”.

Without this fix, assistive technologies and browser autofill might not work properly.

#### Screenshot (if UI-related)
<img width="945" height="117" alt="H2ssgq6DJ7" src="https://github.com/user-attachments/assets/ac1b5501-aefd-4555-990c-22149e43bf6c" />
<img width="944" height="345" alt="chrome_Bvux7N5Oe8" src="https://github.com/user-attachments/assets/7c8da684-b464-4d44-b6fe-88219c33524e" />

#### To-Dos

- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
