### PR TITLE
fix(api): use requestor's permissions for request approval

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -202,7 +202,7 @@ export class MediaRequest {
     }
 
     // Apply overrides if the user is not an admin or has the "advanced request" permission
-    const useOverrides = !user.hasPermission([Permission.MANAGE_REQUESTS], {
+    const useOverrides = !requestUser.hasPermission([Permission.MANAGE_REQUESTS], {
       type: 'or',
     });
 
@@ -337,7 +337,7 @@ export class MediaRequest {
         media,
         requestedBy: requestUser,
         // If the user is an admin or has the "auto approve" permission, automatically approve the request
-        status: user.hasPermission(
+        status: requestUser.hasPermission(
           [
             requestBody.is4k
               ? Permission.AUTO_APPROVE_4K
@@ -447,7 +447,7 @@ export class MediaRequest {
         media,
         requestedBy: requestUser,
         // If the user is an admin or has the "auto approve" permission, automatically approve the request
-        status: user.hasPermission(
+        status: requestUser.hasPermission(
           [
             requestBody.is4k
               ? Permission.AUTO_APPROVE_4K
@@ -485,7 +485,7 @@ export class MediaRequest {
           (sn) =>
             new SeasonRequest({
               seasonNumber: sn,
-              status: user.hasPermission(
+              status: requestUser.hasPermission(
                 [
                   requestBody.is4k
                     ? Permission.AUTO_APPROVE_4K


### PR DESCRIPTION
… than the logged in user account

In the POST /request API call, the permissions make the request and quotas are all inherited from the "requesting user". The only difference comes from the auto-approve permissions, which for some reason use the admin or API key holder permissions.

To make this code more consistent with the expected behavior, I updated the code to look at the requestUser permissions for auto-requests.

#### Description

The users reported a bug on my plugin that uses Jellyseerr: https://github.com/kinggeorges12/JellyBridge/issues/17

I noticed that the behavior in this MediaRequest class was inconsistent, where the user requesting an item would be checked for quotas and requests (like do they have the ability to add requests AT ALL), but when checking for user overrides or auto-approve, the API keyholder or authorized user permissions were checked.

Bug: when requesting media through the API for another user, the approval process is skipped for the requesting user (userId in the API call for POST /requests). When creating new requests as the root account, the request is auto-approved since this permission cannot be changed for admin accounts.

What this means is that there is no way to make the approval process work when sending requests as another user from an admin account. Although this is noted in the API "If the user has the ADMIN or AUTO_APPROVE permissions, their request will be auomatically approved.", the comment is completely misleading, because the "user" it is talking about is NOT the userId provided by the function. I think this change brings it more in-line with expected behavior of this API endpoint.

I already tested this change here for v2.7.3: https://hub.docker.com/repository/docker/kinggeorges12/jellyseerr/tags/2.7.3-jb/

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
