### PR TITLE
fix(setup): fix Plex login not proceeding after authentication

### DIFF
--- a/src/components/Setup/LoginWithPlex.tsx
+++ b/src/components/Setup/LoginWithPlex.tsx
@@ -28,7 +28,8 @@ const LoginWithPlex = ({ onComplete }: LoginWithPlexProps) => {
       const response = await axios.post('/api/v1/auth/plex', { authToken });
 
       if (response.data?.id) {
-        revalidate();
+        const { data: user } = await axios.get('/api/v1/auth/me');
+        revalidate(user, false);
       }
     };
     if (authToken) {


### PR DESCRIPTION
Directly fetch and populate SWR cache with user data instead of relying on revalidate() which is disabled on auth pages since #2213

fix #2288

<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

Fixed an issue in the setup flow where completing Plex authentication in the popup wouldn't automatically proceed to the next step. This was caused by a recent change (#2213) that disabled SWR revalidation on auth pages, which meant the `revalidate()` call after login wasn't actually fetching user data. The fix directly fetches the user data and populates the SWR cache.

- Fixes #2288 

## How Has This Been Tested?

- Choose Plex as a login
- Login with plex

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
