### PR TITLE
revert(media-request): revert #2316 explicitly setting the mediaId when creating request

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -332,16 +332,9 @@ export class MediaRequest {
     if (requestBody.mediaType === MediaType.MOVIE) {
       await mediaRepository.save(media);
 
-      if (!media.id) {
-        throw new Error(
-          `Failed to save media before creating request. Media type: ${requestBody.mediaType}, TMDB ID: ${requestBody.mediaId}, persisted media id: ${media.id}`
-        );
-      }
-
       const request = new MediaRequest({
         type: MediaType.MOVIE,
         media,
-        mediaId: media.id,
         requestedBy: requestUser,
         // If the user is an admin or has the "auto approve" permission, automatically approve the request
         status: user.hasPermission(
@@ -449,16 +442,9 @@ export class MediaRequest {
 
       await mediaRepository.save(media);
 
-      if (!media.id) {
-        throw new Error(
-          `Failed to save media before creating request. Media type: TV, TMDB ID: ${requestBody.mediaId}, is4k: ${requestBody.is4k}`
-        );
-      }
-
       const request = new MediaRequest({
         type: MediaType.TV,
         media,
-        mediaId: media.id,
         requestedBy: requestUser,
         // If the user is an admin or has the "auto approve" permission, automatically approve the request
         status: user.hasPermission(
@@ -534,9 +520,6 @@ export class MediaRequest {
     onDelete: 'CASCADE',
   })
   public media: Media;
-
-  @Column({ name: 'mediaId', nullable: true })
-  public mediaId: number;
 
   @ManyToOne(() => User, (user) => user.requests, {
     eager: true,


### PR DESCRIPTION
## Description

This just reverts #2316. A further description is not required at this point. I'm reverting #2316 and I will be running #2356 personally with all the verbose logging in it to try and debug what and where the issue comes from.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
