### PR TITLE
docs: revert docs to legacy docs temporarily

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -3,9 +3,10 @@
 name: Deploy to GitHub Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - develop
+      - legacy-jellyseerr
     paths:
       - 'docs/**'
       - 'gen-docs/**'


### PR DESCRIPTION
#### Description
This is to revert the docs temporarily to legacy docs until we can release seerr stable.
I also added a manual dispatch, incase we need to interfere manually

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #2109 
