### PR TITLE
fix: remove outdated username placeholder text in login page

### DIFF
--- a/src/components/Login/LocalLogin.tsx
+++ b/src/components/Login/LocalLogin.tsx
@@ -12,7 +12,6 @@ import * as Yup from 'yup';
 
 const messages = defineMessages('components.Login', {
   loginwithapp: 'Login with {appName}',
-  username: 'Username',
   email: 'Email Address',
   password: 'Password',
   validationemailrequired: 'You must provide a valid email address',
@@ -84,11 +83,11 @@ const LocalLogin = ({ revalidate }: LocalLoginProps) => {
                       name="email"
                       placeholder={`${intl.formatMessage(
                         messages.email
-                      )} / ${intl.formatMessage(messages.username)}`}
+                      )}`}
                       type="text"
                       inputMode="email"
                       data-testid="email"
-                      data-form-type="username,email"
+                      data-form-type="email"
                       className="!bg-gray-700/80 placeholder:text-gray-400"
                     />
                   </div>


### PR DESCRIPTION
## Description

This commit removes an outdated username placeholder text for the login page. This is a reminiscent of an old migration from other media servers. 
This commit also changes the data-form-type to just email instead of username. This may break some compatibility with existing password manager saves, but in my testing with Bitwarden that didn't happen (source of the claim of compatibility is GitHub Copilot)

## How Has This Been Tested?

Compiled and ran through Docker compose on my local machine, an EndeavourOS host in x86_64.

## Screenshots / Logs (if applicable)

New:
<img width="1366" height="732" alt="image" src="https://github.com/user-attachments/assets/a25be6a4-ff21-4232-86db-383b5f399abf" />
Old:
<img width="1366" height="732" alt="image" src="https://github.com/user-attachments/assets/0b4c22d5-882c-43ae-80e6-1c973e9c5fe1" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [?] I have updated the documentation accordingly.
- [?] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [?] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Email input placeholder simplified to display "Email" only.
  * Login now accepts email addresses exclusively; username entry/label has been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->