### PR TITLE
fix(UserProfile): handle optional chaining for recentlyWatched data

### DIFF
--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -378,7 +378,7 @@ const UserProfile = () => {
       {user.userType === UserType.PLEX &&
         (user.id === currentUser?.id ||
           currentHasPermission(Permission.ADMIN)) &&
-        (!watchData || !!watchData.recentlyWatched.length) &&
+        (!watchData || !!watchData.recentlyWatched?.length) &&
         !watchDataError && (
           <>
             <div className="slider-header">
@@ -389,7 +389,7 @@ const UserProfile = () => {
             <Slider
               sliderKey="media"
               isLoading={!watchData}
-              items={watchData?.recentlyWatched.map((item) => (
+              items={watchData?.recentlyWatched?.map((item) => (
                 <TmdbTitleCard
                   key={`media-slider-item-${item.id}`}
                   id={item.id}


### PR DESCRIPTION
#### Description
This PR fixes a client-side `TypeError` in the "Recently Watched" section of user profiles. The issue occurred when `recentlyWatched` was `undefined`. The fix adds optional chaining to prevent the app from crashing.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1849
