### PR TITLE
fix(base-scanner): fix PROCESSING status persisting for unmonitored seasons

### DIFF
--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -332,6 +332,11 @@ class BaseScanner<T> {
                 season.processing &&
                 existingSeason.status !== MediaStatus.DELETED
               ? MediaStatus.PROCESSING
+              : !season.is4kOverride &&
+                !season.processing &&
+                season.episodes === 0 &&
+                existingSeason.status === MediaStatus.PROCESSING
+              ? MediaStatus.UNKNOWN
               : existingSeason.status;
 
           // Same thing here, except we only do updates if 4k is enabled
@@ -347,6 +352,11 @@ class BaseScanner<T> {
                 season.processing &&
                 existingSeason.status4k !== MediaStatus.DELETED
               ? MediaStatus.PROCESSING
+              : season.is4kOverride &&
+                !season.processing &&
+                season.episodes4k === 0 &&
+                existingSeason.status4k === MediaStatus.PROCESSING
+              ? MediaStatus.UNKNOWN
               : existingSeason.status4k;
         } else {
           newSeasons.push(


### PR DESCRIPTION


## Description

BaseScanner's fallthrough logic was preventing unmonitored seasons from resetting to UNKNOWN status. When SonarrScanner detected an unmonitored season, BaseScanner was preserving the existing PROCESSING status instead of resetting it.

This PR adds explicit logic to detect when a season is no longer being processed and resets the status to UNKNOWN, making it requestable again.

- Fixes #2310
- Fixes #1972

## How Has This Been Tested?

(Not tested by me. Can be tested using `:preview-unmonitored-season-processing`
Steps to test:)
1. Add a TV show to Sonarr with Season 1 monitored (no files)
2. Run Sonarr scan. This should set Season 1 status to PROCESSING
3. Now unmonitor Season 1 in Sonarr
4. Run Sonarr scan. This should now properly set Season 1 status to UNKNOWN 
5. Verify whether season is now requestable in UI 

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
