### PR TITLE
fix(download-tracker): reset both service caches when resetting downloads

### DIFF
--- a/server/lib/downloadtracker.ts
+++ b/server/lib/downloadtracker.ts
@@ -56,6 +56,7 @@ class DownloadTracker {
 
   public async resetDownloadTracker() {
     this.radarrServers = {};
+    this.sonarrServers = {};
   }
 
   public updateDownloads() {


### PR DESCRIPTION
#### Description
This PR updates the `resetDownloadTracker()` method to clear both Radarr and Sonarr caches instead of only Radarr.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
