### PR TITLE
ci: add link checks to the docs

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -50,11 +50,13 @@ jobs:
                       --no-progress
                       --accept 200..204,300..304,307,308,404,429,999
                       --include '^(http|https)://.*'
+                      --exclude '^file://'
                       --exclude '^https?://localhost'
                       --exclude '^https?://127\.0\.0\.1'
                       --exclude '^https?://0\.0\.0\.0'
                       --exclude '^https?://\[\:\:1\]'
                       --exclude '^https?://\[\:\:\]'
+                      --exclude '^https?://support.discord.com'
                       './docs/**/*.md'
                       './docs/**/*.mdx'
                       './gen-docs/**/*.md'


### PR DESCRIPTION
Add a check that will parse all links in the docs for broken links, it will run on the same schedule as codeql and on pr / push to docs, it will fail when it finds an issue with a link and the link will be shown in that runs summary.