### PR TITLE
fix(api): catch error when watchlist item doesn't exist anymore

### DIFF
--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -312,12 +312,25 @@ class PlexTvAPI extends ExternalAPI {
       const watchlistDetails = await Promise.all(
         (cachedWatchlist?.response.MediaContainer.Metadata ?? []).map(
           async (watchlistItem) => {
-            const detailedResponse = await this.getRolling<MetadataResponse>(
-              `/library/metadata/${watchlistItem.ratingKey}`,
-              {
-                baseURL: 'https://discover.provider.plex.tv',
+            let detailedResponse: MetadataResponse;
+            try {
+              detailedResponse = await this.getRolling<MetadataResponse>(
+                `/library/metadata/${watchlistItem.ratingKey}`,
+                {
+                  baseURL: 'https://discover.provider.plex.tv',
+                }
+              );
+            } catch (e) {
+              if (e.response?.status === 404) {
+                logger.warn(
+                  `Item with ratingKey ${watchlistItem.ratingKey} not found, it may have been removed from the server.`,
+                  { label: 'Plex.TV Metadata API' }
+                );
+                return null;
+              } else {
+                throw e;
               }
-            );
+            }
 
             const metadata = detailedResponse.MediaContainer.Metadata[0];
 
@@ -343,7 +356,9 @@ class PlexTvAPI extends ExternalAPI {
         )
       );
 
-      const filteredList = watchlistDetails.filter((detail) => detail.tmdbId);
+      const filteredList = watchlistDetails.filter(
+        (detail) => detail?.tmdbId
+      ) as PlexWatchlistItem[];
 
       return {
         offset,


### PR DESCRIPTION
#### Description

This PR handles errors that may be returned by the Plex API when retrieving a watchlist item that no longer exists.

Preview tag: `preview-debug-plex-watchlist`

#### To-Dos

- [x] Successful build `pnpm build`
- ~~[ ] Translation keys `pnpm i18n:extract`~~
- ~~[ ] Database migration (if required)~~

#### Issues Fixed or Closed

- Fixes #1893