### PR TITLE
fix(api): add a migration script to rename *arr tags with spaces

### DIFF
--- a/server/api/servarr/base.ts
+++ b/server/api/servarr/base.ts
@@ -198,6 +198,25 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
     }
   };
 
+  public renameTag = async ({
+    id,
+    label,
+  }: {
+    id: number;
+    label: string;
+  }): Promise<Tag> => {
+    try {
+      const response = await this.axios.put<Tag>(`/tag/${id}`, {
+        id,
+        label,
+      });
+
+      return response.data;
+    } catch (e) {
+      throw new Error(`[${this.apiName}] Failed to rename tag: ${e.message}`);
+    }
+  };
+
   async refreshMonitoredDownloads(): Promise<void> {
     await this.runCommand('RefreshMonitoredDownloads', {});
   }

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -363,6 +363,7 @@ export interface AllSettings {
   jobs: Record<JobId, JobSettings>;
   network: NetworkSettings;
   metadataSettings: MetadataSettings;
+  migrations: string[];
 }
 
 const SETTINGS_PATH = process.env.CONFIG_DIRECTORY
@@ -593,6 +594,7 @@ class Settings {
           forceMaxTtl: -1,
         },
       },
+      migrations: [],
     };
     if (initialSettings) {
       this.data = merge(this.data, initialSettings);
@@ -720,6 +722,14 @@ class Settings {
 
   set network(data: NetworkSettings) {
     this.data.network = data;
+  }
+
+  get migrations(): string[] {
+    return this.data.migrations;
+  }
+
+  set migrations(data: string[]) {
+    this.data.migrations = data;
   }
 
   get clientId(): string {

--- a/server/lib/settings/migrations/0007_migrate_arr_tags.ts
+++ b/server/lib/settings/migrations/0007_migrate_arr_tags.ts
@@ -1,0 +1,91 @@
+import RadarrAPI from '@server/api/servarr/radarr';
+import SonarrAPI from '@server/api/servarr/sonarr';
+import { getRepository } from '@server/datasource';
+import { User } from '@server/entity/User';
+import type { AllSettings } from '@server/lib/settings';
+
+const migrationArrTags = async (settings: any): Promise<AllSettings> => {
+  if (
+    Array.isArray(settings.migrations) &&
+    settings.migrations.includes('0007_migrate_arr_tags')
+  ) {
+    return settings;
+  }
+
+  const userRepository = getRepository(User);
+  const users = await userRepository.find({
+    select: ['id'],
+  });
+
+  let errorOccurred = false;
+
+  for (const radarrSettings of settings.radarr || []) {
+    if (!radarrSettings.tagRequests) {
+      continue;
+    }
+    try {
+      const radarr = new RadarrAPI({
+        apiKey: radarrSettings.apiKey,
+        url: RadarrAPI.buildUrl(radarrSettings, '/api/v3'),
+      });
+      const radarrTags = await radarr.getTags();
+      for (const user of users) {
+        const userTag = radarrTags.find((v) =>
+          v.label.startsWith(user.id + ' - ')
+        );
+        if (!userTag) {
+          continue;
+        }
+        await radarr.renameTag({
+          id: userTag.id,
+          label: userTag.label.replace(`${user.id} - `, `${user.id}-`),
+        });
+      }
+    } catch {
+      console.error(
+        `Unable to rename Radarr tags to the new format. Please check your Radarr connection settings for the instance "${radarrSettings.name}".`
+      );
+      errorOccurred = true;
+    }
+  }
+
+  for (const sonarrSettings of settings.sonarr || []) {
+    if (!sonarrSettings.tagRequests) {
+      continue;
+    }
+    try {
+      const sonarr = new SonarrAPI({
+        apiKey: sonarrSettings.apiKey,
+        url: SonarrAPI.buildUrl(sonarrSettings, '/api/v3'),
+      });
+      const sonarrTags = await sonarr.getTags();
+      for (const user of users) {
+        const userTag = sonarrTags.find((v) =>
+          v.label.startsWith(user.id + ' - ')
+        );
+        if (!userTag) {
+          continue;
+        }
+        await sonarr.renameTag({
+          id: userTag.id,
+          label: userTag.label.replace(`${user.id} - `, `${user.id}-`),
+        });
+      }
+    } catch {
+      console.error(
+        `Unable to rename Sonarr tags to the new format. Please check your Sonarr connection settings for the instance "${sonarrSettings.name}".`
+      );
+      errorOccurred = true;
+    }
+  }
+
+  if (!errorOccurred) {
+    if (!Array.isArray(settings.migrations)) {
+      settings.migrations = [];
+    }
+    settings.migrations.push('0007_migrate_arr_tags');
+  }
+  return settings;
+};
+
+export default migrationArrTags;


### PR DESCRIPTION
#### Description

This PR adds a migration script that will run at the startup of the app to remove the spaces from the *arr tags of Jellyseerr.

#### To-Dos

- [x] Disclosed any use of AI (see our [policy](https://github.com/fallenbagel/jellyseerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes#1897
- Re #1913
- Re https://github.com/Radarr/Radarr/issues/11251
