### PR TITLE
fix(requests): mark requests as completed when media is already available

### DIFF
--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -354,11 +354,9 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
             mediaId: entity.media.id,
           });
 
-          if (entity.status !== MediaRequestStatus.APPROVED) {
-            const requestRepository = getRepository(MediaRequest);
-            entity.status = MediaRequestStatus.APPROVED;
-            await requestRepository.save(entity);
-          }
+          const requestRepository = getRepository(MediaRequest);
+          entity.status = MediaRequestStatus.COMPLETED;
+          await requestRepository.save(entity);
           return;
         }
 
@@ -532,11 +530,12 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
             mediaId: entity.media.id,
           });
 
-          if (entity.status !== MediaRequestStatus.APPROVED) {
-            const requestRepository = getRepository(MediaRequest);
-            entity.status = MediaRequestStatus.APPROVED;
-            await requestRepository.save(entity);
-          }
+          const requestRepository = getRepository(MediaRequest);
+          entity.status = MediaRequestStatus.COMPLETED;
+          entity.seasons.forEach((season) => {
+            season.status = MediaRequestStatus.COMPLETED;
+          });
+          await requestRepository.save(entity);
           return;
         }
 

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -948,6 +948,15 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     try {
       await this.sendToRadarr(event.entity as MediaRequest);
       await this.sendToSonarr(event.entity as MediaRequest);
+    } catch (e) {
+      logger.error('Error while sending to *arr in afterUpdate subscriber', {
+        label: 'Media Request',
+        requestId: (event.entity as MediaRequest).id,
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
+    }
+
+    try {
       await this.updateParentStatus(event.entity as MediaRequest);
 
       if (event.entity.status === MediaRequestStatus.COMPLETED) {
@@ -959,11 +968,14 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         }
       }
     } catch (e) {
-      logger.error('Error in afterUpdate subscriber', {
-        label: 'Media Request',
-        requestId: (event.entity as MediaRequest).id,
-        errorMessage: e instanceof Error ? e.message : String(e),
-      });
+      logger.error(
+        'Error while updating parent status in afterUpdate subscriber',
+        {
+          label: 'Media Request',
+          requestId: (event.entity as MediaRequest).id,
+          errorMessage: e instanceof Error ? e.message : String(e),
+        }
+      );
     }
   }
 
@@ -975,13 +987,25 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     try {
       await this.sendToRadarr(event.entity as MediaRequest);
       await this.sendToSonarr(event.entity as MediaRequest);
-      await this.updateParentStatus(event.entity as MediaRequest);
     } catch (e) {
-      logger.error('Error in afterInsert subscriber', {
+      logger.error('Error while sending to *arr in afterInsert subscriber', {
         label: 'Media Request',
         requestId: (event.entity as MediaRequest).id,
         errorMessage: e instanceof Error ? e.message : String(e),
       });
+    }
+
+    try {
+      await this.updateParentStatus(event.entity as MediaRequest);
+    } catch (e) {
+      logger.error(
+        'Error while updating parent status in afterInsert subscriber',
+        {
+          label: 'Media Request',
+          requestId: (event.entity as MediaRequest).id,
+          errorMessage: e instanceof Error ? e.message : String(e),
+        }
+      );
     }
   }
 

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -348,7 +348,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         if (
           media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
         ) {
-          logger.warn('Media already exists, marking request as APPROVED', {
+          logger.warn('Media already exists, marking request as COMPLETED', {
             label: 'Media Request',
             requestId: entity.id,
             mediaId: entity.media.id,
@@ -524,7 +524,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         if (
           media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
         ) {
-          logger.warn('Media already exists, marking request as APPROVED', {
+          logger.warn('Media already exists, marking request as COMPLETED', {
             label: 'Media Request',
             requestId: entity.id,
             mediaId: entity.media.id,

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -9,7 +9,7 @@ import { MediaRequest } from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
 import type { EntitySubscriberInterface, UpdateEvent } from 'typeorm';
-import { EventSubscriber } from 'typeorm';
+import { EventSubscriber, In } from 'typeorm';
 
 @EventSubscriber()
 export class MediaSubscriber implements EntitySubscriberInterface<Media> {
@@ -45,7 +45,7 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
       },
       where: {
         media: { id: event.id },
-        status: MediaRequestStatus.APPROVED,
+        status: In([MediaRequestStatus.APPROVED, MediaRequestStatus.FAILED]),
         is4k,
       },
     });


### PR DESCRIPTION
## Description

Fixes requests getting stuck and not appearing under the "available" filter when media is already available.

`sendToRadarr` and `sendToSonarr` marked requests as `APPROVED` when media was already available when this should be `COMPLETED`. This caused the retry path to leave requests stuck since the "available" filter requires both `COMPLETED` and `AVAILABLE`.

In addition, `MediaSubscriber.updateRelatedMediaRequest` only queried `APPROVED` requests when transitioning to `COMPLETED`, so `FAILED` requests were never picked up when media became available via library scan. This is now updated to include `FAILED` requests in the completion query.

`afterUpdate` and `afterInsert` also had a single try/catch, so a failure in `sendTo*arr` would skip `updateParentStatus` entirely. These are now separated so `updateParentStatus` runs regardless.

- Fixes #2409

## How Has This Been Tested?

Not tested. Check #2409. 

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved error handling and logging during media request processing by separating send-to-external-service operations from parent-status updates to ensure clearer failure visibility.

* **Behavioral Change**
  * Some requests that previously became APPROVED now become COMPLETED.
  * Completion now propagates to related items (including seasons) and considers a broader set of related statuses when determining completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->