### PR TITLE
feat(availability-sync): added logging for 4K movie availability checks in Plex and Radarr

### DIFF
--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -118,21 +118,6 @@ class AvailabilitySync {
           throw new Error('Job aborted');
         }
 
-        if (
-          media.mediaType === 'movie' &&
-          media.status4k === MediaStatus.AVAILABLE
-        ) {
-          logger.debug(
-            `Processing movie [TMDB ID ${media.tmdbId}] with 4K status AVAILABLE`,
-            {
-              label: 'AvailabilitySync',
-              ratingKey: media.ratingKey,
-              ratingKey4k: media.ratingKey4k,
-              externalServiceId4k: media.externalServiceId4k,
-            }
-          );
-        }
-
         // Check plex, radarr, and sonarr for that specific media and
         // if unavailable, then we change the status accordingly.
         // If a non-4k or 4k version exists in at least one of the instances, we will only update that specific version
@@ -152,35 +137,11 @@ class AvailabilitySync {
           const existsInRadarr = await this.mediaExistsInRadarr(media, false);
           const existsInRadarr4k = await this.mediaExistsInRadarr(media, true);
 
-          if (media.status4k === MediaStatus.AVAILABLE) {
-            logger.debug(
-              `Radarr check results for movie [TMDB ID ${media.tmdbId}]`,
-              {
-                label: 'AvailabilitySync',
-                existsInRadarr,
-                existsInRadarr4k,
-              }
-            );
-          }
-
           // plex
           if (mediaServerType === MediaServerType.PLEX) {
             const { existsInPlex } = await this.mediaExistsInPlex(media, false);
             const { existsInPlex: existsInPlex4k } =
               await this.mediaExistsInPlex(media, true);
-
-            if (media.status4k === MediaStatus.AVAILABLE) {
-              logger.debug(
-                `Plex check results for movie [TMDB ID ${media.tmdbId}]`,
-                {
-                  label: 'AvailabilitySync',
-                  existsInPlex,
-                  existsInPlex4k,
-                  ratingKey: media.ratingKey,
-                  ratingKey4k: media.ratingKey4k,
-                }
-              );
-            }
 
             if (existsInPlex || existsInRadarr) {
               movieExists = true;
@@ -188,8 +149,6 @@ class AvailabilitySync {
                 `The non-4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
                 {
                   label: 'AvailabilitySync',
-                  existsInPlex,
-                  existsInRadarr,
                 }
               );
             }
@@ -200,18 +159,6 @@ class AvailabilitySync {
                 `The 4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
                 {
                   label: 'AvailabilitySync',
-                  existsInPlex4k,
-                  existsInRadarr4k,
-                }
-              );
-            } else {
-              logger.debug(
-                `4K movie [TMDB ID ${media.tmdbId}] not found in Plex or Radarr - will be marked as deleted`,
-                {
-                  label: 'AvailabilitySync',
-                  existsInPlex4k,
-                  existsInRadarr4k,
-                  ratingKey4k: media.ratingKey4k,
                 }
               );
             }
@@ -760,18 +707,6 @@ class AvailabilitySync {
           const is4kMovie =
             resolution?.length === 2 && Number(resolution[0]) >= 2000;
           existsInRadarr = is4k ? is4kMovie : !is4kMovie;
-
-          if (is4k && media.status4k === MediaStatus.AVAILABLE) {
-            logger.debug(
-              `Radarr movie found for 4K movie [TMDB ID ${media.tmdbId}]`,
-              {
-                label: 'AvailabilitySync',
-                hasFile: radarr.hasFile,
-                resolution: radarr?.movieFile?.mediaInfo?.resolution,
-                is4kMovie,
-              }
-            );
-          }
         }
       } catch (ex) {
         if (!ex.message.includes('404')) {
@@ -787,17 +722,6 @@ class AvailabilitySync {
           );
         }
       }
-    }
-
-    if (is4k && media.status4k === MediaStatus.AVAILABLE) {
-      logger.debug(
-        `Radarr check result for 4K movie [TMDB ID ${media.tmdbId}]: ${
-          existsInRadarr ? 'EXISTS' : 'NOT FOUND'
-        }`,
-        {
-          label: 'AvailabilitySync',
-        }
-      );
     }
 
     return existsInRadarr;
