### PR TITLE
fix(jellyfin-api): use standard Authorization header

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -145,7 +145,7 @@ class JellyfinAPI extends ExternalAPI {
       {},
       {
         headers: {
-          'X-Emby-Authorization': authHeaderVal,
+          Authorization: authHeaderVal,
           'Content-Type': 'application/json',
           Accept: 'application/json',
         },


### PR DESCRIPTION
## Description
Replace `X-Emby-Authorization` with `Authorization` header to fix 
authentication failures when users have `<EnableLegacyAuthorization>false</EnableLegacyAuthorization>` in their Jellyfin `system.xml`. This option was introduced in 10.11 (enabled by default) for testing without the legacy authorization methods and will be enforced (disabled by default) in 10.12. We should be using the modern authorization method anyway.

It is backwards compatible as the new header was introduced a while ago.

## How Has This Been Tested?

- Authenticated against 10.11.x
- Authenticated against 10.10.x

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
