### PR TITLE
fix: delete endpoint on push notification disable

### DIFF
--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -269,15 +269,19 @@ router.delete<{ userId: number; endpoint: string }>(
     try {
       const userPushSubRepository = getRepository(UserPushSubscription);
 
-      const userPushSub = await userPushSubRepository.findOneOrFail({
-        relations: {
-          user: true,
-        },
+      const userPushSub = await userPushSubRepository.findOne({
+        relations: { user: true },
         where: {
           user: { id: req.params.userId },
           endpoint: req.params.endpoint,
         },
       });
+
+      // If not found, just return 204 to prevent push disable failure
+      // (rare scenario where user push sub does not exist)
+      if (!userPushSub) {
+        return res.status(204).send();
+      }
 
       await userPushSubRepository.remove(userPushSub);
       return res.status(204).send();

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
@@ -111,6 +111,11 @@ const UserWebPushSettings = () => {
     try {
       await unsubscribeToPushNotifications(user?.id, endpoint);
 
+      // Delete from backend if endpoint is available
+      if (subEndpoint) {
+        await deletePushSubscriptionFromBackend(subEndpoint);
+      }
+
       localStorage.setItem('pushNotificationsEnabled', 'false');
       setWebPushEnabled(false);
       addToast(intl.formatMessage(messages.webpushhasbeendisabled), {


### PR DESCRIPTION
#### Description

Quick PR that deletes the current endpoint on the users device when disabling the push subscription. Added a check on the backend in case the endpoint doesn't match to prevent any errors (it's possible there is a scenario where the endpoint has changed due to it being refreshed).

- Will prevent rare scenarios where user can enable/disable a few times and load the DB

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)