### PR TITLE
fix(overriderules): test service using the right endpoint

### DIFF
--- a/src/components/Settings/OverrideRule/OverrideRuleModal.tsx
+++ b/src/components/Settings/OverrideRule/OverrideRuleModal.tsx
@@ -11,11 +11,7 @@ import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import type OverrideRule from '@server/entity/OverrideRule';
-import type {
-  DVRSettings,
-  RadarrSettings,
-  SonarrSettings,
-} from '@server/lib/settings';
+import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
 import axios from 'axios';
 import { Field, Formik } from 'formik';
 import { useCallback, useEffect, useState } from 'react';
@@ -81,23 +77,26 @@ const OverrideRuleModal = ({
   });
 
   const getServiceInfos = useCallback(
-    async ({
-      hostname,
-      port,
-      apiKey,
-      baseUrl,
-      useSsl = false,
-    }: {
-      hostname: string;
-      port: number;
-      apiKey: string;
-      baseUrl?: string;
-      useSsl?: boolean;
-    }) => {
+    async (
+      {
+        hostname,
+        port,
+        apiKey,
+        baseUrl,
+        useSsl = false,
+      }: {
+        hostname: string;
+        port: number;
+        apiKey: string;
+        baseUrl?: string;
+        useSsl?: boolean;
+      },
+      type: 'radarr' | 'sonarr'
+    ) => {
       setIsTesting(true);
       try {
         const response = await axios.post<DVRTestResponse>(
-          '/api/v1/settings/sonarr/test',
+          `/api/v1/settings/${type}/test`,
           {
             hostname,
             apiKey,
@@ -119,15 +118,19 @@ const OverrideRuleModal = ({
   );
 
   useEffect(() => {
-    let service: DVRSettings | null = null;
-    if (rule?.radarrServiceId !== null && rule?.radarrServiceId !== undefined) {
-      service = radarrServices[rule?.radarrServiceId] || null;
+    if (
+      rule?.radarrServiceId !== null &&
+      rule?.radarrServiceId !== undefined &&
+      radarrServices[rule?.radarrServiceId]
+    ) {
+      getServiceInfos(radarrServices[rule?.radarrServiceId], 'radarr');
     }
-    if (rule?.sonarrServiceId !== null && rule?.sonarrServiceId !== undefined) {
-      service = sonarrServices[rule?.sonarrServiceId] || null;
-    }
-    if (service) {
-      getServiceInfos(service);
+    if (
+      rule?.sonarrServiceId !== null &&
+      rule?.sonarrServiceId !== undefined &&
+      sonarrServices[rule?.sonarrServiceId]
+    ) {
+      getServiceInfos(sonarrServices[rule?.sonarrServiceId], 'sonarr');
     }
   }, [
     getServiceInfos,
@@ -256,13 +259,13 @@ const OverrideRuleModal = ({
                             setFieldValue('radarrServiceId', id);
                             setFieldValue('sonarrServiceId', null);
                             if (radarrServices[id]) {
-                              getServiceInfos(radarrServices[id]);
+                              getServiceInfos(radarrServices[id], 'radarr');
                             }
                           } else if (e.target.value.startsWith('sonarr-')) {
                             setFieldValue('radarrServiceId', null);
                             setFieldValue('sonarrServiceId', id);
                             if (sonarrServices[id]) {
-                              getServiceInfos(sonarrServices[id]);
+                              getServiceInfos(sonarrServices[id], 'sonarr');
                             }
                           } else {
                             setFieldValue('radarrServiceId', null);


### PR DESCRIPTION
## Description

This PR modify the test call to the *arr service to use Radarr or Sonnarr depending on the service type, instead of always using the Sonarr endpoint

## How Has This Been Tested?

In the "New override rule" modal check that the call made when selecting the service is made on `/api/v1/settings/{TYPE}/test` depending on the service type instead of `/api/v1/settings/sonarr/test`.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
