### PR TITLE
fix(mediarequest): explicitly set mediaId when creating request 

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -333,7 +333,9 @@ export class MediaRequest {
       await mediaRepository.save(media);
 
       if (!media.id) {
-        throw new Error('Failed to save media before creating request.');
+        throw new Error(
+          `Failed to save media before creating request. Media type: ${requestBody.mediaType}, TMDB ID: ${requestBody.mediaId}, persisted media id: ${media.id}`
+        );
       }
 
       const request = new MediaRequest({
@@ -448,7 +450,9 @@ export class MediaRequest {
       await mediaRepository.save(media);
 
       if (!media.id) {
-        throw new Error('Failed to save media before creating request.');
+        throw new Error(
+          `Failed to save media before creating request. Media type: TV, TMDB ID: ${requestBody.mediaId}, is4k: ${requestBody.is4k}`
+        );
       }
 
       const request = new MediaRequest({


### PR DESCRIPTION
## Description
Fixes an intermittent issue where `media_request` records were being created with `mediaId = NULL`, causing a `TypeError: can't access property "tmdbId", P.media is null` crash on the user profile page. 

The underlying cause is TypeORM's implicit relation-to-foreign-key mapping failing intermittently when creating a `MediaRequest` with a `media` object reference. The media record was being saved successfully (confirmed by timestamp correlation within milliseconds, see #2315), but the `mediaId` foreign key wasn't being written to the request.

This PR adds an explicit `mediaId` column to the entity and sets it directly from `media.id` after save, bypassing TypeORM's implicit behavior, along with a guard check that throws early if the media save fails to return an ID.

- Fixes #2315
- Ref https://github.com/sct/overseerr/pull/4100 (This seems to be the underlying issue that caused some requests can lose their associated media relation CC: @OwsleyJr)

## How Has This Been Tested?

- The issue is intermittent. Can't really reproduce reliably it happens every now and then.
- Therefore, I tested whether requests still work or not.
- It still works

## Screenshots / Logs (if applicable)

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
~~- [ ] Translation keys `pnpm i18n:extract`~~
~~- [ ] Database migration (if required)~~
