### PR TITLE
refactor(userlist): responsive columns and buttons

### DIFF
--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -750,12 +750,12 @@ const UserList = () => {
             >
               {intl.formatMessage(messages.created)}
             </SortableColumnHeader>
-            <Table.TH className="min-w-[13rem] text-right sm:min-w-[14rem] overflow-visible whitespace-normal">
+            <Table.TH className="w-1/12 whitespace-nowrap text-right">
               {(data.results ?? []).length > 1 && (
                 <div className="flex justify-end">
                   <Button
                     buttonType="warning"
-                    className="w-full"
+                    className="w-full sm:min-w-[12rem]"
                     onClick={() => setShowBulkEditModal(true)}
                     disabled={selectedUsers.length === 0}
                   >
@@ -876,7 +876,7 @@ const UserList = () => {
               </Table.TD>
               <Table.TD
                 alignText="right"
-                className="flex min-w-[13rem] flex-col space-y-1 sm:min-w-[14rem] sm:flex-row sm:space-x-1 sm:space-y-0"
+                className="grid grid-cols-1 gap-1 sm:grid-cols-2 sm:gap-2"
               >
                 <Button
                   buttonType="warning"

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -876,7 +876,7 @@ const UserList = () => {
               </Table.TD>
               <Table.TD
                 alignText="right"
-                className="flex max-w-[13rem] flex-col space-y-1 sm:max-w-[14rem] sm:flex-row sm:space-x-1 sm:space-y-0"
+                className="flex min-w-[13rem] flex-col space-y-1 sm:min-w-[14rem] sm:flex-row sm:space-x-1 sm:space-y-0"
               >
                 <Button
                   buttonType="warning"

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -750,10 +750,11 @@ const UserList = () => {
             >
               {intl.formatMessage(messages.created)}
             </SortableColumnHeader>
-            <Table.TH className="text-right">
+            <Table.TH className="flex text-right">
               {(data.results ?? []).length > 1 && (
                 <Button
                   buttonType="warning"
+                  className="w-full"
                   onClick={() => setShowBulkEditModal(true)}
                   disabled={selectedUsers.length === 0}
                 >
@@ -871,11 +872,14 @@ const UserList = () => {
                   day: 'numeric',
                 })}
               </Table.TD>
-              <Table.TD alignText="right">
+              <Table.TD
+                alignText="right"
+                className="flex flex-col space-y-1 sm:flex-row sm:space-x-1 sm:space-y-0"
+              >
                 <Button
                   buttonType="warning"
                   disabled={user.id === 1 && currentUser?.id !== 1}
-                  className="mr-2"
+                  className="w-full"
                   onClick={() =>
                     router.push(
                       '/users/[userId]/settings',
@@ -887,6 +891,7 @@ const UserList = () => {
                 </Button>
                 <Button
                   buttonType="danger"
+                  className="w-full"
                   disabled={
                     user.id === 1 ||
                     (currentUser?.id !== 1 &&

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -750,7 +750,7 @@ const UserList = () => {
             >
               {intl.formatMessage(messages.created)}
             </SortableColumnHeader>
-            <Table.TH className="w-[13rem] text-right sm:w-[14rem]">
+            <Table.TH className="min-w-[13rem] text-right sm:min-w-[14rem] overflow-visible whitespace-normal">
               {(data.results ?? []).length > 1 && (
                 <div className="flex justify-end">
                   <Button

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -881,7 +881,6 @@ const UserList = () => {
                 <Button
                   buttonType="warning"
                   disabled={user.id === 1 && currentUser?.id !== 1}
-                  className="flex-1"
                   onClick={() =>
                     router.push(
                       '/users/[userId]/settings',
@@ -893,7 +892,6 @@ const UserList = () => {
                 </Button>
                 <Button
                   buttonType="danger"
-                  className="flex-1"
                   disabled={
                     user.id === 1 ||
                     (currentUser?.id !== 1 &&

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -750,18 +750,20 @@ const UserList = () => {
             >
               {intl.formatMessage(messages.created)}
             </SortableColumnHeader>
-            <Table.TH className="flex text-right">
-              {(data.results ?? []).length > 1 && (
-                <Button
-                  buttonType="warning"
-                  className="w-full"
-                  onClick={() => setShowBulkEditModal(true)}
-                  disabled={selectedUsers.length === 0}
-                >
-                  <PencilIcon />
-                  <span>{intl.formatMessage(messages.bulkedit)}</span>
-                </Button>
-              )}
+            <Table.TH className="text-right">
+              <div className="flex">
+                {(data.results ?? []).length > 1 && (
+                  <Button
+                    buttonType="warning"
+                    className="w-full"
+                    onClick={() => setShowBulkEditModal(true)}
+                    disabled={selectedUsers.length === 0}
+                  >
+                    <PencilIcon />
+                    <span>{intl.formatMessage(messages.bulkedit)}</span>
+                  </Button>
+                )}
+              </div>
             </Table.TH>
           </tr>
         </thead>

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -750,9 +750,9 @@ const UserList = () => {
             >
               {intl.formatMessage(messages.created)}
             </SortableColumnHeader>
-            <Table.TH className="text-right">
-              <div className="flex">
-                {(data.results ?? []).length > 1 && (
+            <Table.TH className="w-[13rem] text-right sm:w-[14rem]">
+              {(data.results ?? []).length > 1 && (
+                <div className="flex justify-end">
                   <Button
                     buttonType="warning"
                     className="w-full"
@@ -762,8 +762,8 @@ const UserList = () => {
                     <PencilIcon />
                     <span>{intl.formatMessage(messages.bulkedit)}</span>
                   </Button>
-                )}
-              </div>
+                </div>
+              )}
             </Table.TH>
           </tr>
         </thead>
@@ -876,12 +876,12 @@ const UserList = () => {
               </Table.TD>
               <Table.TD
                 alignText="right"
-                className="flex flex-col space-y-1 sm:flex-row sm:space-x-1 sm:space-y-0"
+                className="flex max-w-[13rem] flex-col space-y-1 sm:max-w-[14rem] sm:flex-row sm:space-x-1 sm:space-y-0"
               >
                 <Button
                   buttonType="warning"
                   disabled={user.id === 1 && currentUser?.id !== 1}
-                  className="w-full"
+                  className="flex-1"
                   onClick={() =>
                     router.push(
                       '/users/[userId]/settings',
@@ -893,7 +893,7 @@ const UserList = () => {
                 </Button>
                 <Button
                   buttonType="danger"
-                  className="w-full"
+                  className="flex-1"
                   disabled={
                     user.id === 1 ||
                     (currentUser?.id !== 1 &&


### PR DESCRIPTION
#### Description
When i login and view my users, and who is requesting what etc, it bugs me that edit and delete is not the same width, also they are touching and makes me feel kind of yucky. I went in and modified the classes so that the buttons are not touching and to make them be the same size, or at a minimum fill the div with w-full.

#### Screenshot (if UI-related)

**Old User Buttons**
<img width="1223" height="654" alt="old-users-buttons" src="https://github.com/user-attachments/assets/bbd2f56a-041c-47ad-ac71-23ef8c6db2d4" />

**New User Buttons**
<img width="1215" height="768" alt="new-users-buttons" src="https://github.com/user-attachments/assets/31ff9d32-f98a-4500-82ce-74c3df034177" />

**Old User Buttons Mobile View**
<img width="406" height="620" alt="old-users-buttons-mobile" src="https://github.com/user-attachments/assets/a7ec15bc-8f10-406e-ad83-316e08355519" />

**New User Buttons Mobile View**
<img width="429" height="638" alt="new-users-buttons-mobile" src="https://github.com/user-attachments/assets/20f3680b-d14d-4b64-be64-a1b0dfefc401" />


#### To-Dos

- [x] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))

I consulted chatgipitty, on which classes to use to implement the changes I was looking for. Consulting chatgipitty replaced the typical consultation of the tailwind css docs. The end results were manually typed by my fingers, and visually judged by my eyes and brain.

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

No issue, but can make one if its wanted / needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved responsive layout of the user list table for better display across different screen sizes.
  * Enhanced action buttons (edit/delete) with adaptive spacing and alignment for mobile and smaller screens.
  * Refined table header styling with improved content overflow handling and whitespace management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->