### PR TITLE
chore(helm): switch from Deployment to StatefulSet

### DIFF
--- a/charts/jellyseerr-chart/Chart.yaml
+++ b/charts/jellyseerr-chart/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.23.0-0"
 name: jellyseerr-chart
 description: Jellyseerr helm chart for Kubernetes
 type: application
-version: 2.6.2
+version: 2.7.0
 appVersion: "2.7.3"
 maintainers:
   - name: Jellyseerr

--- a/charts/jellyseerr-chart/README.md
+++ b/charts/jellyseerr-chart/README.md
@@ -1,6 +1,6 @@
 # jellyseerr-chart
 
-![Version: 2.6.2](https://img.shields.io/badge/Version-2.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
+![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
 
 Jellyseerr helm chart for Kubernetes
 
@@ -19,6 +19,17 @@ Jellyseerr helm chart for Kubernetes
 ## Requirements
 
 Kubernetes: `>=1.23.0-0`
+
+## Update Notes
+
+### Updating to 2.7.0
+
+Jellyseerr is a stateful application and it is not designed to have multiple replicas. In version 2.7.0 we address this by:
+
+- replacing `Deployment` with `StatefulSet`
+- removing `replicaCount` value
+
+If `replicaCount` value was used - remove it. Helm update should work fine after that.
 
 ## Values
 
@@ -55,7 +66,6 @@ Kubernetes: `>=1.23.0-0`
 | probes.livenessProbe | object | `{}` | Configure liveness probe |
 | probes.readinessProbe | object | `{}` | Configure readiness probe |
 | probes.startupProbe | string | `nil` | Configure startup probe |
-| replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | service.port | int | `80` |  |
@@ -64,7 +74,6 @@ Kubernetes: `>=1.23.0-0`
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |
-| strategy | object | `{"type":"Recreate"}` | Deployment strategy |
 | tolerations | list | `[]` |  |
-| volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
-| volumes | list | `[]` | Additional volumes on the output Deployment definition. |
+| volumeMounts | list | `[]` | Additional volumeMounts on the output StatefulSet definition. |
+| volumes | list | `[]` | Additional volumes on the output StatefulSet definition. |

--- a/charts/jellyseerr-chart/README.md.gotmpl
+++ b/charts/jellyseerr-chart/README.md.gotmpl
@@ -14,4 +14,15 @@
 
 {{ template "chart.requirementsSection" . }}
 
+## Update Notes
+
+### Updating to 2.7.0
+
+Jellyseerr is a stateful application and it is not designed to have multiple replicas. In version 2.7.0 we address this by:
+
+- replacing `Deployment` with `StatefulSet`
+- removing `replicaCount` value
+
+If `replicaCount` value was used - remove it. Helm update should work fine after that.
+
 {{ template "chart.valuesSection" . }}

--- a/charts/jellyseerr-chart/templates/statefulset.yaml
+++ b/charts/jellyseerr-chart/templates/statefulset.yaml
@@ -1,13 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "jellyseerr.fullname" . }}
   labels:
     {{- include "jellyseerr.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
-  strategy:
-    type: {{ .Values.strategy.type }}
+  serviceName: {{ include "jellyseerr.fullname" . }}
   selector:
     matchLabels:
       {{- include "jellyseerr.selectorLabels" . | nindent 6 }}

--- a/charts/jellyseerr-chart/values.yaml
+++ b/charts/jellyseerr-chart/values.yaml
@@ -1,5 +1,3 @@
-replicaCount: 1
-
 image:
   registry: ghcr.io
   repository: fallenbagel/jellyseerr
@@ -11,10 +9,6 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-
-# -- Deployment strategy
-strategy:
-  type: Recreate
 
 # Liveness / Readiness / Startup Probes
 probes:
@@ -115,14 +109,14 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
-# -- Additional volumes on the output Deployment definition.
+# -- Additional volumes on the output StatefulSet definition.
 volumes: []
 # - name: foo
 #   secret:
 #     secretName: mysecret
 #     optional: false
 
-# -- Additional volumeMounts on the output Deployment definition.
+# -- Additional volumeMounts on the output StatefulSet definition.
 volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"


### PR DESCRIPTION
#### Description

Jellyseerr is not designed to support multiple cuncurrently running instances. To ensure that only one instance can run at any given time we:

- Replace `Deployment` with `StatefulSet`: switch from running "at least N pods" to "at most N pods".
- Remove `replicaCount` value: default is `1`, we do not want to support more.

#### Testing

Chart with the proposed changes is available here:
```
oci://ghcr.io/sbogomolov/jellyseerr/jellyseerr-chart
```

I have tested the new chart in my cluster, successfully upgrading from `2.6.2` to this version.

#### Issues Fixed or Closed

- Resolves https://github.com/fallenbagel/jellyseerr/discussions/1899.