### PR TITLE
fix(migration): add cleanup step for duplicate push subscriptions before enforcing unique constraint

### DIFF
--- a/server/migration/postgres/1765233385034-AddUniqueConstraintToPushSubscription.ts
+++ b/server/migration/postgres/1765233385034-AddUniqueConstraintToPushSubscription.ts
@@ -6,6 +6,15 @@ export class AddUniqueConstraintToPushSubscription1765233385034
   name = 'AddUniqueConstraintToPushSubscription1765233385034';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM "user_push_subscription"
+      WHERE id NOT IN (
+        SELECT MAX(id)
+        FROM "user_push_subscription"
+        GROUP BY "endpoint", "userId"
+      )
+    `);
+
     await queryRunner.query(
       `ALTER TABLE "user_push_subscription" ADD CONSTRAINT "UQ_6427d07d9a171a3a1ab87480005" UNIQUE ("endpoint", "userId")`
     );

--- a/server/migration/sqlite/1765233385034-AddUniqueConstraintToPushSubscription.ts
+++ b/server/migration/sqlite/1765233385034-AddUniqueConstraintToPushSubscription.ts
@@ -6,6 +6,15 @@ export class AddUniqueConstraintToPushSubscription1765233385034
   name = 'AddUniqueConstraintToPushSubscription1765233385034';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM "user_push_subscription"
+      WHERE id NOT IN (
+        SELECT MAX(id)
+        FROM "user_push_subscription"
+        GROUP BY "endpoint", "userId"
+      )
+    `);
+
     await queryRunner.query(
       `CREATE UNIQUE INDEX "UQ_6427d07d9a171a3a1ab87480005" ON "user_push_subscription" ("endpoint", "userId")`
     );


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


This PR fixes duplicate `user_push_subscription` entries by removing them before applying the `UNIQUE` constraint on `(endpoint, userId)`.

- Fixes #2265

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Inserted dummy duplicate `user_push_subscription` entries.
2. Ran the migration.
3. Verified that duplicates were removed and the `UNIQUE` constraint was applied successfully.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
