### PR TITLE
fix(imageproxy): restrict to relative paths to prevent baseURL override

### DIFF
--- a/server/routes/imageproxy.ts
+++ b/server/routes/imageproxy.ts
@@ -32,6 +32,18 @@ function initTvdbImageProxy() {
 
 router.get('/:type/*', async (req, res) => {
   const imagePath = req.path.replace(/^\/\w+/, '');
+
+  if (
+    !imagePath.startsWith('/') ||
+    imagePath.startsWith('//') ||
+    imagePath.includes('://')
+  ) {
+    logger.error('Invalid image path detected', {
+      imagePath: imagePath.slice(0, 200),
+    });
+    return res.status(400).send('Invalid image path');
+  }
+
   try {
     let imageData;
     if (req.params.type === 'tmdb') {


### PR DESCRIPTION
## Description

- Problem: The `/imageproxy` route could be tricked into fetching absolute URLs, bypassing the intended `baseURL`.
- Why it matters: This allowed for potential SSRF where internal network resources or server-side metadata could be accessed through the proxy.
- What changed: Added a check to ensure `imagePath` is a relative path starting with `/` and does not contain protocol strings or double slashes.

## How Has This Been Tested?

- Verified that standard TMDB/TVDB paths (e.g., `/t/p/xxx.jpg`) still work.
- Verified that absolute URLs and double-slash bypasses are blocked.

## Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] Disclosed any use of AI.
- [x] All new and existing tests passed. 🦞

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation for the image proxy route to reject invalid image paths and return appropriate error responses. This prevents potential issues from malformed requests, improving system reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->