### PR TITLE
fix(servarr): increase default API timeout from 5000ms to 10000ms

### DIFF
--- a/server/api/servarr/base.ts
+++ b/server/api/servarr/base.ts
@@ -92,7 +92,7 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
     apiKey,
     cacheName,
     apiName,
-    timeout = 5000,
+    timeout = 10000,
   }: {
     url: string;
     apiKey: string;


### PR DESCRIPTION
## Description
Increases the default timeout for Servarr API requests from 5000ms to 10000ms. Users were frequently hitting timeout errors on endpoints like `/rootfolder` that perform disk I/O, particularly when Radarr/Sonarr is under load or querying network-mounted storage. The previous 5s default was too aggressive for these scenarios. Since responses from these endpoints are cached, the longer timeout has negligible impact on user experience.

## How Has This Been Tested?


## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced API request timeout handling to improve system reliability and reduce potential connection interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->