### PR TITLE
ci: fix AI-generated workflow trigger

### DIFF
--- a/.github/workflows/ai-generated.yml
+++ b/.github/workflows/ai-generated.yml
@@ -3,7 +3,7 @@
 name: 'AI-generated pull requests'
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled, reopened]
 
 permissions:


### PR DESCRIPTION
#### Description

Trying to fix the trigger of the `ai-generated.yml` workflow to make it run on the PR target: https://runs-on.com/github-actions/pull-request-vs-pull-request-target/#the-pull_request_target-event-trigger

#### Screenshot (if UI-related)

- [ ] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
