### PR TITLE
docs: Remove double quotes (") from DB_HOST environment variable

### DIFF
--- a/docs/extending-seerr/database-config.mdx
+++ b/docs/extending-seerr/database-config.mdx
@@ -30,7 +30,7 @@ If your PostgreSQL server is configured to accept TCP connections, you can speci
 
 ```dotenv
 DB_TYPE=postgres # Which DB engine to use, either sqlite or postgres. The default is sqlite.
-DB_HOST="localhost" # (optional) The host (URL) of the database. The default is "localhost".
+DB_HOST=localhost # (optional) The host (URL) of the database. The default is "localhost".
 DB_PORT="5432" # (optional) The port to connect to. The default is "5432".
 DB_USER= # (required) Username used to connect to the database.
 DB_PASS= # (required) Password of the user used to connect to the database.


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Documentation implies the DB_HOST environment variable requires double quotes (")

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running DB_HOST without quotes when built from source. Correcting documentation
## Screenshots / Logs (if applicable)
N/A
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the PostgreSQL TCP connection example in the database configuration guide with corrected configuration snippet formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->