### PR TITLE
fix(watchlist): remove error log when a media from the watchlist is blacklisted

### DIFF
--- a/server/lib/watchlistsync.ts
+++ b/server/lib/watchlistsync.ts
@@ -3,6 +3,7 @@ import { MediaStatus, MediaType } from '@server/constants/media';
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import {
+  BlacklistedMediaError,
   DuplicateMediaRequestError,
   MediaRequest,
   NoSeasonsAvailableError,
@@ -143,6 +144,9 @@ class WatchlistSync {
               mediaTitle: mediaItem.title,
               errorMessage: e.message,
             });
+            break;
+          // Blacklisted media should be silently ignored during watchlist sync to avoid spam
+          case BlacklistedMediaError:
             break;
           default:
             logger.error('Failed to create media request from watchlist', {


### PR DESCRIPTION
## Description

This PR removes the error log produced when the watchlist sync job runs and tries to request a blacklisted media.

- Fixes #2404

## How Has This Been Tested?

Not tested. Very simple fix.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
