### PR TITLE
fix(media): handle 4K Radarr removal for multiple instances

### DIFF
--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -150,6 +150,31 @@ const ManageSlideOver = ({
     return false;
   };
 
+  const isDefault4kService = () => {
+    if (data.mediaInfo) {
+      if (data.mediaInfo.mediaType === MediaType.MOVIE) {
+        return (
+          radarrData?.find(
+            (radarr) =>
+              radarr.isDefault &&
+              radarr.is4k &&
+              radarr.id === data.mediaInfo?.serviceId4k
+          ) !== undefined
+        );
+      } else {
+        return (
+          sonarrData?.find(
+            (sonarr) =>
+              sonarr.isDefault &&
+              sonarr.is4k &&
+              sonarr.id === data.mediaInfo?.serviceId4k
+          ) !== undefined
+        );
+      }
+    }
+    return false;
+  };
+
   const markAvailable = async (is4k = false) => {
     if (data.mediaInfo) {
       await axios.post(`/api/v1/media/${data.mediaInfo?.id}/available`, {
@@ -572,7 +597,7 @@ const ManageSlideOver = ({
                         </span>
                       </Button>
                     </a>
-                    {isDefaultService() && (
+                    {isDefault4kService() && (
                       <div>
                         <ConfirmButton
                           onClick={() => deleteMediaFile(true)}


### PR DESCRIPTION
#### Description
This PR fixes an issue where removing 4K movies from Radarr failed when multiple Radarr instances were configured.
The backend was misparsing boolean query parameters and using string slugs instead of TMDB IDs.
The fix ensures that the correct 4K Radarr instance is targeted and that TMDB IDs are used for movie removal.

> [!NOTE]
> This PR does not fix the "all-or-nothing" behavior where clicking "Remove from ..." removes the entire request instead of just removing the media from the instance.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Partially fixes #1958
