### PR TITLE
fix(overriderules): display the users of an override rule

### DIFF
--- a/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
+++ b/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
@@ -134,7 +134,6 @@ const OverrideRuleTiles = ({
         const users: User[] = response.data.results;
         setUsers(users);
       }
-      setUsers(users);
     })();
   }, [rules, users]);
 


### PR DESCRIPTION
## Description

This PR fixes the display of the users associated to an override rule. They were not displayed before.

## How Has This Been Tested?

1. Create an override rule with some users.
2. See that the involved users are not display on the tile in the "Services" page.

## Screenshots / Logs (if applicable)

Before:
<img width="368" height="198" alt="image" src="https://github.com/user-attachments/assets/8c40a84a-56d9-4cae-b171-c00cd149f750" />

After:
<img width="368" height="198" alt="image" src="https://github.com/user-attachments/assets/200df151-1d3e-4bee-9325-992eeb3055d0" />


## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
