### PR TITLE
fix(ui): remove duplicate download items in manage slide over

### DIFF
--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -35,10 +35,8 @@ import { useIntl } from 'react-intl';
 import useSWR from 'swr';
 
 const filterDuplicateDownloads = (
-  items: DownloadingItem[] | undefined
+  items: DownloadingItem[] = []
 ): DownloadingItem[] => {
-  if (!items || items.length === 0) return [];
-
   const seen = new Set<string>();
   return items.filter((item) => {
     if (seen.has(item.downloadId)) return false;


### PR DESCRIPTION
## Description
Prevents duplicate download items from being displayed by filtering based on title uniqueness. This improves UI clarity when the same content appears multiple times in the download status.

### Summary
- Adds `getUniqueByTitle` function to filter duplicate download items based on title
- Applies filtering to both regular and 4K download status lists
- Improves UI clarity by preventing duplicate entries in the manage slide over

### Screenshot

<details><summary>Before </summary><p>
<img width="416" height="863" alt="image" src="https://github.com/user-attachments/assets/d1b8d0ec-8e9e-4f14-b7ab-1ced7e6d4341" />
</p></details> 

<details><summary>After </summary><p>
<img width="426" height="212" alt="image" src="https://github.com/user-attachments/assets/8227c5af-1733-46f1-9434-92b48826b67c" />
</p></details> 


### Test plan
- [X] Verify that duplicate download items no longer appear in the manage slide over
- [X] Check that both regular and 4K download lists are properly deduplicated
- [X] Ensure filtering doesn't affect other functionality in the component

