### PR TITLE
perf: add missing indexes on all foreign key columns

### DIFF
--- a/server/entity/Blocklist.ts
+++ b/server/entity/Blocklist.ts
@@ -36,6 +36,7 @@ export class Blocklist implements BlocklistItem {
   @ManyToOne(() => User, (user) => user.id, {
     eager: true,
   })
+  @Index()
   user?: User;
 
   @OneToOne(() => Media, (media) => media.blocklist, {

--- a/server/entity/Issue.ts
+++ b/server/entity/Issue.ts
@@ -5,6 +5,7 @@ import {
   AfterLoad,
   Column,
   Entity,
+  Index,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -19,6 +20,7 @@ class Issue {
   public id: number;
 
   @Column({ type: 'int' })
+  @Index()
   public issueType: IssueType;
 
   @Column({ type: 'int', default: IssueStatus.OPEN })
@@ -34,12 +36,14 @@ class Issue {
     eager: true,
     onDelete: 'CASCADE',
   })
+  @Index()
   public media: Media;
 
   @ManyToOne(() => User, (user) => user.createdIssues, {
     eager: true,
     onDelete: 'CASCADE',
   })
+  @Index()
   public createdBy: User;
 
   @ManyToOne(() => User, {
@@ -47,6 +51,7 @@ class Issue {
     onDelete: 'CASCADE',
     nullable: true,
   })
+  @Index()
   public modifiedBy?: User;
 
   @OneToMany(() => IssueComment, (comment) => comment.issue, {

--- a/server/entity/IssueComment.ts
+++ b/server/entity/IssueComment.ts
@@ -1,5 +1,11 @@
 import { DbAwareColumn } from '@server/utils/DbColumnHelper';
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import Issue from './Issue';
 import { User } from './User';
 
@@ -12,11 +18,13 @@ class IssueComment {
     eager: true,
     onDelete: 'CASCADE',
   })
+  @Index()
   public user: User;
 
   @ManyToOne(() => Issue, (issue) => issue.comments, {
     onDelete: 'CASCADE',
   })
+  @Index()
   public issue: Issue;
 
   @Column({ type: 'text' })

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -521,12 +521,14 @@ export class MediaRequest {
     eager: true,
     onDelete: 'CASCADE',
   })
+  @Index()
   public media: Media;
 
   @ManyToOne(() => User, (user) => user.requests, {
     eager: true,
     onDelete: 'CASCADE',
   })
+  @Index()
   public requestedBy: User;
 
   @ManyToOne(() => User, {
@@ -535,6 +537,7 @@ export class MediaRequest {
     eager: true,
     onDelete: 'SET NULL',
   })
+  @Index()
   public modifiedBy?: User;
 
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })

--- a/server/entity/Season.ts
+++ b/server/entity/Season.ts
@@ -1,6 +1,12 @@
 import { MediaStatus } from '@server/constants/media';
 import { DbAwareColumn } from '@server/utils/DbColumnHelper';
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import Media from './Media';
 
 @Entity()
@@ -20,6 +26,7 @@ class Season {
   @ManyToOne(() => Media, (media) => media.seasons, {
     onDelete: 'CASCADE',
   })
+  @Index()
   public media: Promise<Media>;
 
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })

--- a/server/entity/SeasonRequest.ts
+++ b/server/entity/SeasonRequest.ts
@@ -1,6 +1,12 @@
 import { MediaRequestStatus } from '@server/constants/media';
 import { DbAwareColumn } from '@server/utils/DbColumnHelper';
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { MediaRequest } from './MediaRequest';
 
 @Entity()
@@ -17,6 +23,7 @@ class SeasonRequest {
   @ManyToOne(() => MediaRequest, (request) => request.seasons, {
     onDelete: 'CASCADE',
   })
+  @Index()
   public request: MediaRequest;
 
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })

--- a/server/entity/UserPushSubscription.ts
+++ b/server/entity/UserPushSubscription.ts
@@ -2,6 +2,7 @@ import { DbAwareColumn } from '@server/utils/DbColumnHelper';
 import {
   Column,
   Entity,
+  Index,
   ManyToOne,
   PrimaryGeneratedColumn,
   Unique,
@@ -18,6 +19,7 @@ export class UserPushSubscription {
     eager: true,
     onDelete: 'CASCADE',
   })
+  @Index()
   public user: User;
 
   @Column()

--- a/server/entity/Watchlist.ts
+++ b/server/entity/Watchlist.ts
@@ -47,12 +47,14 @@ export class Watchlist implements WatchlistItem {
     eager: true,
     onDelete: 'CASCADE',
   })
+  @Index()
   public requestedBy: User;
 
   @ManyToOne(() => Media, (media) => media.watchlists, {
     eager: true,
     onDelete: 'CASCADE',
   })
+  @Index()
   public media: Media;
 
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })

