### PR TITLE
fix(login-local): remove userRepository select fields from query

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -609,7 +609,6 @@ authRoutes.post('/local', async (req, res, next) => {
   try {
     const user = await userRepository
       .createQueryBuilder('user')
-      .select(['user.id', 'user.email', 'user.password', 'user.plexId'])
       .where('user.email = :email', { email: body.email.toLowerCase() })
       .getOne();
 


### PR DESCRIPTION
## Description
This change removes the field selection from the userRepository query.

Comparing with Jellyfin login method, it does not do any `select` in the userRepository query, so should the Local login method.

Before changing anything, I used Grok to understand what does the `.select(['user.id', 'user.email', 'user.password', 'user.plexId'])` line precisely, the change was manually made

## How Has This Been Tested?
This has not been tested.

## Screenshots / Logs (if applicable)
`POST /api/v1/auth/local` before this PR:
<img width="638" height="172" alt="SCR-20260216-dxql" src="https://github.com/user-attachments/assets/60153991-8712-4e74-980d-dc01f1179004" />

...compared to `POST /api/v1/auth/jellyfin`:
<img width="674" height="440" alt="SCR-20260216-dzje" src="https://github.com/user-attachments/assets/68e53869-2768-4a7e-9a01-ffe2c8538f90" />

## Checklist:
- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the authentication system where user data retrieval was incomplete, ensuring all necessary user information is now properly returned during login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->