### PR TITLE
build(docker): enable corepack so we don't need to pin pnpm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM node:22-alpine AS BUILD_IMAGE
 
-WORKDIR /app
-
 ARG SOURCE_DATE_EPOCH
 ARG TARGETPLATFORM
 ARG COMMIT_TAG
 ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 ENV COMMIT_TAG=${COMMIT_TAG}
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
 
 RUN \
   case "${TARGETPLATFORM}" in \
@@ -17,7 +19,7 @@ RUN \
   ;; \
   esac
 
-RUN npm install --global pnpm@10
+WORKDIR /app
 
 COPY package.json pnpm-lock.yaml postinstall-win.js ./
 RUN CYPRESS_INSTALL_BINARY=0 pnpm install --frozen-lockfile
@@ -33,11 +35,13 @@ RUN pnpm prune --prod --ignore-scripts && \
 
 FROM node:22-alpine
 
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
 WORKDIR /app
 
 RUN apk add --no-cache tzdata tini && rm -rf /tmp/*
-
-RUN npm install -g pnpm@10
 
 # copy from build image
 COPY --from=BUILD_IMAGE /app ./

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,9 +1,11 @@
 FROM node:22-alpine
 
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
 COPY . /app
 WORKDIR /app
-
-RUN npm install --global pnpm@10
 
 RUN pnpm install
 


### PR DESCRIPTION
#### Description

Enable corepack in dockerfile so we don't to install pnpm and pin the version inside the dockerfile (less maintenance) :)

https://pnpm.io/docker

```
STEP 7/8: RUN pnpm install
! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-10.17.1.tgz
```
