### PR TITLE
chore(workflows): remove redundant Hugging Face model cache

### DIFF
--- a/.github/workflows/detect-duplicate.yml
+++ b/.github/workflows/detect-duplicate.yml
@@ -45,13 +45,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-
-      - name: Cache embedding model
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ~/.cache/huggingface
-          key: hf-model-${{ vars.EMBEDDING_MODEL }}
-
       - name: Install dependencies
         working-directory: bin/duplicate-detector
         env:

--- a/.github/workflows/rebuild-issue-index.yml
+++ b/.github/workflows/rebuild-issue-index.yml
@@ -43,13 +43,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-
-      - name: Cache embedding model
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ~/.cache/huggingface
-          key: hf-model-${{ vars.EMBEDDING_MODEL }}
-
       - name: Install dependencies
         working-directory: bin/duplicate-detector
         env:


### PR DESCRIPTION
## Description

Remove separate Hugging Face model cache as the pnpm store cache already includes all node_modules content, including the downloaded model files. The redundant cache was causing "Path Validation Error" warnings.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
