### PR TITLE
fix(prettier): include sw.js file in .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,7 +9,11 @@ cypress/config/settings.cypress.json
 # assets
 src/assets/
 public/
+!public/sw.js
 docs/
+!/public/
+/public/*
+!/public/sw.js
 
 # helm charts
 **/charts


### PR DESCRIPTION
#### Description

Fixes an error with Prettier ignoring the `sw.js` file in the public folder.

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
