### PR TITLE
feat(imdb ratings): add IMDb ratings for TV Shows

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -6725,6 +6725,66 @@ paths:
                   criticsRating:
                     type: string
                     enum: ['Rotten', 'Fresh']
+  /tv/{tvId}/ratingscombined:
+    get:
+      summary: Get RT and IMDB TV ratings combined
+      description: Returns ratings from RottenTomatoes and IMDB based on the provided tvId in a JSON object.
+      tags:
+        - tv
+      parameters:
+        - in: path
+          name: tvId
+          required: true
+          schema:
+            type: number
+            example: 76479
+      responses:
+        '200':
+          description: Ratings returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rt:
+                    type: object
+                    properties:
+                      title:
+                        type: string
+                        example: The Boys
+                      year:
+                        type: number
+                        example: 2019
+                      url:
+                        type: string
+                        example: 'http://www.rottentomatoes.com/tv/the_boys/'
+                      criticsScore:
+                        type: number
+                        example: 96
+                      criticsRating:
+                        type: string
+                        enum: ['Rotten', 'Fresh', 'Certified Fresh']
+                      audienceScore:
+                        type: number
+                        example: 94
+                      audienceRating:
+                        type: string
+                        enum: ['Spilled', 'Upright']
+                  imdb:
+                    type: object
+                    properties:
+                      title:
+                        type: string
+                        example: The Boys
+                      url:
+                        type: string
+                        example: 'https://www.imdb.com/title/tt1190634'
+                      criticsScore:
+                        type: number
+                        example: 8.7
+                      votes:
+                        type: number
+                        example: 382000
   /person/{personId}:
     get:
       summary: Get person details

--- a/server/api/rating/imdbAgregarrProxy.ts
+++ b/server/api/rating/imdbAgregarrProxy.ts
@@ -1,0 +1,60 @@
+import ExternalAPI from '@server/api/externalapi';
+import type { IMDBRating } from '@server/api/rating/imdbRadarrProxy';
+import cacheManager from '@server/lib/cache';
+
+interface AgregarrRatingResponse {
+  imdbId: string;
+  rating: number | null;
+  votes: number;
+}
+
+/**
+ * Agregarr hosts a free IMDb ratings proxy that supports both movies and TV.
+ * We use it for TV Shows only as Radarr's IMDb ratings proxy is proven and reliable.
+ */
+class IMDBAgregarrProxy extends ExternalAPI {
+  constructor() {
+    super(
+      'https://api.agregarr.org',
+      {},
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        nodeCache: cacheManager.getCache('imdb').data,
+      }
+    );
+  }
+
+  public async getTvRatings(imdbId: string): Promise<IMDBRating | null> {
+    if (!imdbId) {
+      return null;
+    }
+
+    try {
+      const data = await this.get<AgregarrRatingResponse[]>(
+        `/api/ratings?id=${encodeURIComponent(imdbId)}`
+      );
+
+      const rating = data?.find((result) => result.imdbId === imdbId);
+
+      if (!rating || rating.rating === null) {
+        return null;
+      }
+
+      return {
+        title: rating.imdbId,
+        url: `https://www.imdb.com/title/${rating.imdbId}`,
+        criticsScore: rating.rating,
+        criticsScoreCount: rating.votes,
+      };
+    } catch (e) {
+      throw new Error(
+        `[AGREGARR API] Failed to retrieve TV ratings: ${e.message}`
+      );
+    }
+  }
+}
+
+export default IMDBAgregarrProxy;


### PR DESCRIPTION
#### Description

Currently TV Shows do not provide an IMDb rating, there is no official API and so we use Radarr's IMDb ratings for Movies, however they do not provide TV Ratings.

[Agregarr](https://github.com/agregarr/agregarr) hosts a free IMDb ratings proxy for both Movies and TV Shows. 

This PR adds IMDb ratings for TV Shows using the Agregarr API, keeping the original Radarr method for Movies due to its tested reliability. 

#### Screenshot (if UI-related)

<img width="407" height="210" alt="imdbratings" src="https://github.com/user-attachments/assets/8fe7a969-e8c0-4532-929e-087a5cea65fd" />

#### To-Dos

- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

