### PR TITLE
chore: remove packages section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ Check out our documentation for instructions on how to install and run Seerr:
 
 https://docs.seerr.dev/getting-started/
 
-### Packages:
-
-Archlinux: [AUR](https://aur.archlinux.org/packages/jellyseerr)
-
-Nix: [Nixpkg](https://search.nixos.org/packages?channel=unstable&show=jellyseerr)
-
 ## Preview
 
 <img src="./public/preview.jpg">


### PR DESCRIPTION
#### Description

Remove this section, as it is not exhaustive and refers to third-party packages that are not officially supported.
