### PR TITLE
docs(buildfromsource): touch up path inconsistencies

### DIFF
--- a/docs/getting-started/buildfromsource.mdx
+++ b/docs/getting-started/buildfromsource.mdx
@@ -20,14 +20,13 @@ import TabItem from '@theme/TabItem';
 
 ## Unix (Linux, macOS)
 ### Installation
-1. Assuming you want the working directory to be `/opt/seerr/seerr`, create the directory and navigate to it:
+1. Assuming you want the working directory to be `/opt/seerr`, create the directory and navigate to it:
 ```bash
 sudo mkdir -p /opt/seerr && cd /opt/seerr
 ```
 2. Clone the Seerr repository and checkout the main branch:
 ```bash
-git clone https://github.com/seerr-team/seerr.git
-cd seerr
+git clone https://github.com/seerr-team/seerr.git .
 git checkout main
 ```
 3. Install the dependencies:
@@ -81,7 +80,7 @@ EnvironmentFile=/etc/seerr/seerr.conf
 Environment=NODE_ENV=production
 Type=exec
 Restart=on-failure
-WorkingDirectory=/opt/seerr/seerr
+WorkingDirectory=/opt/seerr
 ExecStart=/usr/bin/node dist/index.js
 
 [Install]


### PR DESCRIPTION
## Description

Installation instructions were slightly inconsistent with the systemd unit file example.

## How Has This Been Tested?

n/a

## Screenshots / Logs (if applicable)

Following the instructions prior to this commit produces the following error when starting the example unit file:
```
Nov 30 16:31:08 hostname systemd[1]: Starting jellyseerr.service - Jellyseerr Service...
Nov 30 16:31:08 hostname systemd[1]: Started jellyseerr.service - Jellyseerr Service.
Nov 30 16:31:08 hostname node[22445]: node:internal/modules/cjs/loader:1386
Nov 30 16:31:08 hostname node[22445]:   throw err;
Nov 30 16:31:08 hostname node[22445]:   ^ 
Nov 30 16:31:08 hostname node[22445]: Error: Cannot find module '/opt/jellyseerr/dist/index.js'
Nov 30 16:31:08 hostname node[22445]:     at Function._resolveFilename (node:internal/modules/cjs/loader:1383:15)
Nov 30 16:31:08 hostname node[22445]:     at defaultResolveImpl (node:internal/modules/cjs/loader:1025:19)
Nov 30 16:31:08 hostname node[22445]:     at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1030:22)
Nov 30 16:31:08 hostname node[22445]:     at Function._load (node:internal/modules/cjs/loader:1192:37)
Nov 30 16:31:08 hostname node[22445]:     at TracingChannel.traceSync (node:diagnostics_channel:328:14)
Nov 30 16:31:08 hostname node[22445]:     at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
Nov 30 16:31:08 hostname node[22445]:     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:171:5)
Nov 30 16:31:08 hostname node[22445]:     at node:internal/main/run_main_module:36:49 { 
Nov 30 16:31:08 hostname node[22445]:   code: 'MODULE_NOT_FOUND',
Nov 30 16:31:08 hostname node[22445]:   requireStack: []
Nov 30 16:31:08 hostname node[22445]: } 
Nov 30 16:31:08 hostname node[22445]: Node.js v22.21.1
Nov 30 16:31:08 hostname systemd[1]: jellyseerr.service: Main process exited, code=exited, status=1/FAILURE
Nov 30 16:31:08 hostname systemd[1]: jellyseerr.service: Failed with result 'exit-code'.
```

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ n/a] All new and existing tests passed.
- [ n/a] Successful build `pnpm build`
- [ n/a] Translation keys `pnpm i18n:extract`
- [ n/a] Database migration (if required)
