### PR TITLE
fix(docker): pass `COMMIT_TAG` to build stage for custom image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store CI=true pnpm install --prod --
 
 FROM base AS build
 
+ARG COMMIT_TAG
+ENV COMMIT_TAG=${COMMIT_TAG}
+
 RUN \
   case "${TARGETPLATFORM}" in \
   'linux/arm64' | 'linux/arm/v7') \


### PR DESCRIPTION
#### Description

This PR fixes the issue where custom images built with `--build-arg COMMIT_TAG` would fail because the client bundle didn't receive the commit tag value.

#### Screenshot (if UI-related)

#### To-Dos

~~- [ ] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))~~
~~- [ ] Successful build `pnpm build`~~
~~- [ ] Translation keys `pnpm i18n:extract`~~
~~- [ ] Database migration (if required)~~

#### Issues Fixed or Closed

- Fixes #XXXX
