### PR TITLE
fix(subscriber): prevent infinite loop when requesting existing media with scan disabled

### DIFF
--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -341,9 +341,11 @@ export class MediaRequestSubscriber
             mediaId: entity.media.id,
           });
 
-          const requestRepository = getRepository(MediaRequest);
-          entity.status = MediaRequestStatus.APPROVED;
-          await requestRepository.save(entity);
+          if (entity.status !== MediaRequestStatus.APPROVED) {
+            const requestRepository = getRepository(MediaRequest);
+            entity.status = MediaRequestStatus.APPROVED;
+            await requestRepository.save(entity);
+          }
           return;
         }
 
@@ -505,9 +507,11 @@ export class MediaRequestSubscriber
             mediaId: entity.media.id,
           });
 
-          const requestRepository = getRepository(MediaRequest);
-          entity.status = MediaRequestStatus.APPROVED;
-          await requestRepository.save(entity);
+          if (entity.status !== MediaRequestStatus.APPROVED) {
+            const requestRepository = getRepository(MediaRequest);
+            entity.status = MediaRequestStatus.APPROVED;
+            await requestRepository.save(entity);
+          }
           return;
         }
 


### PR DESCRIPTION
#### Description
This PR fixes yet another infinite loop due to Typeorm lifecycle that occurs when requesting media already exists in *arr with the scan option disabled. The issue was that in `sendToRadarr` and `sendToSonarr` methods unconditionally saved the request as `APPROVED` when the existing media is detected even if it was already in that state. This triggers the `afterUpdate` lifecycle hook repeatedly, thereby creating an infinite loop and the warning log spam reported in #1906. 

Now a simple status check is added before saving to ensure that we only write to database when the status actually requires to be changed. This should prevent the redundant save operation that caused the lifecycle hook to trigger indefinitely. This should in theory also improve the performance as we would be avoiding unnecessary database writes.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1906 
