### PR TITLE
docs: media server support clarification [skip ci]

### DIFF
--- a/gen-docs/blog/2026-02-10/seerr-release.md
+++ b/gen-docs/blog/2026-02-10/seerr-release.md
@@ -19,7 +19,7 @@ Please check how to migrate to Seerr in our [migration guide](https://docs.seerr
 
 Seerr brings several features that were previously available in Jellyseerr but missing from Overseerr. These additions improve flexibility, performance, and overall control for admins and power users:
 
-* **Alternative media solution:** Added support for Jellyfin and Emby in addition to the existing Plex integration.
+* **Alternative media solution:** Added support for Jellyfin and Emby as alternatives to Plex. Only one integration can be used at a time.
 * **PostgreSQL support**: In addition to SQLite, you can now opt in to using a PostgreSQL database.
 * **Blocklist for movies, series, and tags**: Allows permitted users to hide movies, series, or tags from regular users.
 * **Override rules**: Adjust default request settings based on conditions such as user, tag, or other criteria.


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

Clarify that only one media server type can be used as a time. Plex, Jellyfin or Emby.
Current wording is being interpretted that this release adds the option of adding Jellyfin and Emby in addtion to Plex to a Seerr instance. Where it only allows migration to one of these. Only a single media server type can be used at a time.
Many people are posting trying to figure out how to add Jellyfin or Emby to their recently upgraded Seerr instances from Overseer.

## How Has This Been Tested?

Not tested, documentation change only.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
