### PR TITLE
fix(watchlist): handle undefined Guid for Plex watchlist metadata

### DIFF
--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -113,7 +113,7 @@ interface MetadataResponse {
       ratingKey: string;
       type: 'movie' | 'show';
       title: string;
-      Guid: {
+      Guid?: {
         id: `imdb://tt${number}` | `tmdb://${number}` | `tvdb://${number}`;
       }[];
     }[];
@@ -334,10 +334,10 @@ class PlexTvAPI extends ExternalAPI {
 
             const metadata = detailedResponse.MediaContainer.Metadata[0];
 
-            const tmdbString = metadata.Guid.find((guid) =>
+            const tmdbString = metadata.Guid?.find((guid) =>
               guid.id.startsWith('tmdb')
             );
-            const tvdbString = metadata.Guid.find((guid) =>
+            const tvdbString = metadata.Guid?.find((guid) =>
               guid.id.startsWith('tvdb')
             );
 


### PR DESCRIPTION
#### Description

In some special cases, the metadata does not contain a GUID and causes the watchlist synchronization to fail.

#### To-Dos

- [x] Successful build `pnpm build`
- ~~[ ] Translation keys `pnpm i18n:extract`~~
- ~~[ ] Database migration (if required)~~

#### Issues Fixed or Closed

- Fixes #1912
