### PR TITLE
chore(metadata-settings): add autoDismiss to toast notifications

### DIFF
--- a/src/components/Settings/SettingsMetadata.tsx
+++ b/src/components/Settings/SettingsMetadata.tsx
@@ -320,12 +320,14 @@ const SettingsMetadata = () => {
 
               addToast(intl.formatMessage(messages.metadataSettingsSaved), {
                 appearance: 'success',
+                autoDismiss: true,
               });
             } catch (e) {
               addToast(
                 intl.formatMessage(messages.failedToSaveMetadataSettings),
                 {
                   appearance: 'error',
+                  autoDismiss: true,
                 }
               );
             }
@@ -422,6 +424,7 @@ const SettingsMetadata = () => {
                                 ),
                                 {
                                   appearance: 'success',
+                                  autoDismiss: true,
                                 }
                               );
                             }


### PR DESCRIPTION
## Description

This simply adds `autoDismiss: true` to toast notifications on the Metadata Settings page, bringing it in line with the rest of the apps toast behaviour.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
