### PR TITLE
removed the node pnpm cache in favour of the cache we setup

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: package.json
-          cache: 'pnpm'
 
       - name: Pnpm Setup
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
#### Description

Removed the `cache: pnpm` from the node setup step, this was used previously but now that we have a cache built into the workflow that we store and restore, this step is legacy and not required.