### PR TITLE
fix links to docs/

### DIFF
--- a/docs/getting-started/buildfromsource.mdx
+++ b/docs/getting-started/buildfromsource.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 :::warning
 This method is not recommended for most users. It is intended for advanced users who are familiar with managing their own server infrastructure.
 
-Refer to [Configuring Databases](/extending-seerr/database-config#postgresql-options) for details on how to configure your database.
+Refer to [Configuring Databases](/docs/extending-seerr/database-config.mdx#postgresql-options) for details on how to configure your database.
 :::
 
 import Tabs from '@theme/Tabs';

--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -8,7 +8,7 @@ sidebar_position: 1
 This is the recommended method for most users.
 Details on how to install Docker can be found on the [official Docker website](https://docs.docker.com/get-docker/).
 
-Refer to [Configuring Databases](/extending-seerr/database-config#postgresql-options) for details on how to configure your database.
+Refer to [Configuring Databases](/docs/extending-seerr/database-config.mdx#postgresql-options) for details on how to configure your database.
 :::
 
 :::info
@@ -18,7 +18,7 @@ An alternative Docker image is available on Docker Hub for this project. You can
 :::info
 All official Seerr images are cryptographically signed and include a verified [Software Bill of Materials (SBOM)](https://cyclonedx.org/).
 
-To confirm that the container image you are using is authentic and unmodified, please refer to the [Verifying Signed Artifacts](/using-seerr/advanced/verifying-signed-artifacts#verifying-signed-images) guide.
+To confirm that the container image you are using is authentic and unmodified, please refer to the [Verifying Signed Artifacts](/docs/using-seerr/advanced/verifying-signed-artifacts.mdx#verifying-signed-images) guide.
 :::
 
 ## Unix (Linux, macOS)

--- a/docs/getting-started/kubernetes.mdx
+++ b/docs/getting-started/kubernetes.mdx
@@ -11,7 +11,7 @@ This method is not recommended for most users. It is intended for advanced users
 :::info
 All official Seerr charts are cryptographically signed and include a verified [Software Bill of Materials (SBOM)](https://cyclonedx.org/).
 
-To confirm that the chart you are using is authentic and unmodified, please refer to the [Verifying Signed Artifacts](/using-seerr/advanced/verifying-signed-artifacts#verifying-signed-helm-charts) guide.
+To confirm that the chart you are using is authentic and unmodified, please refer to the [Verifying Signed Artifacts](/docs/using-seerr/advanced/verifying-signed-artifacts.mdx#verifying-signed-helm-charts) guide.
 :::
 
 ## Installation

--- a/docs/migration-guide.mdx
+++ b/docs/migration-guide.mdx
@@ -11,11 +11,11 @@ An additional migration will happen for Overseerr users, to migrate their config
 
 :::warning
 Before doing anything you should backup your existing instance so that you can rollback in case something goes wrong.
-See [Backups](/using-seerr/backups) for details on how to properly backup your instance.
+See [Backups](/docs/using-seerr/backups.md) for details on how to properly backup your instance.
 :::
 
 ## Docker
-Refer to [Seerr Docker Documentation](/getting-started/docker), all of our examples have been updated to reflect the below change.
+Refer to [Seerr Docker Documentation](/docs/getting-started/docker.mdx), all of our examples have been updated to reflect the below change.
 
 Changes :
 - Renamed all references from `overseerr` or `jellyseerr` to `seerr`.
@@ -127,7 +127,7 @@ Summary of changes :
 </Tabs>
 
 ## Kubernetes
-Refer to [Seerr Kubernetes Documentation](/getting-started/kubernetes), all of our examples have been updated to reflect the below change.
+Refer to [Seerr Kubernetes Documentation](/docs/getting-started/kubernetes.mdx), all of our examples have been updated to reflect the below change.
 
 Changes :
 - All references to `jellyseerr` have been renamed to `seerr` in the manifests.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -103,7 +103,7 @@ If you can't change your DNS servers or force IPV4 resolution, you can use Seerr
 
 In some places (like China), the ISP blocks not only the DNS resolution but also the connection to the TMDB API.
 
-You can configure Seerr to use a proxy with the [HTTP(S) Proxy](/using-seerr/settings/general#enable-proxy-support) setting.
+You can configure Seerr to use a proxy with the [HTTP(S) Proxy](/docs/using-seerr/settings/general.md#enable-proxy-support) setting.
 
 ### Option 3: Force IPV4 resolution first
 

--- a/docs/using-seerr/notifications/email.md
+++ b/docs/using-seerr/notifications/email.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 ## Configuration
 
 :::info
-If the [Application URL](/using-seerr/settings/general#application-title) setting is configured in **Settings → General**, Seerr will explicitly set the origin server hostname when connecting to the SMTP host.
+If the [Application URL](/docs/using-seerr/settings/general.md#application-title) setting is configured in **Settings → General**, Seerr will explicitly set the origin server hostname when connecting to the SMTP host.
 :::
 
 ### Sender Name (optional)

--- a/docs/using-seerr/notifications/webpush.md
+++ b/docs/using-seerr/notifications/webpush.md
@@ -11,7 +11,7 @@ The web push notification agent enables you and your users to receive Seerr noti
 This notification agent does not require any configuration, but is not enabled in Seerr
 
 :::warning
-Web push notifications require a secure connection to your Seerr instance. Refer to the [Reverse Proxy](/extending-seerr/reverse-proxy) documentation for more information.
+Web push notifications require a secure connection to your Seerr instance. Refer to the [Reverse Proxy](/docs/extending-seerr/reverse-proxy.mdx) documentation for more information.
 :::
 
 To set up web push notifications, simply enable the agent in **Settings → Notifications → Web Push**. You and your users will then be prompted to allow notifications in your web browser.

--- a/docs/using-seerr/settings/notifications.mdx
+++ b/docs/using-seerr/settings/notifications.mdx
@@ -6,4 +6,4 @@ sidebar_position: 5
 
 # Notifications
 
-Please see the [Notifications](/using-seerr/notifications) page for more information.
+Please see the [Notifications](/docs/using-seerr/notifications.mdx) page for more information.

--- a/docs/using-seerr/users/adding-users.mdx
+++ b/docs/using-seerr/users/adding-users.mdx
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # Adding Users
 
-There are currently two methods to add users to Seerr: importing Mediaserver users and creating "local users." All new users are created with the [default permissions](/using-seerr/settings/users#default-permissions) defined in **Settings &rarr; Users**.
+There are currently two methods to add users to Seerr: importing Mediaserver users and creating "local users." All new users are created with the [default permissions](/docs/using-seerr/settings/users.md#default-permissions) defined in **Settings &rarr; Users**.
 
 ### Importing Mediaserver Users
 
@@ -17,20 +17,20 @@ import TabItem from '@theme/TabItem';
   <TabItem value="jellyfin" label="Jellyfin">
     Clicking the **Import Jellyfin Users** button on the **User List** page will fetch the list of users with access to the Jellyfin server and add them to Seerr automatically.
 
-    Importing Jellyfin users is not required, however. Any user with access to the Jellyfin server can log in to Seerr even if they have not been imported, and will be assigned the configured [default permissions](/using-seerr/settings/users#default-permissions) upon their first login.
+    Importing Jellyfin users is not required, however. Any user with access to the Jellyfin server can log in to Seerr even if they have not been imported, and will be assigned the configured [default permissions](/docs/using-seerr/settings/users.md#default-permissions) upon their first login.
 
 :::tip
-To disable new Jellyfin sign-ins, navigate to **Settings &rarr; Users** and uncheck the [**Enable New Jellyfin Sign-In**](/using-seerr/settings/users#enable-new-jellyfinembyplex-sign-in) box.
+To disable new Jellyfin sign-ins, navigate to **Settings &rarr; Users** and uncheck the [**Enable New Jellyfin Sign-In**](/docs/using-seerr/settings/users.md#enable-new-jellyfinembyplex-sign-in) box.
 :::
 
   </TabItem>
   <TabItem value="emby" label="Emby">
     Clicking the **Import Emby Users** button on the **User List** page will fetch the list of users with access to the Emby server and add them to Seerr automatically.
 
-    Importing Emby users is not required, however. Any user with access to the Emby server can log in to Seerr even if they have not been imported, and will be assigned the configured [default permissions](/using-seerr/settings/users#default-permissions) upon their first login.
+    Importing Emby users is not required, however. Any user with access to the Emby server can log in to Seerr even if they have not been imported, and will be assigned the configured [default permissions](/docs/using-seerr/settings/users.md#default-permissions) upon their first login.
 
 :::tip
-To disable new Emby sign-ins, navigate to **Settings &rarr; Users** and uncheck the [**Enable New Emby Sign-In**](/using-seerr/settings/users#enable-new-jellyfinembyplex-sign-in) box.
+To disable new Emby sign-ins, navigate to **Settings &rarr; Users** and uncheck the [**Enable New Emby Sign-In**](/docs/using-seerr/settings/users.md#enable-new-jellyfinembyplex-sign-in) box.
 :::
 
   </TabItem>
@@ -38,10 +38,10 @@ To disable new Emby sign-ins, navigate to **Settings &rarr; Users** and uncheck 
   <TabItem value="plex" label="Plex">
     Clicking the **Import Plex Users** button on the **User List** page will fetch the list of users with access to the Plex server from [plex.tv](https://www.plex.tv/), and add them to Seerr automatically.
 
-    Importing Plex users is not required, however. Any user with access to the Plex server can log in to Seerr even if they have not been imported, and will be assigned the configured [default permissions](/using-seerr/settings/users#default-permissions) upon their first login.
+    Importing Plex users is not required, however. Any user with access to the Plex server can log in to Seerr even if they have not been imported, and will be assigned the configured [default permissions](/docs/using-seerr/settings/users.md#default-permissions) upon their first login.
 
 :::tip
-To disable new Plex sign-ins, navigate to **Settings &rarr; Users** and uncheck the [**Enable New Plex Sign-In**](/using-seerr/settings/users#enable-new-jellyfinembyplex-sign-in) box.
+To disable new Plex sign-ins, navigate to **Settings &rarr; Users** and uncheck the [**Enable New Plex Sign-In**](/docs/using-seerr/settings/users.md#enable-new-jellyfinembyplex-sign-in) box.
 :::
 
   </TabItem>
@@ -57,7 +57,7 @@ Enter a valid email address at which the user can receive messages pertaining to
 
 #### Automatically Generate Password
 
-If an [application URL](/using-seerr/settings/general#application-url) is set and [email notifications](/using-seerr/notifications/email) have been configured and enabled, Seerr can automatically generate a password for the new user.
+If an [application URL](/docs/using-seerr/settings/general.md#application-url) is set and [email notifications](/docs/using-seerr/notifications/email.md) have been configured and enabled, Seerr can automatically generate a password for the new user.
 
 #### Password
 

--- a/docs/using-seerr/users/editing-users.md
+++ b/docs/using-seerr/users/editing-users.md
@@ -31,11 +31,11 @@ You cannot leave this field blank.
 
 ### Display Language
 
-Users can override the [global display language](/using-seerr/settings/general#display-language) to use Seerr in their preferred language.
+Users can override the [global display language](/docs/using-seerr/settings/general.md#display-language) to use Seerr in their preferred language.
 
 ### Discover Region & Discover Language
 
-Users can override the [global filter settings](/using-seerr/settings/general#discover-region-discover-language--streaming-region) to suit their own preferences.
+Users can override the [global filter settings](/docs/using-seerr/settings/general.md#discover-region-discover-language--streaming-region) to suit their own preferences.
 
 ### Movie Request Limit & Series Request Limit
 
@@ -55,7 +55,7 @@ Passwords must be a minimum of 8 characters long.
 
 ## Notifications
 
-Users can configure their personal notification settings here. Please see [Notifications](/using-seerr/notifications/) for details on configuring and enabling notifications.
+Users can configure their personal notification settings here. Please see [Notifications](/docs/using-seerr/notifications/) for details on configuring and enabling notifications.
 
 ## Permissions
 


### PR DESCRIPTION
## Description

I wanted to read through the migration path to do some beta testing of the develop branch and found some links pointing to a 404. These links should be fixed now.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
