### PR TITLE
fix(pushover): prevent notifications when agent is disabled or unconfigured

### DIFF
--- a/server/lib/notifications/agents/pushover.ts
+++ b/server/lib/notifications/agents/pushover.ts
@@ -45,7 +45,17 @@ class PushoverAgent
   }
 
   public shouldSend(): boolean {
-    return true;
+    const settings = this.getSettings();
+
+    if (
+      settings.enabled &&
+      settings.options.accessToken &&
+      settings.options.userToken
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   private async getImagePayload(

--- a/src/components/Settings/Notifications/NotificationsPushover/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsPushover/index.tsx
@@ -49,7 +49,12 @@ const NotificationsPushover = () => {
   const { data: soundsData } = useSWR<PushoverSound[]>(
     data?.options.accessToken
       ? `/api/v1/settings/notifications/pushover/sounds?token=${data.options.accessToken}`
-      : null
+      : null,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      shouldRetryOnError: false,
+    }
   );
 
   const NotificationsPushoverSchema = Yup.object().shape({


### PR DESCRIPTION
## Description

Fixes an issue where Pushover notifications were being sent even when the agent was disabled or configuration was cleared. The validation now ensures notifications are only attempted when the agent is enabled and both tokens are configured. Also adds SWR options to prevent the frontend from spamming the Pushover sounds endpoint on window focus, reconnect, or after errors.

- Fixes #1854

## How Has This Been Tested?

- [X] Configured Pushover with an invalid token and verified the sounds endpoint is no longer spammed on window focus/tab switch
- [X] Disabled Pushover agent and confirmed test notifications are no longer sent
- [X] Cleared Pushover configuration and verified notifications don't attempt to send
- [ ] Enabled agent with valid tokens and confirmed notifications still work as expected (Cant test this as i do not use pushover but should work as intended)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
