### PR TITLE
fix(settings): correct port saving of proxy settings

### DIFF
--- a/src/components/Settings/SettingsNetwork/index.tsx
+++ b/src/components/Settings/SettingsNetwork/index.tsx
@@ -126,7 +126,7 @@ const SettingsNetwork = () => {
                 proxy: {
                   enabled: values.proxyEnabled,
                   hostname: values.proxyHostname,
-                  port: values.proxyPort,
+                  port: Number(values.proxyPort),
                   useSsl: values.proxySsl,
                   user: values.proxyUser,
                   password: values.proxyPassword,


### PR DESCRIPTION
#### Description

The port of the proxy settings was saved as a string instead of a number, causing the API to throw an error and making it impossible to save the network settings.

#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)