### PR TITLE
fix(availability-sync): handle resolution check for single-server setups

### DIFF
--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -612,8 +612,12 @@ class AvailabilitySync {
   ): Promise<boolean> {
     let existsInRadarr = false;
 
-    const has4kServer = this.radarrServers.some((s) => s.is4k);
-    const hasNon4kServer = this.radarrServers.some((s) => !s.is4k);
+    const hasSameServerInBothModes = this.radarrServers.some((a) =>
+      this.radarrServers.some(
+        (b) =>
+          a.is4k !== b.is4k && a.hostname === b.hostname && a.port === b.port
+      )
+    );
 
     // Check for availability in all of the available radarr servers
     // If any find the media, we will assume the media exists
@@ -646,8 +650,8 @@ class AvailabilitySync {
           const is4kMovie =
             resolution?.length === 2 && Number(resolution[0]) >= 2000;
 
-          if (has4kServer && hasNon4kServer) {
-            // Both server types then use resolution to distinguish
+          if (hasSameServerInBothModes && resolution?.length === 2) {
+            // Same server in both modes then use resolution to distinguish
             existsInRadarr = is4k ? is4kMovie : !is4kMovie;
           } else {
             // One server type and if file exists, count it


### PR DESCRIPTION
## Description
PR #1543 introduced resolution checking to check 4k from non4k media when users have both server types configured with the same service. This caused a regression as this causes false deletions for users with only a single non4k service when radarr upgrades file to 4k resolution. 

This PR only applies resolution to checking when both 4k and non4k servers are configured. Otherwise then if file exists then it counts as available.

## How Has This Been Tested?
- Have one non-4k Radarr service
- Upgrade movie from 1080p -> 4k
- Run media availability sync job
- Regression no longer occurs

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
