### PR TITLE
feat(notifications): Play On Media Server in notification

### DIFF
--- a/server/lib/notifications/agents/email.ts
+++ b/server/lib/notifications/agents/email.ts
@@ -21,6 +21,11 @@ class EmailAgent
   extends BaseAgent<NotificationAgentEmail>
   implements NotificationAgent
 {
+  /**
+   * Returns this agents notification settings
+   * Uses a cached copy when available
+   * @protected
+   */
   protected getSettings(): NotificationAgentEmail {
     if (this.settings) {
       return this.settings;
@@ -31,6 +36,10 @@ class EmailAgent
     return settings.notifications.agents.email;
   }
 
+  /**
+   * Determines whether this agent is able to send email notifications
+   * Returns true only if the agent is enabled and the required SMTP settings are configured
+   */
   public shouldSend(): boolean {
     const settings = this.getSettings();
 
@@ -47,12 +56,15 @@ class EmailAgent
   }
 
   /**
+   * Builds the email payload for an email notification
    *
+   * For all notifications it has a button to take you to the media in Seerr
+   * For request notifications it includes a button that links to the media in the chosen media server
    * @param type Type of notification being sent
    * @param payload Notification context
    * @param recipientEmail The recipient's email address
    * @param recipientName The recipient's name
-   * @returns Email options to be used by the email creator, or undefined if it's not applicable
+   * @returns Email notification payload
    * @private
    */
   private buildMessage(
@@ -214,7 +226,9 @@ class EmailAgent
   }
 
   /**
+   * Sends an email notification to the recipients in the payload.
    *
+   * Respects per-user notification settings, and it validates the email address before sending the notification
    * @param type The type of notification being sent
    * @param payload Notification context
    * @returns True if the notification has successfully sent, else returns False

--- a/server/lib/notifications/agents/email.ts
+++ b/server/lib/notifications/agents/email.ts
@@ -168,9 +168,7 @@ class EmailAgent
           applicationTitle,
           recipientName,
           recipientEmail,
-          mediaServerActionUrl: mediaServerUrl
-            ? `${mediaServerUrl}`
-            : undefined,
+          mediaServerActionUrl: mediaServerUrl,
           mediaServerName,
         },
       };

--- a/server/lib/notifications/agents/email.ts
+++ b/server/lib/notifications/agents/email.ts
@@ -46,6 +46,15 @@ class EmailAgent
     return false;
   }
 
+  /**
+   *
+   * @param type Type of notification being sent
+   * @param payload Notification context
+   * @param recipientEmail The recipient's email address
+   * @param recipientName The recipient's name
+   * @returns Email options to be used by the email creator, or undefined if it's not applicable
+   * @private
+   */
   private buildMessage(
     type: Notification,
     payload: NotificationPayload,
@@ -204,6 +213,12 @@ class EmailAgent
     return undefined;
   }
 
+  /**
+   *
+   * @param type The type of notification being sent
+   * @param payload Notification context
+   * @returns True if the notification has successfully sent, else returns False
+   */
   public async send(
     type: Notification,
     payload: NotificationPayload

--- a/server/lib/notifications/agents/email.ts
+++ b/server/lib/notifications/agents/email.ts
@@ -1,12 +1,15 @@
 import { IssueType, IssueTypeName } from '@server/constants/issue';
 import { MediaType } from '@server/constants/media';
-import { MediaServerType } from '@server/constants/server';
 import { getRepository } from '@server/datasource';
 import { User } from '@server/entity/User';
 import PreparedEmail from '@server/lib/email';
 import type { NotificationAgentEmail } from '@server/lib/settings';
 import { NotificationAgentKey, getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
+import {
+  getAvailableMediaServerName,
+  getAvailableMediaServerUrl,
+} from '@server/utils/mediaServerHelper';
 import type { EmailOptions } from 'email-templates';
 import path from 'path';
 import validator from 'validator';
@@ -52,30 +55,8 @@ class EmailAgent
     const settings = getSettings();
     const { applicationUrl, applicationTitle, mediaServerType } = settings.main;
     const { embedPoster } = settings.notifications.agents.email;
-
-    function getAvailableMediaServerName() {
-      if (mediaServerType === MediaServerType.EMBY) {
-        return 'Emby';
-      }
-
-      if (mediaServerType === MediaServerType.PLEX) {
-        return 'Plex';
-      }
-
-      return 'Jellyfin';
-    }
-
-    const mediaServerName = getAvailableMediaServerName();
-
-    function getAvailableMediaServerUrl(): string | undefined {
-      const wants4k = payload.request?.is4k;
-      const url4k = (payload.media as any)?.mediaUrl4k as string | undefined;
-      const url = (payload.media as any)?.mediaUrl as string | undefined;
-
-      return (wants4k ? (url4k ?? url) : (url ?? url4k)) || undefined;
-    }
-
-    const mediaServerUrl = getAvailableMediaServerUrl();
+    const mediaServerName = getAvailableMediaServerName(mediaServerType);
+    const mediaServerUrl = getAvailableMediaServerUrl(payload);
 
     if (type === Notification.TEST_NOTIFICATION) {
       return {

--- a/server/lib/notifications/agents/email.ts
+++ b/server/lib/notifications/agents/email.ts
@@ -74,10 +74,8 @@ class EmailAgent
     recipientName?: string
   ): EmailOptions | undefined {
     const settings = getSettings();
-    const { applicationUrl, applicationTitle, mediaServerType } = settings.main;
+    const { applicationUrl, applicationTitle } = settings.main;
     const { embedPoster } = settings.notifications.agents.email;
-    const mediaServerName = getAvailableMediaServerName(mediaServerType);
-    const mediaServerUrl = getAvailableMediaServerUrl(payload);
 
     if (type === Notification.TEST_NOTIFICATION) {
       return {
@@ -144,6 +142,10 @@ class EmailAgent
           }:`;
           break;
       }
+
+      const { mediaServerType } = settings.main;
+      const mediaServerName = getAvailableMediaServerName(mediaServerType);
+      const mediaServerUrl = getAvailableMediaServerUrl(payload);
 
       return {
         template: path.join(

--- a/server/lib/notifications/agents/slack.ts
+++ b/server/lib/notifications/agents/slack.ts
@@ -53,6 +53,11 @@ class SlackAgent
   extends BaseAgent<NotificationAgentSlack>
   implements NotificationAgent
 {
+  /**
+   * Returns this agent's notification settings
+   * Uses a cached copy when available
+   * @protected
+   */
   protected getSettings(): NotificationAgentSlack {
     if (this.settings) {
       return this.settings;
@@ -64,7 +69,10 @@ class SlackAgent
   }
 
   /**
+   * Builds the Slack Embed for the Slack notification that will be sent
    *
+   * For all notifications it has a button to take you to the media in Seerr
+   * For request notifications it includes a button that links to the media in the chosen media server
    * @param type The type of notification being sent
    * @param payload Notification context
    * @returns The Slack embed payload
@@ -243,6 +251,10 @@ class SlackAgent
     };
   }
 
+  /**
+   * Determines whether this agent is able to send Slack notifications
+   * Returns true only if the agent is enabled and a webhook URL is configured
+   */
   public shouldSend(): boolean {
     const settings = this.getSettings();
 
@@ -254,10 +266,14 @@ class SlackAgent
   }
 
   /**
+   * Sends a Slack notification to the configured Slack webhook
+   *
+   * Returns true when notifications are skipped, disabled/type not enabled, or when the webhook call succeeds
+   * Returns false only when the webhook call fails
    *
    * @param type The type of notification being sent
    * @param payload Notification context
-   * @returns True if the notification was sent successfully, else returns False
+   * @returns True if the notification was sent successfully, otherwise False
    */
   public async send(
     type: Notification,

--- a/server/lib/notifications/agents/slack.ts
+++ b/server/lib/notifications/agents/slack.ts
@@ -63,6 +63,12 @@ class SlackAgent
     return settings.notifications.agents.slack;
   }
 
+  /**
+   *
+   * @param type The type of notification being sent
+   * @param payload Notification context
+   * @returns The Slack embed payload
+   */
   public buildEmbed(
     type: Notification,
     payload: NotificationPayload
@@ -247,6 +253,12 @@ class SlackAgent
     return false;
   }
 
+  /**
+   *
+   * @param type The type of notification being sent
+   * @param payload Notification context
+   * @returns True if the notification was sent successfully, else returns False
+   */
   public async send(
     type: Notification,
     payload: NotificationPayload

--- a/server/lib/notifications/agents/slack.ts
+++ b/server/lib/notifications/agents/slack.ts
@@ -191,22 +191,19 @@ class SlackAgent
           : undefined
       : undefined;
 
+    const actionElements: Element[] = [];
+
     if (url) {
-      blocks.push({
-        type: 'actions',
-        elements: [
-          {
-            action_id: 'open-in-seerr',
-            type: 'button',
-            url,
-            text: {
-              type: 'plain_text',
-              text: `View ${
-                payload.issue ? 'Issue' : 'Media'
-              } in ${applicationTitle}`,
-            },
-          },
-        ],
+      actionElements.push({
+        action_id: 'open-in-seerr',
+        type: 'button',
+        url,
+        text: {
+          type: 'plain_text',
+          text: `View ${
+            payload.issue ? 'Issue' : 'Media'
+          } in ${applicationTitle}`,
+        },
       });
     }
 
@@ -215,21 +212,23 @@ class SlackAgent
       const mediaServerUrl = getAvailableMediaServerUrl(payload);
 
       if (mediaServerUrl) {
-        blocks.push({
-          type: 'actions',
-          elements: [
-            {
-              action_id: 'open-in-mediaServer',
-              type: 'button',
-              url: mediaServerUrl,
-              text: {
-                type: 'plain_text',
-                text: `Play on ${mediaServerName}`,
-              },
-            },
-          ],
+        actionElements.push({
+          action_id: 'open-in-mediaServer',
+          type: 'button',
+          url: mediaServerUrl,
+          text: {
+            type: 'plain_text',
+            text: `Play on ${mediaServerName}`,
+          },
         });
       }
+    }
+
+    if (actionElements.length > 0) {
+      blocks.push({
+        type: 'actions',
+        elements: actionElements,
+      });
     }
 
     return {

--- a/server/lib/notifications/agents/slack.ts
+++ b/server/lib/notifications/agents/slack.ts
@@ -1,8 +1,11 @@
 import { IssueStatus, IssueTypeName } from '@server/constants/issue';
-import { MediaServerType } from '@server/constants/server';
 import type { NotificationAgentSlack } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
+import {
+  getAvailableMediaServerName,
+  getAvailableMediaServerUrl,
+} from '@server/utils/mediaServerHelper';
 import axios from 'axios';
 import { Notification, hasNotificationType } from '..';
 import type { NotificationAgent, NotificationPayload } from './agent';
@@ -67,26 +70,6 @@ class SlackAgent
     const settings = getSettings();
     const { applicationUrl, applicationTitle, mediaServerType } = settings.main;
     const { embedPoster } = settings.notifications.agents.slack;
-
-    function getAvailableMediaServerName() {
-      if (mediaServerType === MediaServerType.EMBY) {
-        return 'Emby';
-      }
-
-      if (mediaServerType === MediaServerType.PLEX) {
-        return 'Plex';
-      }
-
-      return 'Jellyfin';
-    }
-
-    function getAvailableMediaServerUrl(): string | undefined {
-      const wants4k = payload.request?.is4k;
-      const url4k = (payload.media as any)?.mediaUrl4k as string | undefined;
-      const url = (payload.media as any)?.mediaUrl as string | undefined;
-
-      return (wants4k ? (url4k ?? url) : (url ?? url4k)) || undefined;
-    }
 
     const fields: EmbedField[] = [];
 
@@ -228,8 +211,8 @@ class SlackAgent
     }
 
     if (!payload.issue) {
-      const mediaServerName = getAvailableMediaServerName();
-      const mediaServerUrl = getAvailableMediaServerUrl();
+      const mediaServerName = getAvailableMediaServerName(mediaServerType);
+      const mediaServerUrl = getAvailableMediaServerUrl(payload);
 
       if (mediaServerUrl) {
         blocks.push({

--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -65,6 +65,13 @@ class TelegramAgent
     return text ? text.replace(/[_*[\]()~>#+=|{}.!-]/gi, (x) => '\\' + x) : '';
   }
 
+  /**
+   *
+   * @param type The type of notification being sent
+   * @param payload Notification context
+   * @returns Telegram Notification Payload
+   * @private
+   */
   private getNotificationPayload(
     type: Notification,
     payload: NotificationPayload
@@ -169,6 +176,12 @@ class TelegramAgent
         };
   }
 
+  /**
+   *
+   * @param type The type of notification being sent
+   * @param payload Notification payload
+   * @returns True if the notification was sent successfully, else returns false
+   */
   public async send(
     type: Notification,
     payload: NotificationPayload

--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -78,7 +78,9 @@ class TelegramAgent
    * @private
    */
   private escapeText(text: string | undefined): string {
-    return text ? text.replace(/[_*[\]()~>#+=|{}.!-]/gi, (x) => '\\' + x) : '';
+    return text
+      ? text.replace(/[_*[\]()~`\\>#+=|{}.!-]/gi, (x) => '\\' + x)
+      : '';
   }
 
   /**

--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -42,7 +42,7 @@ class TelegramAgent
   private baseUrl = 'https://api.telegram.org/';
 
   /**
-   * Returns this agent's  notification settings.
+   * Returns this agent's notification settings.
    * Uses a cached copy when available.
    * @protected
    */

--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -41,6 +41,11 @@ class TelegramAgent
 {
   private baseUrl = 'https://api.telegram.org/';
 
+  /**
+   * Returns this agent's  notification settings.
+   * Uses a cached copy when available.
+   * @protected
+   */
   protected getSettings(): NotificationAgentTelegram {
     if (this.settings) {
       return this.settings;
@@ -51,6 +56,10 @@ class TelegramAgent
     return settings.notifications.agents.telegram;
   }
 
+  /**
+   * Determines whether this agent is able to send Telegram notifications
+   * Returns True only if Telegram notifications are enabled and the bot API token is filled in, else returns False
+   */
   public shouldSend(): boolean {
     const settings = this.getSettings();
 
@@ -61,15 +70,25 @@ class TelegramAgent
     return false;
   }
 
+  /**
+   * Escapes text for Telegram MarkdownV2
+   * Telegram requires some characters to be escaped to prevent any formatting issues
+   * @param text The unescaped input
+   * @returns Escaped text that is safe for MarkdownV2
+   * @private
+   */
   private escapeText(text: string | undefined): string {
     return text ? text.replace(/[_*[\]()~>#+=|{}.!-]/gi, (x) => '\\' + x) : '';
   }
 
   /**
+   * Builds the Telegram notification payload that will be sent
    *
+   * For all notifications it has a button to take you to the media in Seerr
+   * For request notifications it includes a button that links to the media in the chosen media server
    * @param type The type of notification being sent
    * @param payload Notification context
-   * @returns Telegram Notification Payload
+   * @returns Telegram notification payload
    * @private
    */
   private getNotificationPayload(
@@ -177,10 +196,11 @@ class TelegramAgent
   }
 
   /**
+   * Sends the Telegram notification for the provided type using the payload
    *
    * @param type The type of notification being sent
    * @param payload Notification payload
-   * @returns True if the notification was sent successfully, else returns false
+   * @returns True if the notification was sent successfully, otherwise False
    */
   public async send(
     type: Notification,

--- a/server/lib/notifications/agents/telegram.ts
+++ b/server/lib/notifications/agents/telegram.ts
@@ -180,7 +180,7 @@ class TelegramAgent
       const mediaServerUrl = getAvailableMediaServerUrl(payload);
 
       if (mediaServerUrl) {
-        message += `\n\[Play on ${this.escapeText(mediaServerName)}\]\(${mediaServerUrl}\)`;
+        message += `\n\[Play on ${this.escapeText(mediaServerName)}\]\(${mediaServerUrl.replace(/\)/g, '\\)')}\)`;
       }
     }
     /* eslint-enable */

--- a/server/templates/email/media-request/html.pug
+++ b/server/templates/email/media-request/html.pug
@@ -67,3 +67,9 @@ div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
           a(href=actionUrl style='display: block; margin: 1.5rem 3rem 0; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
             span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255,255,255,0.2);')
               | View Media in #{applicationTitle}
+    if mediaServerActionUrl
+      tr
+        td
+          a(href=mediaServerActionUrl style='display: block; margin: 1.5rem 3rem 0; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
+            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255,255,255,0.2);')
+              | Play on #{mediaServerName}

--- a/server/utils/mediaServerHelper.ts
+++ b/server/utils/mediaServerHelper.ts
@@ -1,0 +1,41 @@
+import { MediaServerType } from '@server/constants/server';
+
+/**
+ * Returns the display name of the media server being used in the seerr installation
+ * If neither Emby nor Plex is detected it falls back to Jellyfin
+ * @param currentMediaServer The currently configured media server type from settings
+ * @returns Human readable media server name
+ */
+export function getAvailableMediaServerName(
+  currentMediaServer: MediaServerType
+): string {
+  if (currentMediaServer === MediaServerType.EMBY) {
+    return 'Emby';
+  }
+
+  if (currentMediaServer === MediaServerType.PLEX) {
+    return 'Plex';
+  }
+
+  return 'Jellyfin';
+}
+
+/**
+ * This function returns the URL of the media directly in the media server
+ * Used later on in the email as a button to send directly to
+ * @param payload Notification payload containing media and request information
+ * @returns Media server URL or undefined if it's unavailable
+ */
+export function getAvailableMediaServerUrl(payload: {
+  request?: { is4k?: boolean };
+  media?: {
+    mediaUrl?: string;
+    mediaUrl4k?: string;
+  };
+}): string | undefined {
+  const wants4k = payload.request?.is4k;
+  const url4k = (payload.media as any)?.mediaUrl4k as string | undefined;
+  const url = (payload.media as any)?.mediaUrl as string | undefined;
+
+  return (wants4k ? (url4k ?? url) : (url ?? url4k)) || undefined;
+}

--- a/server/utils/mediaServerHelper.ts
+++ b/server/utils/mediaServerHelper.ts
@@ -34,8 +34,8 @@ export function getAvailableMediaServerUrl(payload: {
   };
 }): string | undefined {
   const wants4k = payload.request?.is4k;
-  const url4k = (payload.media as any)?.mediaUrl4k as string | undefined;
-  const url = (payload.media as any)?.mediaUrl as string | undefined;
+  const url4k = payload.media?.mediaUrl4k;
+  const url = payload.media?.mediaUrl;
 
   return (wants4k ? (url4k ?? url) : (url ?? url4k)) || undefined;
 }

--- a/server/utils/mediaServerHelper.ts
+++ b/server/utils/mediaServerHelper.ts
@@ -23,6 +23,12 @@ export function getAvailableMediaServerName(
 /**
  * This function returns the URL of the media directly in the media server
  * Used later on in the email as a button to send directly to
+ *
+ * Prefers the 4K URL when the request is marked as 4K and prefers the
+ * standard URL otherwise. If the preferred URL is unavailable, it falls
+ * back to the alternative resolution URL to ensure a playable link is
+ * returned wherever possible.
+ *
  * @param payload Notification payload containing media and request information
  * @returns Media server URL or undefined if it's unavailable
  */


### PR DESCRIPTION
In the email, Telegram, and Slack notification users receive when their media request is now available, I have added a Play on media server (e.g. Play on Plex) button that takes them directly to the media on their media server.

AI Was used to help understand parts of existing codebase so I could re-use parts in my new work.

## Description

In the email notification I have added an extra button to the bottom, in my example I use Plex so for me the button is dynamically called Play on Plex. This takes you directly to the media in the users media stack. The same as the button if you were to view the media in Seerr and click Play on Plex.

It is not "required" but more a quality of life feature, it allows the user to go directly to the media in their chosen media server, eliminates an extra step of having to find it manually in the media server or in Seerr.

- Fixes  https://github.com/seerr-team/seerr/issues/2104

## How Has This Been Tested?

- I have tested the change on all platforms by removing existing media, requesting it, running a full library scan so Seerr picks it back up from Plex, then send an email, slack, and telegram notification to me. I click on the link in each notification individually and it successfully sends me to the media in Plex.

- Ran from my Mac from a fresh Seerr dev instance, added my Plex Media Server as the Media Server and ran a full library scan so Seerr has all the latest data.

- It affects Notifications but it doesn't remove any features but instead adds more useful features.

## Screenshots / Logs (if applicable)
<img width="929" height="592" alt="Screenshot 2026-02-08 at 7 33 49 pm" src="https://github.com/user-attachments/assets/f6510288-da9f-474c-a304-0b91d7cbba2d" />
<img width="334" height="514" alt="Screenshot 2026-02-08 at 7 34 05 pm" src="https://github.com/user-attachments/assets/b5fcd1db-e9d1-4f22-9b24-a995387150b9" />
<img width="673" height="279" alt="image" src="https://github.com/user-attachments/assets/9b3afadf-f73d-4596-a917-e8f53bd93ac0" />

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [X] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now include direct action links to play content on your media server (Plex, Emby, or Jellyfin) in email, Slack, and Telegram messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->