### PR TITLE
 feat(webhook): add jellyfinMediaId and jellyfinUserId to webhook notification

### DIFF
--- a/docs/using-seerr/notifications/webhook.md
+++ b/docs/using-seerr/notifications/webhook.md
@@ -84,13 +84,14 @@ The `{{media}}` will be `null` if there is no relevant media object for the noti
 
 These following special variables are only included in media-related notifications, such as requests.
 
-| Variable             | Value                                                                                                          |
-| -------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `{{media_type}}`     | The media type (`movie` or `tv`)                                                                               |
-| `{{media_tmdbid}}`   | The media's TMDB ID                                                                                            |
-| `{{media_tvdbid}}`   | The media's TheTVDB ID                                                                                         |
-| `{{media_status}}`   | The media's availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`)    |
-| `{{media_status4k}}` | The media's 4K availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`) |
+| Variable                      | Value                                                                                                          |
+| ------------------------------| -------------------------------------------------------------------------------------------------------------- |
+| `{{media_type}}`              | The media type (`movie` or `tv`)                                                                               |
+| `{{media_tmdbid}}`            | The media's TMDB ID                                                                                            |
+| `{{media_tvdbid}}`            | The media's TheTVDB ID                                                                                         |
+| `{{media_status}}`            | The media's availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`)    |
+| `{{media_status4k}}`          | The media's 4K availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`) |
+| `{{media_jellyfinMediaId}}`   | The media's Jellyfin Media ID                                                                                  |
 
 #### Request
 
@@ -104,6 +105,7 @@ The following special variables are only included in request-related notificatio
 | `{{requestedBy_username}}`                | The requesting user's username                  |
 | `{{requestedBy_email}}`                   | The requesting user's email address             |
 | `{{requestedBy_avatar}}`                  | The requesting user's avatar URL                |
+| `{{requestedBy_jellyfinUserId}}`          | The requesting user's Jellyfin User ID          |
 | `{{requestedBy_settings_discordId}}`      | The requesting user's Discord ID (if set)       |
 | `{{requestedBy_settings_telegramChatId}}` | The requesting user's Telegram Chat ID (if set) |
 

--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -28,11 +28,14 @@ const KeyMap: Record<string, string | KeyMapFunction> = {
   media_tmdbid: 'media.tmdbId',
   media_tvdbid: 'media.tvdbId',
   media_type: 'media.mediaType',
+  media_jellyfinMediaId: (payload) =>
+    payload.media?.jellyfinMediaId ?? payload.media?.jellyfinMediaId4k ?? '',
   media_status: (payload) =>
     payload.media ? MediaStatus[payload.media.status] : '',
   media_status4k: (payload) =>
     payload.media ? MediaStatus[payload.media.status4k] : '',
   request_id: 'request.id',
+  requestedBy_jellyfinUserId: 'request.requestedBy.jellyfinUserId',
   requestedBy_username: 'request.requestedBy.displayName',
   requestedBy_email: 'request.requestedBy.email',
   requestedBy_avatar: 'request.requestedBy.avatar',

--- a/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
@@ -34,6 +34,7 @@ const defaultPayload = {
     media_type: '{{media_type}}',
     tmdbId: '{{media_tmdbid}}',
     tvdbId: '{{media_tvdbid}}',
+    jellyfinMediaId: '{{media_jellyfinMediaId}}',
     status: '{{media_status}}',
     status4k: '{{media_status4k}}',
   },
@@ -42,6 +43,7 @@ const defaultPayload = {
     requestedBy_email: '{{requestedBy_email}}',
     requestedBy_username: '{{requestedBy_username}}',
     requestedBy_avatar: '{{requestedBy_avatar}}',
+    requestedBy_jellyfinUserId: '{{requestedBy_jellyfinUserId}}',
     requestedBy_settings_discordId: '{{requestedBy_settings_discordId}}',
     requestedBy_settings_telegramChatId:
       '{{requestedBy_settings_telegramChatId}}',


### PR DESCRIPTION
#### Description
Add jellyfinMediaId and jellyfinUserId to webhook notification in order to enable a webhook to be configured to mark an item as favorite for the requesting user via the jellyfin API.

I consulted Gemini to understand the codebase but the solution was fully authored manually by myself.

#### To-Dos

- [X] Disclosed any use of AI (see our [policy](https://github.com/fallenbagel/jellyseerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [X] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1949
