### PR TITLE
chore(issuetemplate): add a checkbox to search for existing issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -92,6 +92,14 @@ body:
       label: Additional Context
       description: Please provide any additional information that may be relevant or helpful.
   - type: checkboxes
+    id: search-existing
+    attributes:
+      label: Search Existing Issues
+      description: Have you searched existing issues to see if this bug has already been reported?
+      options:
+        - label: Yes, I have searched existing issues.
+          required: true
+  - type: checkboxes
     id: terms
     attributes:
       label: Code of Conduct

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -28,6 +28,14 @@ body:
       label: Additional Context
       description: Provide any additional information or screenshots that may be relevant or helpful.
   - type: checkboxes
+    id: search-existing
+    attributes:
+      label: Search Existing Issues
+      description: Have you searched existing issues to see if this feature has already been requested?
+      options:
+        - label: Yes, I have searched existing issues.
+          required: true
+  - type: checkboxes
     id: terms
     attributes:
       label: Code of Conduct


### PR DESCRIPTION
## Description

This PR adds a checkbox when creating a new issue to ask if users search for already existing issues.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
