### PR TITLE
fix(availability-sync): fix 4K media availability detection

### DIFF
--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -818,20 +818,46 @@ class AvailabilitySync {
         }
 
         if (plexMedia) {
-          // For 4K: ratingKey4k must be different from ratingKey
           if (ratingKey === ratingKey4k) {
             plexMedia = undefined;
           }
 
-          // For movies: verify it actually has 4K resolution
           if (
-            media.mediaType === 'movie' &&
             plexMedia &&
+            media.mediaType === 'movie' &&
             !plexMedia.Media?.some(
               (mediaItem) => (mediaItem.width ?? 0) >= 2000
             )
           ) {
             plexMedia = undefined;
+          }
+
+          if (plexMedia && media.mediaType === 'tv') {
+            const cachedSeasons = this.plexSeasonsCache[ratingKey4k];
+            if (cachedSeasons?.length) {
+              let has4kInAnySeason = false;
+              for (const season of cachedSeasons) {
+                try {
+                  const episodes = await this.plexClient?.getChildrenMetadata(
+                    season.ratingKey
+                  );
+                  const has4kEpisode = episodes?.some((episode) =>
+                    episode.Media?.some(
+                      (mediaItem) => (mediaItem.width ?? 0) >= 2000
+                    )
+                  );
+                  if (has4kEpisode) {
+                    has4kInAnySeason = true;
+                    break;
+                  }
+                } catch {
+                  // If we can't fetch episodes for a season, continue checking other seasons
+                }
+              }
+              if (!has4kInAnySeason) {
+                plexMedia = undefined;
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes an issue where 4K content was incorrectly shown as available after deletion when 4K and 1080p versions were stored in the same Plex library.

We now verify that:
- `ratingKey4k` points to a separate item from ratingKey (ensures they're distinct items)
- For movies: the media has 4K resolution (width >= 2000)
- For TV shows: at least one season has 4K episodes (width >= 2000)

If the `ratingKey` remains the same after deletion, it now checks the actual resolution before marking content as 4K available, preventing false positives when 4K content is deleted but the 1080p version remains.

- Fixes #XXXX

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See this [ticket](https://discord.com/channels/783137440809746482/1459928214087536778)


## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
