### PR TITLE
feat(requests): mark requests as failed when Radarr/Sonarr unreachable

### DIFF
--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -420,13 +420,32 @@ export class MediaRequestSubscriber
           mediaId: entity.media.id,
         });
       } catch (e) {
-        logger.error('Something went wrong sending request to Radarr', {
-          label: 'Media Request',
-          errorMessage: e.message,
-          requestId: entity.id,
-          mediaId: entity.media.id,
+        const requestRepository = getRepository(MediaRequest);
+        const mediaRepository = getRepository(Media);
+        const media = await mediaRepository.findOne({
+          where: { id: entity.media.id },
         });
-        throw new Error(e.message);
+
+        if (media) {
+          entity.status = MediaRequestStatus.FAILED;
+          await requestRepository.save(entity);
+
+          logger.warn(
+            'Failed to send movie request to Radarr due to connection or configuration error, marking status as FAILED',
+            {
+              label: 'Media Request',
+              requestId: entity.id,
+              mediaId: entity.media.id,
+              errorMessage: e.message,
+            }
+          );
+
+          MediaRequest.sendNotification(
+            entity,
+            media,
+            Notification.MEDIA_FAILED
+          );
+        }
       }
     }
   }
@@ -727,13 +746,32 @@ export class MediaRequestSubscriber
           mediaId: entity.media.id,
         });
       } catch (e) {
-        logger.error('Something went wrong sending request to Sonarr', {
-          label: 'Media Request',
-          errorMessage: e.message,
-          requestId: entity.id,
-          mediaId: entity.media.id,
+        const requestRepository = getRepository(MediaRequest);
+        const mediaRepository = getRepository(Media);
+        const media = await mediaRepository.findOne({
+          where: { id: entity.media.id },
         });
-        throw new Error(e.message);
+
+        if (media) {
+          entity.status = MediaRequestStatus.FAILED;
+          await requestRepository.save(entity);
+
+          logger.warn(
+            'Failed to send series request to Sonarr due to connection or configuration error, marking status as FAILED',
+            {
+              label: 'Media Request',
+              requestId: entity.id,
+              mediaId: entity.media.id,
+              errorMessage: e.message,
+            }
+          );
+
+          MediaRequest.sendNotification(
+            entity,
+            media,
+            Notification.MEDIA_FAILED
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
#### Description
This PR fixes requests silently failing when Radarr/Sonarr are unreachable.
Requests are now marked as `FAILED` and notifications are sent to alert both users and admins.

Additionally, this enables the `Retry` button for failed requests, so admins can quickly resend them once the connection to Radarr/Sonarr has been restored.

#### Screenshot (if UI-related)
<img width="399" height="217" alt="image" src="https://github.com/user-attachments/assets/557cdc5d-8987-45ea-bb04-9da590ab0c72" />

#### To-Dos

- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes: #2052
- Closes: #2118
