### PR TITLE
fix(plex-scanner): add TVDb to TMDB fallback in plex scanner

### DIFF
--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -430,6 +430,13 @@ class PlexScanner
         mediaIds.tmdbId = tmdbMedia.id;
       }
 
+      if (mediaIds.tvdbId && !mediaIds.tmdbId) {
+        const show = await this.tmdb.getShowByTvdbId({
+          tvdbId: mediaIds.tvdbId,
+        });
+        mediaIds.tmdbId = show.id;
+      }
+
       // Cache GUIDs
       guidCache.data.set(plexitem.ratingKey, mediaIds);
 


### PR DESCRIPTION
## Description
When Plex doesn't include a `tmdb://` entry in a title's GUID array and only provides a `tvdb://` ID, the scanner fails with "Unable to find TMDB ID" even though the title exists on TMDB with a valid TVDb external ID mapping. The existing code only had a fallback path from IMDb to TMDB but was missing the equivalent TVDb to TMDB lookup. This adds that fallback in `getMediaIds` for the Plex agent, matching the approach already used by the Jellyfin scanner. 

- Fixes #2524.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media data retrieval to better handle cases where certain identifiers are unavailable, ensuring more complete information is available for media processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->