### PR TITLE
fix(webpush): avoid querying push subs with empty user list

### DIFF
--- a/server/lib/notifications/agents/webpush.ts
+++ b/server/lib/notifications/agents/webpush.ts
@@ -260,13 +260,16 @@ class WebPushAgent
           shouldSendAdminNotification(type, user, payload)
       );
 
-      const allSubs = await userPushSubRepository
-        .createQueryBuilder('pushSub')
-        .leftJoinAndSelect('pushSub.user', 'user')
-        .where('pushSub.userId IN (:...users)', {
-          users: manageUsers.map((user) => user.id),
-        })
-        .getMany();
+      const allSubs =
+        manageUsers.length > 0
+          ? await userPushSubRepository
+              .createQueryBuilder('pushSub')
+              .leftJoinAndSelect('pushSub.user', 'user')
+              .where('pushSub.userId IN (:...users)', {
+                users: manageUsers.map((user) => user.id),
+              })
+              .getMany()
+          : [];
 
       // We only want to send the custom notification when type is approved or declined
       // Otherwise, default to the normal notification


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When the only admin is the requester for `MEDIA_AUTO_APPROVED`, `manageUsers`
is empty. Skip the push-subscription query and use `[]` instead of `IN ()`,
which was causing a PostgreSQL syntax error.

- Fixes #XXXX

## How Has This Been Tested?

- Made a request as admin.
- Request automatically approved.
- No syntax error.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
