### PR TITLE
fix: disable automatic auth revalidation on auth pages

### DIFF
--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -58,7 +58,9 @@ export const useUser = ({
   initialData,
 }: { id?: number; initialData?: User } = {}): UserHookResponse => {
   const router = useRouter();
-  const isAuthPage = /^\/(login|setup|resetpassword)/.test(router.pathname);
+  const isAuthPage = /^\/(login|setup|resetpassword(?:\/|$))/.test(
+    router.pathname
+  );
 
   const {
     data,
@@ -66,7 +68,7 @@ export const useUser = ({
     mutate: revalidate,
   } = useSWR<User>(id ? `/api/v1/user/${id}` : `/api/v1/auth/me`, {
     fallbackData: initialData,
-    refreshInterval: 30000,
+    refreshInterval: !isAuthPage ? 30000 : 0,
     revalidateOnFocus: !isAuthPage,
     revalidateOnMount: !isAuthPage,
     revalidateOnReconnect: !isAuthPage,


### PR DESCRIPTION
## Description
Prevents unnecessary `/api/v1/auth/me` requests on login, setup, and password reset pages. These requests used to return 401/403 errors since no user would be logged in, spamming reverse proxy logs and triggering fail2ban rules for users running seerr behind reverse proxy/fail2ban setups.

This PR disables SWR's automatic revalidation (on mount, focus, and interval) when on auth pages, while keeping manual revalidation functional so login flow still works correctly.

- Fixes #738

## How Has This Been Tested?

- Monitored the network logs when on the above mentioned auth pages

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
