### PR TITLE
fix(tvdb): display of special episodes (season 0) for TVDB

### DIFF
--- a/server/api/tvdb/index.ts
+++ b/server/api/tvdb/index.ts
@@ -203,10 +203,6 @@ class Tvdb extends ExternalAPI implements TvShowProvider {
     seasonNumber: number;
     language?: string;
   }): Promise<TmdbSeasonWithEpisodes> {
-    if (seasonNumber === 0) {
-      return this.createEmptySeasonResponse(tvId);
-    }
-
     try {
       const tmdbTvShow = await this.tmdb.getTvShow({ tvId, language });
 
@@ -275,12 +271,12 @@ class Tvdb extends ExternalAPI implements TvShowProvider {
     }
 
     const seasons = tvdbData.seasons
-      .filter(
-        (season) =>
-          season.number > 0 && season.type && season.type.type === 'official'
-      )
+      .filter((season) => season.type && season.type.type === 'official')
       .sort((a, b) => a.number - b.number)
-      .map((season) => this.createSeasonData(season, tvdbData));
+      .map((season) => this.createSeasonData(season, tvdbData))
+      .filter(
+        (season) => season && season.season_number >= 0
+      ) as TmdbTvSeasonResult[];
 
     return seasons;
   }
@@ -289,13 +285,14 @@ class Tvdb extends ExternalAPI implements TvShowProvider {
     season: TvdbSeasonDetails,
     tvdbData: TvdbTvDetails
   ): TmdbTvSeasonResult {
-    if (!season.number) {
+    const seasonNumber = season.number ?? -1;
+    if (seasonNumber < 0) {
       return {
         id: 0,
         episode_count: 0,
         name: '',
         overview: '',
-        season_number: 0,
+        season_number: -1,
         poster_path: '',
         air_date: '',
       };


### PR DESCRIPTION
#### Description

The previous validation condition incorrectly excluded seasons with number 0, preventing the display of special episodes which are typically classified as "season 0" in TVDB.

#### Screenshot (if UI-related)

<img width="2514" height="1238" alt="image" src="https://github.com/user-attachments/assets/50aecbe7-c8df-4c7f-a9b8-ef7bb2397c69" />

<img width="2516" height="1241" alt="image" src="https://github.com/user-attachments/assets/b6f65091-6125-4aa4-ba3a-b648d9867ca1" />


#### To-Dos

- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
