### PR TITLE
fix(api): correct Jellyfin users endpoint documentation

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -2339,8 +2339,12 @@ paths:
                   properties:
                     username:
                       type: string
-                    userId:
-                      type: integer
+                    id:
+                      type: string
+                    thumb:
+                      type: string
+                    email:
+                      type: string
   /settings/jellyfin/sync:
     get:
       summary: Get status of full Jellyfin library sync


### PR DESCRIPTION
#### Description
This PR fixes the incorrect API documentation for the `/settings/jellyfin/users` endpoint.
- Added missing `thumb` and `email` fields
- Fixed field name from `userId` to `id`

#### Screenshot (if UI-related)

#### To-Dos

- [x] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #2072