--- a/server/migration/postgres/1771259406751-AddForeignKeyIndexes.ts
+++ b/server/migration/postgres/1771259406751-AddForeignKeyIndexes.ts
@@ -1,0 +1,153 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddForeignKeyIndexes1771259406751 implements MigrationInterface {
+  name = 'AddForeignKeyIndexes1771259406751';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" DROP CONSTRAINT "FK_53c1ab62c3e5875bc3ac474823e"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" DROP CONSTRAINT "FK_62b7ade94540f9f8d8bede54b99"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_6bbafa28411e6046421991ea21"`
+    );
+    await queryRunner.query(
+      `CREATE SEQUENCE IF NOT EXISTS "blocklist_id_seq" OWNED BY "blocklist"."id"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" ALTER COLUMN "id" SET DEFAULT nextval('"blocklist_id_seq"')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" ALTER COLUMN "id" DROP DEFAULT`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ae34e6b153a90672eb9dc4857d" ON "watchlist" ("requestedById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6641da8d831b93dfcb429f8b8b" ON "watchlist" ("mediaId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_707b033c2d0653f75213614789" ON "issue_comment" ("userId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_180710fead1c94ca499c57a7d4" ON "issue_comment" ("issueId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_53d04c07c3f4f54eae372ed665" ON "issue" ("issueType") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_276e20d053f3cff1645803c95d" ON "issue" ("mediaId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_10b17b49d1ee77e7184216001e" ON "issue" ("createdById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_da88a1019c850d1a7b143ca02e" ON "issue" ("modifiedById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6f14737e346d6b27d8e50d2157" ON "season_request" ("requestId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a1aa713f41c99e9d10c48da75a" ON "media_request" ("mediaId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6997bee94720f1ecb7f3113709" ON "media_request" ("requestedById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f4fc4efa14c3ba2b29c4525fa1" ON "media_request" ("modifiedById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_03f7958328e311761b0de675fb" ON "user_push_subscription" ("userId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_09b94c932e84635c5461f3c0a9" ON "blocklist" ("tmdbId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_356721a49f145aa439c16e6b99" ON "blocklist" ("userId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_087099b39600be695591da9a49" ON "season" ("mediaId") `
+    );
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" ADD CONSTRAINT "FK_356721a49f145aa439c16e6b999" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" ADD CONSTRAINT "FK_5c8af2d0e83b3be6d250eccc19d" FOREIGN KEY ("mediaId") REFERENCES "media"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" DROP CONSTRAINT "FK_5c8af2d0e83b3be6d250eccc19d"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" DROP CONSTRAINT "FK_356721a49f145aa439c16e6b999"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_087099b39600be695591da9a49"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_356721a49f145aa439c16e6b99"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_09b94c932e84635c5461f3c0a9"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_03f7958328e311761b0de675fb"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_f4fc4efa14c3ba2b29c4525fa1"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_6997bee94720f1ecb7f3113709"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_a1aa713f41c99e9d10c48da75a"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_6f14737e346d6b27d8e50d2157"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_da88a1019c850d1a7b143ca02e"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_10b17b49d1ee77e7184216001e"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_276e20d053f3cff1645803c95d"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_53d04c07c3f4f54eae372ed665"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_180710fead1c94ca499c57a7d4"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_707b033c2d0653f75213614789"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_6641da8d831b93dfcb429f8b8b"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_ae34e6b153a90672eb9dc4857d"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" ALTER COLUMN "id" SET DEFAULT nextval('blacklist_id_seq')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" ALTER COLUMN "id" DROP DEFAULT`
+    );
+    await queryRunner.query(`DROP SEQUENCE "blocklist_id_seq"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6bbafa28411e6046421991ea21" ON "blocklist" ("tmdbId") `
+    );
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" ADD CONSTRAINT "FK_62b7ade94540f9f8d8bede54b99" FOREIGN KEY ("mediaId") REFERENCES "media"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" ADD CONSTRAINT "FK_53c1ab62c3e5875bc3ac474823e" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+  }
+}

--- a/server/migration/sqlite/1771259394105-AddForeignKeyIndexes.ts
+++ b/server/migration/sqlite/1771259394105-AddForeignKeyIndexes.ts
@@ -1,0 +1,203 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddForeignKeyIndexes1771259394105 implements MigrationInterface {
+  name = 'AddForeignKeyIndexes1771259394105';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_6bbafa28411e6046421991ea21"`);
+    await queryRunner.query(
+      `CREATE TABLE "temporary_blocklist" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "mediaType" varchar NOT NULL, "title" varchar, "tmdbId" integer NOT NULL, "blocklistedTags" varchar, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "userId" integer, "mediaId" integer, CONSTRAINT "REL_62b7ade94540f9f8d8bede54b9" UNIQUE ("mediaId"), CONSTRAINT "UQ_6bbafa28411e6046421991ea21c" UNIQUE ("tmdbId"))`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_blocklist"("id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId") SELECT "id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId" FROM "blocklist"`
+    );
+    await queryRunner.query(`DROP TABLE "blocklist"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_blocklist" RENAME TO "blocklist"`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6bbafa28411e6046421991ea21" ON "blocklist" ("tmdbId") `
+    );
+    await queryRunner.query(`DROP INDEX "IDX_6bbafa28411e6046421991ea21"`);
+    await queryRunner.query(
+      `CREATE TABLE "temporary_user_push_subscription" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "endpoint" varchar NOT NULL, "p256dh" varchar NOT NULL, "auth" varchar NOT NULL, "userId" integer, "userAgent" varchar, "createdAt" datetime DEFAULT (CURRENT_TIMESTAMP), CONSTRAINT "UQ_6427d07d9a171a3a1ab87480005" UNIQUE ("endpoint", "userId"), CONSTRAINT "UQ_f90ab5a4ed54905a4bb51a7148b" UNIQUE ("auth"), CONSTRAINT "FK_03f7958328e311761b0de675fbe" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_user_push_subscription"("id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt") SELECT "id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt" FROM "user_push_subscription"`
+    );
+    await queryRunner.query(`DROP TABLE "user_push_subscription"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_user_push_subscription" RENAME TO "user_push_subscription"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "temporary_user_push_subscription" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "endpoint" varchar NOT NULL, "p256dh" varchar NOT NULL, "auth" varchar NOT NULL, "userId" integer, "userAgent" varchar, "createdAt" datetime DEFAULT (CURRENT_TIMESTAMP), CONSTRAINT "UQ_6427d07d9a171a3a1ab87480005" UNIQUE ("endpoint", "userId"), CONSTRAINT "UQ_f90ab5a4ed54905a4bb51a7148b" UNIQUE ("auth"), CONSTRAINT "FK_03f7958328e311761b0de675fbe" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_user_push_subscription"("id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt") SELECT "id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt" FROM "user_push_subscription"`
+    );
+    await queryRunner.query(`DROP TABLE "user_push_subscription"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_user_push_subscription" RENAME TO "user_push_subscription"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "temporary_blocklist" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "mediaType" varchar NOT NULL, "title" varchar, "tmdbId" integer NOT NULL, "blocklistedTags" varchar, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "userId" integer, "mediaId" integer, CONSTRAINT "REL_62b7ade94540f9f8d8bede54b9" UNIQUE ("mediaId"), CONSTRAINT "UQ_6bbafa28411e6046421991ea21c" UNIQUE ("tmdbId"))`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_blocklist"("id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId") SELECT "id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId" FROM "blocklist"`
+    );
+    await queryRunner.query(`DROP TABLE "blocklist"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_blocklist" RENAME TO "blocklist"`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ae34e6b153a90672eb9dc4857d" ON "watchlist" ("requestedById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6641da8d831b93dfcb429f8b8b" ON "watchlist" ("mediaId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_707b033c2d0653f75213614789" ON "issue_comment" ("userId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_180710fead1c94ca499c57a7d4" ON "issue_comment" ("issueId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_53d04c07c3f4f54eae372ed665" ON "issue" ("issueType") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_276e20d053f3cff1645803c95d" ON "issue" ("mediaId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_10b17b49d1ee77e7184216001e" ON "issue" ("createdById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_da88a1019c850d1a7b143ca02e" ON "issue" ("modifiedById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6f14737e346d6b27d8e50d2157" ON "season_request" ("requestId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a1aa713f41c99e9d10c48da75a" ON "media_request" ("mediaId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6997bee94720f1ecb7f3113709" ON "media_request" ("requestedById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f4fc4efa14c3ba2b29c4525fa1" ON "media_request" ("modifiedById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_03f7958328e311761b0de675fb" ON "user_push_subscription" ("userId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_09b94c932e84635c5461f3c0a9" ON "blocklist" ("tmdbId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_356721a49f145aa439c16e6b99" ON "blocklist" ("userId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_087099b39600be695591da9a49" ON "season" ("mediaId") `
+    );
+    await queryRunner.query(`DROP INDEX "IDX_09b94c932e84635c5461f3c0a9"`);
+    await queryRunner.query(`DROP INDEX "IDX_356721a49f145aa439c16e6b99"`);
+    await queryRunner.query(
+      `CREATE TABLE "temporary_blocklist" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "mediaType" varchar NOT NULL, "title" varchar, "tmdbId" integer NOT NULL, "blocklistedTags" varchar, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "userId" integer, "mediaId" integer, CONSTRAINT "REL_62b7ade94540f9f8d8bede54b9" UNIQUE ("mediaId"), CONSTRAINT "UQ_6bbafa28411e6046421991ea21c" UNIQUE ("tmdbId"), CONSTRAINT "FK_356721a49f145aa439c16e6b999" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION, CONSTRAINT "FK_5c8af2d0e83b3be6d250eccc19d" FOREIGN KEY ("mediaId") REFERENCES "media" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_blocklist"("id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId") SELECT "id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId" FROM "blocklist"`
+    );
+    await queryRunner.query(`DROP TABLE "blocklist"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_blocklist" RENAME TO "blocklist"`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_09b94c932e84635c5461f3c0a9" ON "blocklist" ("tmdbId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_356721a49f145aa439c16e6b99" ON "blocklist" ("userId") `
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_356721a49f145aa439c16e6b99"`);
+    await queryRunner.query(`DROP INDEX "IDX_09b94c932e84635c5461f3c0a9"`);
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" RENAME TO "temporary_blocklist"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "blocklist" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "mediaType" varchar NOT NULL, "title" varchar, "tmdbId" integer NOT NULL, "blocklistedTags" varchar, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "userId" integer, "mediaId" integer, CONSTRAINT "REL_62b7ade94540f9f8d8bede54b9" UNIQUE ("mediaId"), CONSTRAINT "UQ_6bbafa28411e6046421991ea21c" UNIQUE ("tmdbId"))`
+    );
+    await queryRunner.query(
+      `INSERT INTO "blocklist"("id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId") SELECT "id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId" FROM "temporary_blocklist"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_blocklist"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_356721a49f145aa439c16e6b99" ON "blocklist" ("userId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_09b94c932e84635c5461f3c0a9" ON "blocklist" ("tmdbId") `
+    );
+    await queryRunner.query(`DROP INDEX "IDX_087099b39600be695591da9a49"`);
+    await queryRunner.query(`DROP INDEX "IDX_356721a49f145aa439c16e6b99"`);
+    await queryRunner.query(`DROP INDEX "IDX_09b94c932e84635c5461f3c0a9"`);
+    await queryRunner.query(`DROP INDEX "IDX_03f7958328e311761b0de675fb"`);
+    await queryRunner.query(`DROP INDEX "IDX_f4fc4efa14c3ba2b29c4525fa1"`);
+    await queryRunner.query(`DROP INDEX "IDX_6997bee94720f1ecb7f3113709"`);
+    await queryRunner.query(`DROP INDEX "IDX_a1aa713f41c99e9d10c48da75a"`);
+    await queryRunner.query(`DROP INDEX "IDX_6f14737e346d6b27d8e50d2157"`);
+    await queryRunner.query(`DROP INDEX "IDX_da88a1019c850d1a7b143ca02e"`);
+    await queryRunner.query(`DROP INDEX "IDX_10b17b49d1ee77e7184216001e"`);
+    await queryRunner.query(`DROP INDEX "IDX_276e20d053f3cff1645803c95d"`);
+    await queryRunner.query(`DROP INDEX "IDX_53d04c07c3f4f54eae372ed665"`);
+    await queryRunner.query(`DROP INDEX "IDX_180710fead1c94ca499c57a7d4"`);
+    await queryRunner.query(`DROP INDEX "IDX_707b033c2d0653f75213614789"`);
+    await queryRunner.query(`DROP INDEX "IDX_6641da8d831b93dfcb429f8b8b"`);
+    await queryRunner.query(`DROP INDEX "IDX_ae34e6b153a90672eb9dc4857d"`);
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" RENAME TO "temporary_blocklist"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "blocklist" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "mediaType" varchar NOT NULL, "title" varchar, "tmdbId" integer NOT NULL, "blocklistedTags" varchar, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "userId" integer, "mediaId" integer, CONSTRAINT "REL_62b7ade94540f9f8d8bede54b9" UNIQUE ("mediaId"), CONSTRAINT "UQ_6bbafa28411e6046421991ea21c" UNIQUE ("tmdbId"))`
+    );
+    await queryRunner.query(
+      `INSERT INTO "blocklist"("id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId") SELECT "id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId" FROM "temporary_blocklist"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_blocklist"`);
+    await queryRunner.query(
+      `ALTER TABLE "user_push_subscription" RENAME TO "temporary_user_push_subscription"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user_push_subscription" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "endpoint" varchar NOT NULL, "p256dh" varchar NOT NULL, "auth" varchar NOT NULL, "userId" integer, "userAgent" varchar, "createdAt" datetime DEFAULT (CURRENT_TIMESTAMP), CONSTRAINT "UQ_6427d07d9a171a3a1ab87480005" UNIQUE ("endpoint", "userId"), CONSTRAINT "UQ_f90ab5a4ed54905a4bb51a7148b" UNIQUE ("auth"), CONSTRAINT "FK_03f7958328e311761b0de675fbe" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "user_push_subscription"("id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt") SELECT "id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt" FROM "temporary_user_push_subscription"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_user_push_subscription"`);
+    await queryRunner.query(
+      `ALTER TABLE "user_push_subscription" RENAME TO "temporary_user_push_subscription"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user_push_subscription" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "endpoint" varchar NOT NULL, "p256dh" varchar NOT NULL, "auth" varchar NOT NULL, "userId" integer, "userAgent" varchar, "createdAt" datetime DEFAULT (CURRENT_TIMESTAMP), CONSTRAINT "UQ_6427d07d9a171a3a1ab87480005" UNIQUE ("endpoint", "userId"), CONSTRAINT "UQ_f90ab5a4ed54905a4bb51a7148b" UNIQUE ("auth"), CONSTRAINT "FK_03f7958328e311761b0de675fbe" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "user_push_subscription"("id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt") SELECT "id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt" FROM "temporary_user_push_subscription"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_user_push_subscription"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6bbafa28411e6046421991ea21" ON "blocklist" ("tmdbId") `
+    );
+    await queryRunner.query(`DROP INDEX "IDX_6bbafa28411e6046421991ea21"`);
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" RENAME TO "temporary_blocklist"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "blocklist" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "mediaType" varchar NOT NULL, "title" varchar, "tmdbId" integer NOT NULL, "blocklistedTags" varchar, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "userId" integer, "mediaId" integer, CONSTRAINT "REL_62b7ade94540f9f8d8bede54b9" UNIQUE ("mediaId"), CONSTRAINT "UQ_6bbafa28411e6046421991ea21c" UNIQUE ("tmdbId"), CONSTRAINT "FK_62b7ade94540f9f8d8bede54b99" FOREIGN KEY ("mediaId") REFERENCES "media" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_53c1ab62c3e5875bc3ac474823e" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "blocklist"("id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId") SELECT "id", "mediaType", "title", "tmdbId", "blocklistedTags", "createdAt", "userId", "mediaId" FROM "temporary_blocklist"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_blocklist"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6bbafa28411e6046421991ea21" ON "blocklist" ("tmdbId") `
+    );
+  }
+}


### PR DESCRIPTION
## Description
Adds Indexes to all `@ManyToOne` relations that were missing FK indexes. Most impactful is `season.mediaId` which caused 10+ second load times on the discover page for users with large libraries (~50k media) (reported by @mmozeiko). Fixes a full table scan on every eager-loaded join.

## How Has This Been Tested?

## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [X] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized database performance by indexing key relationship fields across multiple entities to improve query speed and efficiency without affecting existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->