### PR TITLE
fix(jellyfin-scanner): include unmatched seasons in processable seasons

### DIFF
--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -397,6 +397,13 @@ class JellyfinScanner
               episodes: totalStandard,
               episodes4k: total4k,
             });
+          } else {
+            processableSeasons.push({
+              seasonNumber: season.season_number,
+              totalEpisodes: season.episode_count,
+              episodes: 0,
+              episodes4k: 0,
+            });
           }
         }
 


### PR DESCRIPTION
## Description
The Jellyfin scanner was only passing seasons it found in the Jellyfin library to `processShow`, omitting any seasons that weren't present in the metadata provider. This meant that if a user requested a single season of a multi-season show and that season was downloaded, `processShow` would only have Season entities for that one season and since all known seasons were available, the show was incorrectly marked as fully available. A subsequent Sonarr scan would then correct it to partially available, but the initial status was wrong and could trigger incorrect notifications.

PR #2412 addressed a related issue by changing the availability calculation to check actual Season entities rather than scanner input, but it couldn't account for seasons that were never passed to `processShow` in the first place. The Plex scanner already handles this correctly by [including unmatched seasons with zero episodes](https://github.com/seerr-team/seerr/blob/a0d0eb185800a1444f5402b15bdd1047b05b04aa/server/lib/scanners/plex/index.ts#L335-L367). This change applies the same pattern to the Jellyfin scanner.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of seasons that lack matching Jellyfin entries, ensuring they're properly tracked and represented in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->