### PR TITLE
fix(collection): allow re-request of deleted items in a collection

### DIFF
--- a/src/components/CollectionDetails/index.tsx
+++ b/src/components/CollectionDetails/index.tsx
@@ -134,7 +134,10 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
       type: 'or',
     }) &&
     data.parts.filter(
-      (part) => !part.mediaInfo || part.mediaInfo.status === MediaStatus.UNKNOWN
+      (part) =>
+        !part.mediaInfo ||
+        part.mediaInfo.status === MediaStatus.DELETED ||
+        part.mediaInfo.status === MediaStatus.UNKNOWN
     ).length > 0;
 
   const hasRequestable4k =
@@ -144,7 +147,9 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
     }) &&
     data.parts.filter(
       (part) =>
-        !part.mediaInfo || part.mediaInfo.status4k === MediaStatus.UNKNOWN
+        !part.mediaInfo ||
+        part.mediaInfo.status4k === MediaStatus.DELETED ||
+        part.mediaInfo.status4k === MediaStatus.UNKNOWN
     ).length > 0;
 
   const collectionAttributes: React.ReactNode[] = [];


### PR DESCRIPTION
## Description

Fix an issue where re-requesting an entire collection or some items of a collection is not possible if these items have been deleted.

- Fixes #1749

## How Has This Been Tested?

- Have a collection with some deleted items
- Try to request the items from the Request Collection modal
- Fails

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
