### PR TITLE
fix(login): add missing keys to PlexLoginButton FormattedMessage chidren

### DIFF
--- a/src/components/Login/PlexLoginButton.tsx
+++ b/src/components/Login/PlexLoginButton.tsx
@@ -3,6 +3,7 @@ import Button from '@app/components/Common/Button';
 import { SmallLoadingSpinner } from '@app/components/Common/LoadingSpinner';
 import usePlexLogin from '@app/hooks/usePlexLogin';
 import defineMessages from '@app/utils/defineMessages';
+import { Fragment } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 const messages = defineMessages('components.Login', {
@@ -46,8 +47,12 @@ const PlexLoginButton = ({
         >
           {(chunks) => (
             <>
-              {chunks.map((c) =>
-                typeof c === 'string' ? <span>{c}</span> : c
+              {chunks.map((c, index) =>
+                typeof c === 'string' ? (
+                  <span key={index}>{c}</span>
+                ) : (
+                  <Fragment key={index}>{c}</Fragment>
+                )
               )}
             </>
           )}


### PR DESCRIPTION
## Description

Fixed a React warning about missing keys in the `PlexLoginButton` component. The `FormattedMessage` children were being mapped without key props, causing a console warning during login. Added index-based keys to the mapped elements.

<img width="1479" height="898" alt="image" src="https://github.com/user-attachments/assets/4d27d35f-ddd3-480b-b8b7-0e9d978254da" />

## How Has This Been Tested?

- Press login with plex button
- Observe no above error in browser console

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
