### PR TITLE
fix(ui): correct season pluralisation in RequestCard

### DIFF
--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -5,7 +5,6 @@ import Tooltip from '@app/components/Common/Tooltip';
 import RequestModal from '@app/components/RequestModal';
 import StatusBadge from '@app/components/StatusBadge';
 import useDeepLinks from '@app/hooks/useDeepLinks';
-import useSettings from '@app/hooks/useSettings';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
@@ -219,7 +218,6 @@ interface RequestCardProps {
 }
 
 const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
-  const settings = useSettings();
   const { ref, inView } = useInView({
     triggerOnce: true,
   });
@@ -402,14 +400,7 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
             <div className="my-0.5 hidden items-center text-sm sm:my-1 sm:flex">
               <span className="mr-2 font-bold ">
                 {intl.formatMessage(messages.seasons, {
-                  seasonCount:
-                    (settings.currentSettings.enableSpecialEpisodes
-                      ? title.seasons.length
-                      : title.seasons.filter(
-                          (season) => season.seasonNumber !== 0
-                        ).length) === request.seasons.length
-                      ? 0
-                      : request.seasons.length,
+                  seasonCount: request.seasons.length,
                 })}
               </span>
               <div className="hide-scrollbar overflow-x-scroll">


### PR DESCRIPTION
## Description
Fixes the season label pluralization on request cards where single-season requests incorrectly displayed "Seasons 1" instead of "Season 1". The previous logic passed 0 to the ICU plural formatter when all seasons were requested, which always resolved to the plural form regardless of actual count. The label now properly reflects singular vs plural based on how many seasons were actually requested.

- Fixes #2263

## How Has This Been Tested?

- Request single season (singular)
- Request multiple seasons (plural)

## Screenshots / Logs (if applicable)
<img width="1212" height="412" alt="image" src="https://github.com/user-attachments/assets/280ba593-83c4-4af7-89f4-a812c24ed978" />

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
