### PR TITLE
chore: disable nextjs telemetry

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 .next/
 dist/
 config/
+cache/config.json
 pnpm-lock.yaml
 cypress/config/settings.cypress.json
 .github

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -33,5 +33,11 @@ module.exports = {
         rangeEnd: 0,
       },
     },
+    {
+      files: 'cache/config.json',
+      options: {
+        rangeEnd: 0, // default: Infinity
+      },
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@10.24.0",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
+    "postinstall": "next telemetry disable",
     "dev": "nodemon -e ts --watch server --watch seerr-api.yml -e .json,.ts,.yml -x ts-node -r tsconfig-paths/register --files --project server/tsconfig.json server/index.ts",
     "build:server": "tsc --project server/tsconfig.json && copyfiles -u 2 server/templates/**/*.{html,pug} dist/templates && tsc-alias -p server/tsconfig.json",
     "build:next": "next build",


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Disable nextjs telemetry
https://nextjs.org/telemetry

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
❯ pnpm install
Lockfile is up to date, resolution step is skipped
Packages: +1936
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 1936, reused 1933, downloaded 0, added 1936, done

dependencies:
+ @dr.pogodin/csurf 1.16.6
+ @formatjs/intl-displaynames 6.8.13
+ @formatjs/intl-locale 3.1.1
+ @formatjs/intl-pluralrules 5.4.6
+ @formatjs/intl-utils 3.8.4
+ @headlessui/react 1.7.12
+ @heroicons/react 2.2.0
+ @seerr-team/react-tailwindcss-datepicker 1.3.4
+ @supercharge/request-ip 1.2.0
+ @svgr/webpack 6.5.1
+ @tanem/react-nprogress 5.0.56
+ @types/ua-parser-js 0.7.39
+ @types/wink-jaro-distance 2.0.2
+ ace-builds 1.43.4
+ axios 1.13.3
+ axios-rate-limit 1.4.0
+ bcrypt 6.0.0
+ bowser 2.13.1
+ connect-typeorm 1.1.4
+ cookie-parser 1.4.7
+ copy-to-clipboard 3.3.3
+ country-flag-icons 1.6.4
+ cronstrue 2.23.0
+ date-fns 2.29.3
+ dns-caching 0.2.7
+ email-templates 12.0.3
+ express 4.21.2
+ express-openapi-validator 4.13.8
+ express-rate-limit 6.7.0
+ express-session 1.18.2
+ formik 2.4.9
+ gravatar-url 3.1.0
+ http-proxy-agent 7.0.2
+ https-proxy-agent 7.0.6
+ lodash 4.17.23
+ mime 3.0.0
+ next 14.2.35
+ node-cache 5.1.2
+ node-gyp 9.3.1
+ node-schedule 2.1.1
+ nodemailer 7.0.12
+ openpgp 6.3.0
+ pg 8.17.2
+ pug 3.0.3
+ react 18.3.1
+ react-ace 10.1.0
+ react-animate-height 2.1.2
+ react-aria 3.44.0
+ react-dom 18.3.1
+ react-intersection-observer 9.4.3
+ react-intl 6.6.8
+ react-markdown 8.0.5
+ react-popper-tooltip 4.4.2
+ react-select 5.10.2
+ react-spring 9.7.1
+ react-toast-notifications 2.5.1
+ react-transition-group 4.4.5
+ react-truncate-markup 5.1.2
+ react-use-clipboard 1.0.9
+ reflect-metadata 0.1.13
+ secure-random-password 0.2.3
+ semver 7.7.3
+ sharp 0.33.4
+ sqlite3 5.1.7
+ swagger-ui-express 4.6.2
+ swr 2.3.8
+ tailwind-merge 2.6.0
+ typeorm 0.3.28
+ ua-parser-js 1.0.40
+ undici 7.18.2
+ validator 13.15.23
+ web-push 3.6.7
+ wink-jaro-distance 2.0.0
+ winston 3.19.0
+ winston-daily-rotate-file 4.7.1
+ xml2js 0.5.0
+ yamljs 0.3.0
+ yup 0.32.11
+ zod 4.3.6

devDependencies:
+ @commitlint/cli 17.4.4
+ @commitlint/config-conventional 17.4.4
+ @tailwindcss/aspect-ratio 0.4.2
+ @tailwindcss/forms 0.5.10
+ @tailwindcss/typography 0.5.16
+ @types/bcrypt 6.0.0
+ @types/cookie-parser 1.4.10
+ @types/country-flag-icons 1.2.2
+ @types/csurf 1.11.5
+ @types/email-templates 8.0.4
+ @types/express 4.17.17
+ @types/express-session 1.18.2
+ @types/lodash 4.17.21
+ @types/mime 3.0.4
+ @types/node 22.10.5
+ @types/node-schedule 2.1.8
+ @types/nodemailer 7.0.9
+ @types/react 18.3.27
+ @types/react-dom 18.3.0
+ @types/react-transition-group 4.4.12
+ @types/secure-random-password 0.2.1
+ @types/semver 7.7.1
+ @types/swagger-ui-express 4.1.8
+ @types/validator 13.15.10
+ @types/web-push 3.6.4
+ @types/xml2js 0.4.14
+ @types/yamljs 0.2.31
+ @types/yup 0.29.14
+ @typescript-eslint/eslint-plugin 7.18.0
+ @typescript-eslint/parser 7.18.0
+ autoprefixer 10.4.23
+ baseline-browser-mapping 2.9.18
+ commitizen 4.3.1
+ copyfiles 2.4.1
+ cy-mobile-commands 0.3.0
+ cypress 14.5.4
+ cz-conventional-changelog 3.3.0
+ eslint 8.57.1
+ eslint-config-next 14.2.35
+ eslint-config-prettier 8.6.0
+ eslint-plugin-formatjs 4.9.0
+ eslint-plugin-jsx-a11y 6.10.2
+ eslint-plugin-no-relative-import-paths 1.6.1
+ eslint-plugin-prettier 4.2.1
+ eslint-plugin-react 7.37.5
+ eslint-plugin-react-hooks 4.6.0
+ husky 8.0.3
+ lint-staged 13.1.2
+ nodemon 3.1.11
+ postcss 8.5.6
+ prettier 3.8.1
+ prettier-plugin-organize-imports 4.3.0
+ prettier-plugin-tailwindcss 0.6.14
+ tailwindcss 3.4.19
+ ts-node 10.9.2
+ tsc-alias 1.8.16
+ tsconfig-paths 4.2.0
+ typescript 5.4.5

> seerr@0.1.0 postinstall /home/lortega/Github/seerr
> next telemetry disable

Next.js' telemetry collection is already disabled.

Status: Disabled

You have opted-out of Next.js' anonymous telemetry program.
No data will be collected from your machine.

Learn more: https://nextjs.org/telemetry

> seerr@0.1.0 prepare /home/lortega/Github/seerr
> node bin/prepare.js

husky - Git hooks installed

Done in 4.2s using pnpm v10.24.0
```

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automatic post-install step that disables Next.js telemetry during package installation.
  * Updated formatting/ignore rules to include the cache configuration path and corrected markdown newline handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->