### PR TITLE
fix(api): remove spaces from tags in *arr

### DIFF
--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -292,9 +292,17 @@ export class MediaRequestSubscriber
         }
 
         if (radarrSettings.tagRequests) {
-          let userTag = (await radarr.getTags()).find((v) =>
+          const radarrTags = await radarr.getTags();
+          // old tags had space around the hyphen
+          let userTag = radarrTags.find((v) =>
             v.label.startsWith(entity.requestedBy.id + ' - ')
           );
+          // new tags do not have spaces around the hyphen, since spaces are not allowed anymore
+          if (!userTag) {
+            userTag = radarrTags.find((v) =>
+              v.label.startsWith(entity.requestedBy.id + '-')
+            );
+          }
           if (!userTag) {
             logger.info(`Requester has no active tag. Creating new`, {
               label: 'Media Request',
@@ -302,11 +310,11 @@ export class MediaRequestSubscriber
               mediaId: entity.media.id,
               userId: entity.requestedBy.id,
               newTag:
-                entity.requestedBy.id + ' - ' + entity.requestedBy.displayName,
+                entity.requestedBy.id + '-' + entity.requestedBy.displayName,
             });
             userTag = await radarr.createTag({
               label:
-                entity.requestedBy.id + ' - ' + entity.requestedBy.displayName,
+                entity.requestedBy.id + '-' + entity.requestedBy.displayName,
             });
           }
           if (userTag.id) {
@@ -601,9 +609,17 @@ export class MediaRequestSubscriber
         }
 
         if (sonarrSettings.tagRequests) {
-          let userTag = (await sonarr.getTags()).find((v) =>
+          const sonarrTags = await sonarr.getTags();
+          // old tags had space around the hyphen
+          let userTag = sonarrTags.find((v) =>
             v.label.startsWith(entity.requestedBy.id + ' - ')
           );
+          // new tags do not have spaces around the hyphen, since spaces are not allowed anymore
+          if (!userTag) {
+            userTag = sonarrTags.find((v) =>
+              v.label.startsWith(entity.requestedBy.id + '-')
+            );
+          }
           if (!userTag) {
             logger.info(`Requester has no active tag. Creating new`, {
               label: 'Media Request',
@@ -611,11 +627,11 @@ export class MediaRequestSubscriber
               mediaId: entity.media.id,
               userId: entity.requestedBy.id,
               newTag:
-                entity.requestedBy.id + ' - ' + entity.requestedBy.displayName,
+                entity.requestedBy.id + '-' + entity.requestedBy.displayName,
             });
             userTag = await sonarr.createTag({
               label:
-                entity.requestedBy.id + ' - ' + entity.requestedBy.displayName,
+                entity.requestedBy.id + '-' + entity.requestedBy.displayName,
             });
           }
           if (userTag.id) {


### PR DESCRIPTION
#### Description

This PR removes the spaces in the tags sent to *arr when the Tag Requests option is enabled. Spaces in tags are an unintended behavior and are not longer supported.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- ~~[ ] Translation keys `pnpm i18n:extract`~~
- ~~[ ] Database migration (if required)~~

#### Issues Fixed or Closed

- Fixes #1897
