### PR TITLE
fix(override-rules): show correct genres for both *arr services

### DIFF
--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -12,7 +12,6 @@ import type {
   TmdbGenre,
   TmdbKeywordSearchResponse,
 } from '@server/api/themoviedb/interfaces';
-import type { GenreSliderItem } from '@server/interfaces/api/discoverInterfaces';
 import type { UserResultsResponse } from '@server/interfaces/api/userInterfaces';
 import type {
   Keyword,
@@ -185,9 +184,7 @@ export const GenreSelector = ({
   }, [defaultValue, type]);
 
   const loadGenreOptions = async (inputValue: string) => {
-    const results = await axios.get<GenreSliderItem[]>(
-      `/api/v1/discover/genreslider/${type}`
-    );
+    const results = await axios.get<TmdbGenre[]>(`/api/v1/genres/${type}`);
 
     return results.data
       .map((result) => ({
@@ -201,7 +198,7 @@ export const GenreSelector = ({
 
   return (
     <AsyncSelect
-      key={`genre-select-${defaultDataValue}`}
+      key={`genre-select-${type}-${defaultDataValue}`}
       className="react-select-container"
       classNamePrefix="react-select"
       defaultValue={isMulti ? defaultDataValue : defaultDataValue?.[0]}

--- a/src/components/Settings/OverrideRule/OverrideRuleModal.tsx
+++ b/src/components/Settings/OverrideRule/OverrideRuleModal.tsx
@@ -337,7 +337,13 @@ const OverrideRuleModal = ({
                   <div className="form-input-area">
                     <div className="form-input-field">
                       <GenreSelector
-                        type={values.radarrServiceId ? 'movie' : 'tv'}
+                        type={
+                          values.radarrServiceId != null
+                            ? 'movie'
+                            : values.sonarrServiceId != null
+                            ? 'tv'
+                            : 'tv'
+                        }
                         defaultValue={values.genre}
                         isMulti
                         isDisabled={!isValidated || isTesting}


### PR DESCRIPTION
#### Description
The PR fixes the override rules page not showing correct genres when selecting either Radarr or Sonarr as the service.

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
