### PR TITLE
fix(link-account): fix error-message override

### DIFF
--- a/src/components/UserProfile/UserSettings/UserLinkedAccountsSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserLinkedAccountsSettings/index.tsx
@@ -100,14 +100,16 @@ const UserLinkedAccountsSettings = () => {
       );
       await revalidateUser();
     } catch (e) {
-      if (e?.response?.status === 401) {
-        setError(intl.formatMessage(messages.plexErrorUnauthorized));
-      } else if (e?.response?.status === 422) {
-        setError(intl.formatMessage(messages.plexErrorExists));
-      } else {
-        setError(intl.formatMessage(messages.errorUnknown));
+      switch (e?.response?.status) {
+        case 401:
+          setError(intl.formatMessage(messages.plexErrorUnauthorized));
+          break;
+        case 422:
+          setError(intl.formatMessage(messages.plexErrorExists));
+          break;
+        default:
+          setError(intl.formatMessage(messages.errorUnknown));
       }
-      setError(intl.formatMessage(messages.errorUnknown));
     }
   };
 


### PR DESCRIPTION
## Description

This is a bug that was identified by `coderabbitai` on a separate PR.

This was the report:

> `src/components/UserProfile/UserSettings/UserLinkedAccountsSettings/index.tsx (1)`
> `102-111`: ⚠️ Potential issue | 🔴 Critical
>
> **Critical: Duplicate setError call masks specific error messages.**
>
> Line 110 unconditionally overwrites all error messages with the generic "errorUnknown" message, preventing users from seeing the helpful error messages for unauthorized (401) or duplicate account (422) scenarios. This defeats the purpose of the specific error handling above it.



## How Has This Been Tested?

I tested by trying to link an account and then closing the pop-up. This generates an `unknown error`.

Unfortunately, I don't know how to generate a `401` or a `422` error.

## Screenshots / Logs (if applicable)

<img width="1065" height="626" alt="image" src="https://github.com/user-attachments/assets/e8260e33-11ba-4bb0-ac4c-6282a001c676" />


## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling code structure in user account settings to enhance maintainability and code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->