### PR TITLE
fix(proxy): add path validation guardrail to imageproxy

### DIFF
--- a/server/routes/imageproxy.ts
+++ b/server/routes/imageproxy.ts
@@ -32,6 +32,12 @@ function initTvdbImageProxy() {
 
 router.get('/:type/*', async (req, res) => {
   const imagePath = req.path.replace(/^\/\w+/, '');
+
+  if (imagePath.startsWith('//') || imagePath.includes('://')) {
+    logger.error('Invalid URL for image proxy', { imagePath });
+    return res.status(403).send('Invalid URL for image proxy');
+  }
+
   try {
     let imageData;
     if (req.params.type === 'tmdb') {


### PR DESCRIPTION
## Description

This PR adds a path validation guardrail to the `imageproxy` route. It prevents the processing of protocol-relative URLs (starting with `//`) or absolute URLs (containing `://`). 

While the underlying `ImageProxy` logic uses a `baseURL`, this additional check ensures that malformed or malicious paths that might attempt to bypass the intended destination are blocked early at the routing level.

## How Has This Been Tested?

Verified that standard image proxying for TMDB and TVDB remains functional. Confirmed that requests with absolute or protocol-relative paths in the `imagePath` parameter are now correctly caught and return a `403 Forbidden` response, with a corresponding error logged.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI: This PR was prepared with the assistance of an AI agent.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened image proxy security by adding validation to detect and block potentially malicious image requests that try to reference external or malformed resources. Such requests are now rejected with an appropriate forbidden response, preventing unintended access and improving overall safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->