### PR TITLE
feat(api): add excludeKeywords parameter to discovery queries

### DIFF
--- a/jellyseerr-api.yml
+++ b/jellyseerr-api.yml
@@ -5199,6 +5199,12 @@ paths:
             type: string
             example: 1,2
         - in: query
+          name: excludeKeywords
+          schema:
+            type: string
+            example: 3,4
+          description: Comma-separated list of keyword IDs to exclude from results
+        - in: query
           name: sortBy
           schema:
             type: string
@@ -5518,6 +5524,12 @@ paths:
           schema:
             type: string
             example: 1,2
+        - in: query
+          name: excludeKeywords
+          schema:
+            type: string
+            example: 3,4
+          description: Comma-separated list of keyword IDs to exclude from results
         - in: query
           name: sortBy
           schema:

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -86,6 +86,7 @@ interface DiscoverMovieOptions {
   genre?: string;
   studio?: string;
   keywords?: string;
+  excludeKeywords?: string;
   sortBy?: SortOptions;
   watchRegion?: string;
   watchProviders?: string;
@@ -111,6 +112,7 @@ interface DiscoverTvOptions {
   genre?: string;
   network?: number;
   keywords?: string;
+  excludeKeywords?: string;
   sortBy?: SortOptions;
   watchRegion?: string;
   watchProviders?: string;
@@ -495,6 +497,7 @@ class TheMovieDb extends ExternalAPI implements TvShowProvider {
     genre,
     studio,
     keywords,
+    excludeKeywords,
     withRuntimeGte,
     withRuntimeLte,
     voteAverageGte,
@@ -545,6 +548,7 @@ class TheMovieDb extends ExternalAPI implements TvShowProvider {
           with_genres: genre,
           with_companies: studio,
           with_keywords: keywords,
+          without_keywords: excludeKeywords,
           'with_runtime.gte': withRuntimeGte,
           'with_runtime.lte': withRuntimeLte,
           'vote_average.gte': voteAverageGte,
@@ -577,6 +581,7 @@ class TheMovieDb extends ExternalAPI implements TvShowProvider {
     genre,
     network,
     keywords,
+    excludeKeywords,
     withRuntimeGte,
     withRuntimeLte,
     voteAverageGte,
@@ -628,6 +633,7 @@ class TheMovieDb extends ExternalAPI implements TvShowProvider {
           with_genres: genre,
           with_networks: network,
           with_keywords: keywords,
+          without_keywords: excludeKeywords,
           'with_runtime.gte': withRuntimeGte,
           'with_runtime.lte': withRuntimeLte,
           'vote_average.gte': voteAverageGte,

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -61,6 +61,7 @@ const QueryFilterOptions = z.object({
   studio: z.coerce.string().optional(),
   genre: z.coerce.string().optional(),
   keywords: z.coerce.string().optional(),
+  excludeKeywords: z.coerce.string().optional(),
   language: z.coerce.string().optional(),
   withRuntimeGte: z.coerce.string().optional(),
   withRuntimeLte: z.coerce.string().optional(),
@@ -90,6 +91,7 @@ discoverRoutes.get('/movies', async (req, res, next) => {
   try {
     const query = ApiQuerySchema.parse(req.query);
     const keywords = query.keywords;
+    const excludeKeywords = query.excludeKeywords;
 
     const data = await tmdb.getDiscoverMovies({
       page: Number(query.page),
@@ -105,6 +107,7 @@ discoverRoutes.get('/movies', async (req, res, next) => {
         ? new Date(query.primaryReleaseDateGte).toISOString().split('T')[0]
         : undefined,
       keywords,
+      excludeKeywords,
       withRuntimeGte: query.withRuntimeGte,
       withRuntimeLte: query.withRuntimeLte,
       voteAverageGte: query.voteAverageGte,
@@ -381,6 +384,7 @@ discoverRoutes.get('/tv', async (req, res, next) => {
   try {
     const query = ApiQuerySchema.parse(req.query);
     const keywords = query.keywords;
+    const excludeKeywords = query.excludeKeywords;
     const data = await tmdb.getDiscoverTv({
       page: Number(query.page),
       sortBy: query.sortBy as SortOptions,
@@ -395,6 +399,7 @@ discoverRoutes.get('/tv', async (req, res, next) => {
         : undefined,
       originalLanguage: query.language,
       keywords,
+      excludeKeywords,
       withRuntimeGte: query.withRuntimeGte,
       withRuntimeLte: query.withRuntimeLte,
       voteAverageGte: query.voteAverageGte,

--- a/src/components/Discover/FilterSlideover/index.tsx
+++ b/src/components/Discover/FilterSlideover/index.tsx
@@ -33,6 +33,7 @@ const messages = defineMessages('components.Discover.FilterSlideover', {
   studio: 'Studio',
   genres: 'Genres',
   keywords: 'Keywords',
+  excludeKeywords: 'Exclude Keywords',
   originalLanguage: 'Original Language',
   runtimeText: '{minValue}-{maxValue} minute runtime',
   ratingText: 'Ratings between {minValue} and {maxValue}',
@@ -179,6 +180,19 @@ const FilterSlideover = ({
           isMulti
           onChange={(value) => {
             updateQueryParams('keywords', value?.map((v) => v.value).join(','));
+          }}
+        />
+        <span className="text-lg font-semibold">
+          {intl.formatMessage(messages.excludeKeywords)}
+        </span>
+        <KeywordSelector
+          defaultValue={currentFilters.excludeKeywords}
+          isMulti
+          onChange={(value) => {
+            updateQueryParams(
+              'excludeKeywords',
+              value?.map((v) => v.value).join(',')
+            );
           }}
         />
         <span className="text-lg font-semibold">

--- a/src/components/Discover/constants.ts
+++ b/src/components/Discover/constants.ts
@@ -99,6 +99,7 @@ export const QueryFilterOptions = z.object({
   studio: z.string().optional(),
   genre: z.string().optional(),
   keywords: z.string().optional(),
+  excludeKeywords: z.string().optional(),
   language: z.string().optional(),
   withRuntimeGte: z.string().optional(),
   withRuntimeLte: z.string().optional(),
@@ -159,6 +160,10 @@ export const prepareFilterValues = (
 
   if (values.keywords) {
     filterValues.keywords = values.keywords;
+  }
+
+  if (values.excludeKeywords) {
+    filterValues.excludeKeywords = values.excludeKeywords;
   }
 
   if (values.language) {

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -78,6 +78,7 @@
   "components.Discover.FilterSlideover.activefilters": "{count, plural, one {# Active Filter} other {# Active Filters}}",
   "components.Discover.FilterSlideover.certification": "Content Rating",
   "components.Discover.FilterSlideover.clearfilters": "Clear Active Filters",
+  "components.Discover.FilterSlideover.excludeKeywords": "Exclude Keywords",
   "components.Discover.FilterSlideover.filters": "Filters",
   "components.Discover.FilterSlideover.firstAirDate": "First Air Date",
   "components.Discover.FilterSlideover.from": "From",


### PR DESCRIPTION
#### Description
This PR adds keyword exclusion functionality to the discover filter system.

#### Screenshot (if UI-related)

##### Without exclusion
<img width="1415" height="896" alt="image" src="https://github.com/user-attachments/assets/1d2c24cb-0d4f-4168-8edf-cf57d484f6f8" />

##### With exclusion
<img width="1418" height="898" alt="image" src="https://github.com/user-attachments/assets/9be1bc40-10d1-49d1-86eb-58ded692980e" />


#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #350 
