### PR TITLE
fix: run the blocklist migration last

### DIFF
--- a/server/migration/postgres/1771080196816-RenameBlacklistToBlocklist.ts
+++ b/server/migration/postgres/1771080196816-RenameBlacklistToBlocklist.ts
@@ -1,7 +1,7 @@
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class RenameBlacklistToBlocklist1746900000000 implements MigrationInterface {
-  name = 'RenameBlacklistToBlocklist1746900000000';
+export class RenameBlacklistToBlocklist1771080196816 implements MigrationInterface {
+  name = 'RenameBlacklistToBlocklist1771080196816';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "blacklist" RENAME TO "blocklist"`);

--- a/server/migration/sqlite/1771080196816-RenameBlacklistToBlocklist.ts
+++ b/server/migration/sqlite/1771080196816-RenameBlacklistToBlocklist.ts
@@ -1,7 +1,7 @@
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class RenameBlacklistToBlocklist1746900000000 implements MigrationInterface {
-  name = 'RenameBlacklistToBlocklist1746900000000';
+export class RenameBlacklistToBlocklist1771080196816 implements MigrationInterface {
+  name = 'RenameBlacklistToBlocklist1771080196816';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`


### PR DESCRIPTION
## Description

This PR moves the blocklist migration at the end, so that previous migrations merged before the blocklist one don't conflict with this one.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
