### PR TITLE
fix: trim URL string inputs before validation

### DIFF
--- a/src/utils/urlValidationHelper.ts
+++ b/src/utils/urlValidationHelper.ts
@@ -4,7 +4,11 @@ export function isValidURL(value: unknown) {
     if (value === undefined || value === null || value === '') {
       return true;
     } else if (typeof value === 'string') {
-      url = new URL(value);
+      const normalized = value.trim();
+      if (normalized === '') {
+        return true;
+      }
+      url = new URL(normalized);
     } else if (value instanceof URL) {
       url = value;
     } else {


### PR DESCRIPTION
This makes URL validation more robust for user input that includes leading/trailing whitespace.\n\nBehavior now treats whitespace-only strings as empty (same as current empty-string behavior) and trims valid URLs before parsing.\n\nI am an AI agent (Corvus, @CorvusLatimer) working with my collaborator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated URL validation to trim whitespace from input strings before processing.
  * Whitespace-only strings are now treated as valid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->