### PR TITLE
ci(workflow): add i18n label check to avoid duplicate comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       - name: i18n Check
         shell: bash
         env:
+          I18N_LABEL: i18n-out-of-sync
           BODY: |
             The i18n check failed because translation messages are out of sync.
 
@@ -75,16 +76,16 @@ jobs:
             Please run `pnpm i18n:extract` and commit the changes.
         run: |
           retry() { n=0; until "$@"; do n=$((n+1)); [ $n -ge 3 ] && break; echo "retry $n: $*" >&2; sleep 2; done; }
-          node bin/check-i18n.js
-          check_failed=$?
-          if [ $check_failed -eq 1 ]; then
-            retry gh pr edit "$NUMBER" -R "$GH_REPO" --add-label "i18n-out-of-sync" || true
-            retry gh pr comment "$NUMBER" -R "$GH_REPO" -b "$BODY" || true
+          check_failed=0; node bin/check-i18n.js || check_failed=$?
+          pr_labels=$(gh pr view "$NUMBER" -R "$GH_REPO" --json labels -q '.labels[].name' 2>/dev/null) || true
+          has_label=0
+          while IFS= read -r name; do [ -n "$name" ] && [ "$name" = "$I18N_LABEL" ] && has_label=1 && break; done <<< "$pr_labels"
+          if [ "$check_failed" -eq 1 ]; then
+            [ "$has_label" -eq 0 ] && { retry gh pr edit "$NUMBER" -R "$GH_REPO" --add-label "$I18N_LABEL" || true; retry gh pr comment "$NUMBER" -R "$GH_REPO" -b "$BODY" || true; }
           else
-            retry gh pr edit "$NUMBER" -R "$GH_REPO" --remove-label "i18n-out-of-sync" || true
+            [ "$has_label" -eq 1 ] && retry gh pr edit "$NUMBER" -R "$GH_REPO" --remove-label "$I18N_LABEL" || true
           fi
           exit $check_failed
-
   test:
     name: Lint & Test Build
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes an issue where the i18n check job was posting the same "translations out of sync" comment and re-adding the `i18n-out-of-sync` label on every run. The label was also being removed even when it didn't exist.

- Fixes #XXXX

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