@@ -934,20 +858,6 @@ class AvailabilitySync {
     let existsInPlex = false;
     let preventSeasonSearch = false;
 
-    if (
-      is4k &&
-      media.mediaType === 'movie' &&
-      media.status4k === MediaStatus.AVAILABLE
-    ) {
-      logger.debug(
-        `Checking if 4K movie [TMDB ID ${media.tmdbId}] exists in Plex`,
-        {
-          label: 'AvailabilitySync',
-          ratingKey4k,
-        }
-      );
-    }
-
     // Check each plex instance to see if the media still exists
     // If found, we will assume the media exists and prevent removal
     // We can use the cache we built when we fetched the series with mediaExistsInPlex
@@ -961,28 +871,6 @@ class AvailabilitySync {
           this.plexSeasonsCache[ratingKey] =
             await this.plexClient?.getChildrenMetadata(ratingKey);
         }
-
-        if (
-          plexMedia &&
-          media.mediaType === 'movie' &&
-          media.status4k === MediaStatus.AVAILABLE
-        ) {
-          const mediaDetails = plexMedia.Media?.map((m) => ({
-            width: m.width,
-            height: m.height,
-            videoResolution: m.videoResolution,
-            is4kByWidth: (m.width ?? 0) >= 2000,
-          }));
-
-          logger.debug(
-            `Plex metadata for non-4K movie [TMDB ID ${media.tmdbId}] using ratingKey`,
-            {
-              label: 'AvailabilitySync',
-              ratingKey,
-              mediaDetails,
-            }
-          );
-        }
       }
 
       if (ratingKey4k && is4k) {
@@ -993,57 +881,29 @@ class AvailabilitySync {
             await this.plexClient?.getChildrenMetadata(ratingKey4k);
         }
 
-        if (plexMedia) {
-          if (
-            media.mediaType === 'movie' &&
-            media.status4k === MediaStatus.AVAILABLE
-          ) {
-            const mediaDetails = plexMedia.Media?.map((m) => ({
-              width: m.width,
-              height: m.height,
-              videoResolution: m.videoResolution,
-              is4kByWidth: (m.width ?? 0) >= 2000,
-            }));
+        if (plexMedia && media.mediaType === 'movie') {
+          const has4kByWidth = plexMedia.Media?.some(
+            (mediaItem) => (mediaItem.width ?? 0) >= 2000
+          );
 
-            const has4kByWidth = plexMedia.Media?.some(
-              (mediaItem) => (mediaItem.width ?? 0) >= 2000
-            );
+          if (is4k) {
+            if (ratingKey === ratingKey4k || !has4kByWidth) {
+              plexMedia = undefined;
+            }
+          } else {
             const hasNon4kByWidth = plexMedia.Media?.some(
               (mediaItem) =>
                 (mediaItem.width ?? 0) < 2000 && (mediaItem.width ?? 0) > 0
             );
-
-            logger.debug(
-              `Plex metadata for 4K movie [TMDB ID ${media.tmdbId}] using ratingKey4k`,
-              {
-                label: 'AvailabilitySync',
-                ratingKey,
-                ratingKey4k,
-                has4kByWidth,
-                hasNon4kByWidth,
-                mediaDetails,
-              }
-            );
+            if (!hasNon4kByWidth && has4kByWidth) {
+              plexMedia = undefined;
+            }
           }
         }
       }
 
       if (plexMedia) {
         existsInPlex = true;
-      } else {
-        if (
-          is4k &&
-          media.mediaType === 'movie' &&
-          media.status4k === MediaStatus.AVAILABLE
-        ) {
-          logger.debug(
-            `No Plex metadata found for 4K movie [TMDB ID ${media.tmdbId}] using ratingKey4k`,
-            {
-              label: 'AvailabilitySync',
-              ratingKey4k,
-            }
-          );
-        }
       }
     } catch (ex) {
       if (!ex.message.includes('404')) {

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -881,21 +881,27 @@ class AvailabilitySync {
             await this.plexClient?.getChildrenMetadata(ratingKey4k);
         }
 
-        if (plexMedia && media.mediaType === 'movie') {
-          const has4kByWidth = plexMedia.Media?.some(
-            (mediaItem) => (mediaItem.width ?? 0) >= 2000
-          );
-
-          if (is4k) {
-            if (ratingKey === ratingKey4k || !has4kByWidth) {
-              plexMedia = undefined;
-            }
-          } else {
-            const hasNon4kByWidth = plexMedia.Media?.some(
-              (mediaItem) =>
-                (mediaItem.width ?? 0) < 2000 && (mediaItem.width ?? 0) > 0
+        if (plexMedia) {
+          if (media.mediaType === 'movie') {
+            const has4kByWidth = plexMedia.Media?.some(
+              (mediaItem) => (mediaItem.width ?? 0) >= 2000
             );
-            if (!hasNon4kByWidth && has4kByWidth) {
+
+            if (is4k) {
+              if (ratingKey === ratingKey4k || !has4kByWidth) {
+                plexMedia = undefined;
+              }
+            } else {
+              const hasNon4kByWidth = plexMedia.Media?.some(
+                (mediaItem) =>
+                  (mediaItem.width ?? 0) < 2000 && (mediaItem.width ?? 0) > 0
+              );
+              if (!hasNon4kByWidth && has4kByWidth) {
+                plexMedia = undefined;
+              }
+            }
+          } else if (media.mediaType === 'tv' && is4k) {
+            if (ratingKey === ratingKey4k) {
               plexMedia = undefined;
             }
           }


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Fixes #XXXX

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
