### PR TITLE
fix(sonarr): use configured metadata provider for season filtering

### DIFF
--- a/server/lib/scanners/sonarr/index.ts
+++ b/server/lib/scanners/sonarr/index.ts
@@ -1,6 +1,12 @@
+import { getMetadataProvider } from '@server/api/metadata';
 import type { SonarrSeries } from '@server/api/servarr/sonarr';
 import SonarrAPI from '@server/api/servarr/sonarr';
-import type { TmdbTvDetails } from '@server/api/themoviedb/interfaces';
+import TheMovieDb from '@server/api/themoviedb';
+import { ANIME_KEYWORD_ID } from '@server/api/themoviedb/constants';
+import type {
+  TmdbKeyword,
+  TmdbTvDetails,
+} from '@server/api/themoviedb/interfaces';
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import type {
@@ -102,6 +108,15 @@ class SonarrScanner
       }
 
       const tmdbId = tvShow.id;
+      const metadataProvider = tvShow.keywords.results.some(
+        (keyword: TmdbKeyword) => keyword.id === ANIME_KEYWORD_ID
+      )
+        ? await getMetadataProvider('anime')
+        : await getMetadataProvider('tv');
+
+      if (!(metadataProvider instanceof TheMovieDb)) {
+        tvShow = await metadataProvider.getTvShow({ tvId: tmdbId });
+      }
       const settings = getSettings();
 
       const filteredSeasons = sonarrSeries.seasons.filter(


### PR DESCRIPTION
## Description
The Sonarr scanner was always using TMDB as the source of truth for season data when checking availability, even when the metadata provider was set to TVDB. This caused incorrect availability statuses for shows where TMDB and TVDB have different season structures. For example, Animaniacs is split into two separate series on TMDB (5 seasons + 3 seasons) but combined into a single 8-season series on TVDB. The scanner would see all 5 TMDB seasons as available and mark the show as fully available, which blocked users from requesting the remaining seasons via "Request More."

This adds the same metadata provider resolution that the Jellyfin/emby and Plex scanners already use, so the Sonarr scanner now respects the configured provider when filtering seasons.

- Fixes #2466

## How Has This Been Tested?

This can be tested using the image tag `preview-fix-sonarr-scanner-metadata-provider`

## Screenshots / Logs (if applicable)

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better metadata handling for TV show libraries: the app now detects anime and uses the appropriate metadata source, reducing incorrect or missing show details.
  * TV show data is now refreshed when using alternate metadata sources so library entries display accurate, up-to-date information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->