### PR TITLE
fix(watchlist-sync): correct permission typo for TV auto requests

### DIFF
--- a/server/lib/watchlistsync.ts
+++ b/server/lib/watchlistsync.ts
@@ -45,7 +45,7 @@ class WatchlistSync {
         [
           Permission.AUTO_REQUEST,
           Permission.AUTO_REQUEST_MOVIE,
-          Permission.AUTO_APPROVE_TV,
+          Permission.AUTO_REQUEST_TV,
         ],
         { type: 'or' }
       )


### PR DESCRIPTION
## Description
The watchlist sync's first permission check incorrectly references `AUTO_APPROVE_TV` instead of `AUTO_REQUEST_TV`. 

Since these are entirely different permissions where `AUTO_APPROVE_TV` controls whether requests get automatically approved, while `AUTO_REQUEST_TV` controls whether a user's Plex Watchlist items should be automatically submitted as requests, this typo allows users who only have auto-approve permissions but no auto-request permissions to pass the initial gate and enter the sync flow, resulting in unnecessary request creation attempts every sync cycle.

- Fixes https://github.com/seerr-team/seerr/issues/2484

## How Has This Been Tested?


## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated permission handling for TV watchlist auto-sync functionality to ensure appropriate access controls are applied during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->