### PR TITLE
fix(availability-sync): remove incorrect existence flags for media in Radarr, Sonarr, and Plex

### DIFF
--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -646,7 +646,6 @@ class AvailabilitySync {
         }
       } catch (ex) {
         if (!ex.message.includes('404')) {
-          existsInRadarr = true;
           logger.debug(
             `Failure retrieving the ${is4k ? '4K' : 'non-4K'} movie [TMDB ID ${
               media.tmdbId
@@ -700,7 +699,6 @@ class AvailabilitySync {
         }
       } catch (ex) {
         if (!ex.message.includes('404')) {
-          existsInSonarr = true;
           preventSeasonSearch = true;
           logger.debug(
             `Failure retrieving the ${is4k ? '4K' : 'non-4K'} show [TMDB ID ${
@@ -820,10 +818,21 @@ class AvailabilitySync {
 
       if (plexMedia) {
         existsInPlex = true;
+        logger.debug(
+          `Found ${is4k ? '4K' : 'non-4K'} ${
+            media.mediaType === 'tv' ? 'show' : 'movie'
+          } [TMDB ID ${media.tmdbId}] in Plex`,
+          {
+            ratingKey: is4k ? ratingKey4k : ratingKey,
+            plexTitle: plexMedia.title,
+            plexRatingKey: plexMedia.ratingKey,
+            plexGuid: plexMedia.guid,
+            label: 'Availability Sync',
+          }
+        );
       }
     } catch (ex) {
       if (!ex.message.includes('404')) {
-        existsInPlex = true;
         preventSeasonSearch = true;
         logger.debug(
           `Failure retrieving the ${is4k ? '4K' : 'non-4K'} ${


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is an attempt to fix a bug where non-404 errors when checking Plex/Radarr/Sonarr incorrectly set `existsIn* = true`, preventing deleted media from being marked as unavailable.

- Fixes #XXXX

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)