### PR TITLE
docs(unraid): improve unraid migration guide 

### DIFF
--- a/docs/getting-started/third-parties/unraid.mdx
+++ b/docs/getting-started/third-parties/unraid.mdx
@@ -26,7 +26,7 @@ Seerr is now rootless. Unraid typically runs Docker containers as `nobody:users`
 :::
 
 :::info
-*If migrating**: Copy your existing Seerr/Overseerr config files (e.g., from `/mnt/user/appdata/overseerr/` or `/mnt/user/appdata/jellyseerr`) to `/mnt/user/appdata/seerr`, then apply the permissions below
+**If migrating**: Copy your existing Jellyseerr/Overseerr config files (e.g., from `/mnt/user/appdata/overseerr/` or `/mnt/user/appdata/jellyseerr`) to `/mnt/user/appdata/seerr`, then apply the permissions below
 :::
 
 Open the Unraid terminal and run:


### PR DESCRIPTION
### 1. Create the config directory

:::note
Seerr is now rootless. Unraid typically runs Docker containers as `nobody:users` (UID 99, GID 100), but Seerr now runs internally as UID 1000, GID 1000. This creates a permission mismatch. :::

:::info
**If migrating**: Copy your existing Seerr files to the new folder, then apply the permissions below. :::

Open the Unraid terminal and run:

```bash
mkdir -p /mnt/user/appdata/seerr
chown -R 1000:1000 /mnt/user/appdata/seerr
```

<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Fixes #2460

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added notes for Unraid setup: Seerr runs rootless as UID 1000 / GID 1000 and may need permission adjustments.
  * Added migration guidance to copy existing Jellyseerr/Overseerr appdata into Seerr and set correct permissions.
  * Minor formatting improvements to info/note blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->