### PR TITLE
fix: most number types should be integer types in seerr-api.yml, and 48 additional commits; 49 commits to seerr-api.yml

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -1896,6 +1896,47 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MediaRequest'
+    SeasonsAll:
+      type: string
+      enum:
+        - all
+    PostRequest:
+      type: object
+      properties:
+        mediaType:
+          type: string
+          enum: [movie, tv]
+          example: movie
+        mediaId:
+          type: integer
+          example: 123
+        tvdbId:
+          type: integer
+          example: 123
+        seasons:
+          oneOf:
+            - type: array
+              items:
+                type: integer
+                minimum: 0
+            - $ref: '#/components/schemas/SeasonsAll'
+        is4k:
+          type: boolean
+          example: false
+        serverId:
+          type: integer
+        profileId:
+          type: integer
+        rootFolder:
+          type: string
+        languageProfileId:
+          type: integer
+        userId:
+          type: integer
+          nullable: true
+      required:
+        - mediaType
+        - mediaId
     RequestsCounts:
       type: object
       properties:
@@ -6120,43 +6161,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                mediaType:
-                  type: string
-                  enum: [movie, tv]
-                  example: movie
-                mediaId:
-                  type: integer
-                  example: 123
-                tvdbId:
-                  type: integer
-                  example: 123
-                seasons:
-                  oneOf:
-                    - type: array
-                      items:
-                        type: integer
-                        minimum: 0
-                    - type: string
-                      enum: [all]
-                is4k:
-                  type: boolean
-                  example: false
-                serverId:
-                  type: integer
-                profileId:
-                  type: integer
-                rootFolder:
-                  type: string
-                languageProfileId:
-                  type: integer
-                userId:
-                  type: integer
-                  nullable: true
-              required:
-                - mediaType
-                - mediaId
+              $ref: '#/components/schemas/PostRequest'
       responses:
         '201':
           description: Succesfully created the request


### PR DESCRIPTION
#### Description

NSwag generates double types when number is provided. Seerr service returns 400 Bad Request when decimal numbers are sent from HttpClient. This fix changes most number types to integer types in seerr-api.yml, which can be used to generate NSwag API clients which after the change generate int types versus double types in C#.

#### Screenshot (if UI-related)

N/A: Not UI related.

#### To-Dos

- [ ] I mostly used the find and replace tool in VS Code, some of it was edited by hand, some of it was generated in VS Code using AI auto-completion after it noticed what I was doing. I did review each line carefully before committing to my branch.
- [ ] Successfully built using `pnpm build` via Podman Compose on Windows 11. I was able to run, compile the pages, configure the Seerr service, connect to Jellyfin service, sync libraries, and perform all normal tasks following this commit.
- [ ] N/A: Translation keys `pnpm i18n:extract`
- [ ] N/A: Database migration (if required)

#### Issues Fixed or Closed

N/A: I didn't see any open issues.