### PR TITLE
fix(sonarr): re-monitor episodes when re-requesting deleted but monitored seasons

### DIFF
--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -209,6 +209,34 @@ class SonarrAPI extends ServarrBase<{
             series: newSeriesResponse.data,
           });
 
+          try {
+            const episodes = await this.getEpisodes(newSeriesResponse.data.id);
+            const episodeIdsToMonitor = episodes
+              .filter(
+                (ep) =>
+                  options.seasons.includes(ep.seasonNumber) && !ep.monitored
+              )
+              .map((ep) => ep.id);
+
+            if (episodeIdsToMonitor.length > 0) {
+              logger.debug(
+                'Re-monitoring unmonitored episodes for requested seasons.',
+                {
+                  label: 'Sonarr',
+                  seriesId: newSeriesResponse.data.id,
+                  episodeCount: episodeIdsToMonitor.length,
+                }
+              );
+              await this.monitorEpisodes(episodeIdsToMonitor);
+            }
+          } catch (e) {
+            logger.warn('Failed to re-monitor episodes', {
+              label: 'Sonarr',
+              errorMessage: e.message,
+              seriesId: newSeriesResponse.data.id,
+            });
+          }
+
           if (options.searchNow) {
             this.searchSeries(newSeriesResponse.data.id);
           }
@@ -315,6 +343,38 @@ class SonarrAPI extends ServarrBase<{
           seriesId,
         }
       );
+    }
+  }
+
+  public async getEpisodes(seriesId: number): Promise<EpisodeResult[]> {
+    try {
+      const response = await this.axios.get<EpisodeResult[]>('/episode', {
+        params: { seriesId },
+      });
+      return response.data;
+    } catch (e) {
+      logger.error('Failed to retrieve episodes', {
+        label: 'Sonarr API',
+        errorMessage: e.message,
+        seriesId,
+      });
+      throw new Error('Failed to get episodes');
+    }
+  }
+
+  public async monitorEpisodes(episodeIds: number[]): Promise<void> {
+    try {
+      await this.axios.put('/episode/monitor', {
+        episodeIds,
+        monitored: true,
+      });
+    } catch (e) {
+      logger.error('Failed to monitor episodes', {
+        label: 'Sonarr API',
+        errorMessage: e.message,
+        episodeIds,
+      });
+      throw new Error('Failed to monitor episodes');
     }
   }
 


### PR DESCRIPTION
## Description

When a user has media that was previously available and then deletes the files, Sonarr's "Unmonitor Deleted Episodes" feature automatically unmonitors the individual episodes while leaving the parent season in a monitored state. This creates an edge case where re-requesting the season through Seerr fails to grab any episodes.

The issue occurs because Seerr sets the season's monitored flag to true, but Sonarr only cascades monitoring state changes down to episodes when it detects an actual change. Since the season is already monitored, Sonarr treats this as a no-op and the episodes remain unmonitored. The search command executes but finds nothing to grab because all episodes are unmonitored at the individual level.

This PR adds explicit episode-level monitoring when updating an existing series. After the series update succeeds and before triggering a search, we now fetch all episodes for the requested seasons and re-monitor any that are currently unmonitored. This ensures that re-requests work correctly regardless of whether the season state changed or episodes were previously unmonitored due to file deletion.

- Fixes #2309

## How Has This Been Tested?
(I have not tested this. Can be tested via the image `:preview-remonitor-sonarr-episodes`. Steps to test:)
1. Add a series with a season in Sonarr, ensure files are available
2. Enable "Unmonitor Deleted Episodes" in Sonarr's Media Management settings
3. Delete the season folder from disk
4. Run a disk scan in Sonarr, confirm episodes become unmonitored while season stays monitored
5. Run media availability sync in Seerr, confirm status changes to "deleted"
6. Re-request the season through Seerr
7. Confirm episodes are now monitored in Sonarr and search is triggered

## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
