### PR TITLE
feat(api): load API key through systemd credentials with env fallback

### DIFF
--- a/docs/using-seerr/settings/general.md
+++ b/docs/using-seerr/settings/general.md
@@ -12,7 +12,18 @@ This is your Seerr API key, which can be used to integrate Seerr with third-part
 
 If you need to generate a new API key for any reason, simply click the button to the right of the text box.
 
-If you want to set the API key, rather than letting it be randomly generated, you can use the API_KEY environment variable. Whatever that variable is set to will be your API key.
+If you want to set the API key, rather than letting it be randomly generated,
+you can use the API_KEY environment variable. Whatever that variable is set to
+will be your API key.
+
+You can also use the `api-key` credential, if you're using a systemd service.
+
+```ini
+[Service]
+LoadCredential=api-key:/path/to/your/api-key-secret
+```
+
+[Learn more](https://systemd.io/CREDENTIALS/).
 
 ## Application Title
 

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -745,17 +745,27 @@ class Settings {
   }
 
   public async regenerateApiKey(): Promise<MainSettings> {
-    this.main.apiKey = this.generateApiKey();
+    this.main.apiKey = await this.generateApiKey();
     await this.save();
     return this.main;
   }
 
-  private generateApiKey(): string {
-    if (process.env.API_KEY) {
+  private async apiKeyFromEnvOrCred(): Promise<string | undefined> {
+    const apiKeyCredential = `${process.env.CREDENTIALS_DIRECTORY}/api-key`;
+
+    try {
+      return await fs.readFile(apiKeyCredential, 'utf-8');
+    } catch {
       return process.env.API_KEY;
-    } else {
-      return Buffer.from(`${Date.now()}${randomUUID()}`).toString('base64');
     }
+  }
+
+  private async generateApiKey(): Promise<string> {
+    const apiKey = await this.apiKeyFromEnvOrCred();
+
+    return (
+      apiKey || Buffer.from(`${Date.now()}${randomUUID()}`).toString('base64')
+    );
   }
 
   /**
@@ -794,11 +804,12 @@ class Settings {
     // generate keys and ids if it's missing
     let change = false;
     if (!this.data.main.apiKey) {
-      this.data.main.apiKey = this.generateApiKey();
+      this.data.main.apiKey = await this.generateApiKey();
       change = true;
-    } else if (process.env.API_KEY) {
-      if (this.main.apiKey != process.env.API_KEY) {
-        this.main.apiKey = process.env.API_KEY;
+    } else {
+      const apiKey = await this.apiKeyFromEnvOrCred();
+      if (apiKey && this.main.apiKey != apiKey) {
+        this.main.apiKey = apiKey;
       }
     }
     if (!this.data.clientId) {


### PR DESCRIPTION
#### Description

On Linux systems, be a well-behaved daemon and prefer systemd credential `api-key` if passed to the service. This is done through a file, access is checked by the kernel, and there's no process inheritance, TL;DR is more secure than env vars. See: [systemd Credentials](https://systemd.io/CREDENTIALS/). 

It would still fallback to the `API_KEY` env var as there's no need for this to be a breaking change.

#### To-Dos

- [ ] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

