### PR TITLE
fix(ui): ensure media type filter is always visible on actor ages

### DIFF
--- a/src/components/PersonDetails/index.tsx
+++ b/src/components/PersonDetails/index.tsx
@@ -292,6 +292,7 @@ const PersonDetails = () => {
               </div>
             )}
           </div>
+          <div className="lg:hidden">{mediaTypePicker}</div>
           {data.biography && (
             <div className="relative text-left">
               {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
@@ -314,7 +315,6 @@ const PersonDetails = () => {
           )}
         </div>
       </div>
-      <div className="lg:hidden">{mediaTypePicker}</div>
       {data.knownForDepartment === 'Acting' ? [cast, crew] : [crew, cast]}
       {isLoading && <LoadingSpinner />}
     </>


### PR DESCRIPTION
#### Description

This PR fixes the mobile media type filter visibility issue on actor pages.
The filter was only visible when an actor had a biography text.

#### Screenshot (if UI-related)

#### Before fix
<img width="389" height="410" alt="image" src="https://github.com/user-attachments/assets/53e38b5d-3e72-4a6c-a7ec-9c1897818c5d" />

#### After fix
<img width="393" height="587" alt="image" src="https://github.com/user-attachments/assets/5c5f0dc2-2e99-49d6-95e8-93cef6e76804" />


#### To-Dos

- [x] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #2095
