### PR TITLE
feat(sonarr): add monitorNewItems option to sonarr settings & modal

### DIFF
--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -99,7 +99,7 @@ export interface AddSeriesOptions {
   tags?: number[];
   seriesType: SonarrSeries['seriesType'];
   monitored?: boolean;
-  monitorNewItems?: 'all' | 'none';
+  monitorNewItems?: SonarrSeries['monitorNewItems'];
   searchNow?: boolean;
 }
 

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -49,6 +49,7 @@ export interface SonarrSeries {
   languageProfileId: number;
   seasonFolder: boolean;
   monitored: boolean;
+  monitorNewItems: 'all' | 'none';
   useSceneNumbering: boolean;
   runtime: number;
   tvdbId: number;
@@ -98,6 +99,7 @@ export interface AddSeriesOptions {
   tags?: number[];
   seriesType: SonarrSeries['seriesType'];
   monitored?: boolean;
+  monitorNewItems?: 'all' | 'none';
   searchNow?: boolean;
 }
 
@@ -241,6 +243,7 @@ class SonarrAPI extends ServarrBase<{
           tags: options.tags,
           seasonFolder: options.seasonFolder,
           monitored: options.monitored,
+          monitorNewItems: options.monitorNewItems,
           rootFolderPath: options.rootFolderPath,
           seriesType: options.seriesType,
           addOptions: {

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -93,6 +93,7 @@ export interface SonarrSettings extends DVRSettings {
   activeLanguageProfileId?: number;
   animeTags?: number[];
   enableSeasonFolders: boolean;
+  monitorNewItems: 'all' | 'none';
 }
 
 interface Quota {

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -664,6 +664,7 @@ export class MediaRequestSubscriber
           seriesType,
           tags,
           monitored: true,
+          monitorNewItems: sonarrSettings.monitorNewItems,
           searchNow: !sonarrSettings.preventSearch,
         };
 

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -78,6 +78,7 @@ const messages = defineMessages('components.Settings.SonarrModal', {
   animeTags: 'Anime Tags',
   notagoptions: 'No tags.',
   selecttags: 'Select tags',
+  monitorNewItems: 'Monitor New Items',
 });
 
 interface SonarrModalProps {
@@ -247,6 +248,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
           syncEnabled: sonarr?.syncEnabled ?? false,
           enableSearch: !sonarr?.preventSearch,
           tagRequests: sonarr?.tagRequests ?? false,
+          monitorNewItems: sonarr?.monitorNewItems ?? 'all',
         }}
         validationSchema={SonarrSettingsSchema}
         onSubmit={async (values) => {
@@ -290,6 +292,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
               syncEnabled: values.syncEnabled,
               preventSearch: !values.enableSearch,
               tagRequests: values.tagRequests,
+              monitorNewItems: values.monitorNewItems,
             };
             if (!sonarr) {
               await axios.post('/api/v1/settings/sonarr', submission);
@@ -963,6 +966,27 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                       name="enableSeasonFolders"
                     />
                   </div>
+                </div>
+                <div className="form-row">
+                  <label htmlFor="monitorNewItems" className="text-label">
+                    {intl.formatMessage(messages.monitorNewItems)}
+                  </label>
+                  <div className="form-input-area">
+                    <div className="form-input-field">
+                      <Field
+                        as="select"
+                        id="monitorNewItems"
+                        name="monitorNewItems"
+                        disabled={!isValidated || isTesting}
+                      >
+                        <option value="all">All</option>
+                        <option value="none">None</option>
+                      </Field>
+                    </div>
+                  </div>
+                  {errors.monitorNewItems && touched.monitorNewItems && (
+                    <div className="error">{errors.monitorNewItems}</div>
+                  )}
                 </div>
                 <div className="form-row">
                   <label htmlFor="externalUrl" className="text-label">

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -78,7 +78,7 @@ const messages = defineMessages('components.Settings.SonarrModal', {
   animeTags: 'Anime Tags',
   notagoptions: 'No tags.',
   selecttags: 'Select tags',
-  monitorNewItems: 'Monitor New Items',
+  monitorNewItems: 'Monitor New Seasons',
 });
 
 interface SonarrModalProps {

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1063,6 +1063,7 @@
   "components.Settings.SonarrModal.loadinglanguageprofiles": "Loading language profiles…",
   "components.Settings.SonarrModal.loadingprofiles": "Loading quality profiles…",
   "components.Settings.SonarrModal.loadingrootfolders": "Loading root folders…",
+  "components.Settings.SonarrModal.monitorNewItems": "Monitor New Items",
   "components.Settings.SonarrModal.notagoptions": "No tags.",
   "components.Settings.SonarrModal.port": "Port",
   "components.Settings.SonarrModal.qualityprofile": "Quality Profile",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1063,7 +1063,7 @@
   "components.Settings.SonarrModal.loadinglanguageprofiles": "Loading language profiles…",
   "components.Settings.SonarrModal.loadingprofiles": "Loading quality profiles…",
   "components.Settings.SonarrModal.loadingrootfolders": "Loading root folders…",
-  "components.Settings.SonarrModal.monitorNewItems": "Monitor New Items",
+  "components.Settings.SonarrModal.monitorNewItems": "Monitor New Seasons",
   "components.Settings.SonarrModal.notagoptions": "No tags.",
   "components.Settings.SonarrModal.port": "Port",
   "components.Settings.SonarrModal.qualityprofile": "Quality Profile",


### PR DESCRIPTION
#### Description
This PR adds the option to configure the monitor new items option in the sonarr service modal for when adding a new series.

#### Screenshot (if UI-related)
<img width="1119" height="657" alt="image" src="https://github.com/user-attachments/assets/32d5b136-c7eb-4a85-9b14-179e5ab5e6ce" />

#### To-Dos

- [X] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
~- [ ] Database migration (if required)~

#### Issues Fixed or Closed

- Fixes #XXXX
