### PR TITLE
refactor(notifications): move event from author to title field in Discord Embed

### DIFF
--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -214,16 +214,13 @@ class DiscordAgent
       : undefined;
 
     return {
-      title: payload.subject,
+      title: payload.event
+        ? `${payload.event}: ${payload.subject}`
+        : payload.subject,
       url,
       description: payload.message,
       color,
       timestamp: new Date().toISOString(),
-      author: payload.event
-        ? {
-            name: payload.event,
-          }
-        : undefined,
       fields,
       thumbnail: embedPoster
         ? {


### PR DESCRIPTION
## Description

Moved event description from author field to title field in Discord embed notification. This fixes the issue of the Discord notification popup not displaying the actual thing that triggered the notification, as outlined in #2117.

## Screenshots
New notification:
![image](https://github.com/user-attachments/assets/372d76dc-1291-43fb-87ab-7966b85ca096)

To-Dos

- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/CONTRIBUTING.md#ai-assistance-notice))

The code change was primarily authored by GPT-5 mini through Github, though I verified the change myself

- [x] Successful build pnpm build
- [ ] Translation keys pnpm i18n:extract
- [ ] Database migration (if required)

Issues Fixed or Closed

Fixes #2117