### PR TITLE
feat: add setting to disable Sonarr new season monitoring

### DIFF
--- a/jellyseerr-api.yml
+++ b/jellyseerr-api.yml
@@ -543,6 +543,10 @@ components:
         activeAnimeDirectory:
           type: string
           nullable: true
+        monitorNewItems:
+          type: string
+          enum: [all, none]
+          example: all
         is4k:
           type: boolean
           example: false

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -75,7 +75,9 @@ export interface SonarrSeries {
     ignoreEpisodesWithFiles?: boolean;
     ignoreEpisodesWithoutFiles?: boolean;
     searchForMissingEpisodes?: boolean;
+    monitor?: 'firstSeason' | 'latestSeason' | 'none';
   };
+  monitorNewItems?: string;
   statistics: {
     seasonCount: number;
     episodeFileCount: number;
@@ -99,6 +101,7 @@ export interface AddSeriesOptions {
   seriesType: SonarrSeries['seriesType'];
   monitored?: boolean;
   searchNow?: boolean;
+  monitorNewItems?: string;
 }
 
 export interface LanguageProfile {
@@ -233,6 +236,7 @@ class SonarrAPI extends ServarrBase<{
         tags: options.tags,
         seasonFolder: options.seasonFolder,
         monitored: options.monitored,
+        monitorNewItems: options.monitorNewItems,
         rootFolderPath: options.rootFolderPath,
         seriesType: options.seriesType,
         addOptions: {

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -1272,6 +1272,7 @@ export class MediaRequest {
           tags,
           monitored: true,
           searchNow: !sonarrSettings.preventSearch,
+          monitorNewItems: sonarrSettings.monitorNewItems,
         };
 
         // Run this asynchronously so we don't wait for it on the UI side

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -93,6 +93,7 @@ export interface SonarrSettings extends DVRSettings {
   activeLanguageProfileId?: number;
   animeTags?: number[];
   enableSeasonFolders: boolean;
+  monitorNewItems?: 'all' | 'none';
 }
 
 interface Quota {

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -76,6 +76,9 @@ const messages = defineMessages('components.Settings.SonarrModal', {
   animeTags: 'Anime Tags',
   notagoptions: 'No tags.',
   selecttags: 'Select tags',
+  monitorNewItems: 'Monitor New Seasons',
+  monitorNewItemsAll: 'All Seasons',
+  monitorNewItemsNone: 'No Seasons',
 });
 
 interface SonarrModalProps {
@@ -252,6 +255,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
           syncEnabled: sonarr?.syncEnabled ?? false,
           enableSearch: !sonarr?.preventSearch,
           tagRequests: sonarr?.tagRequests ?? false,
+          monitorNewItems: sonarr?.monitorNewItems ?? 'all',
         }}
         validationSchema={SonarrSettingsSchema}
         onSubmit={async (values) => {
@@ -295,6 +299,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
               syncEnabled: values.syncEnabled,
               preventSearch: !values.enableSearch,
               tagRequests: values.tagRequests,
+              monitorNewItems: values.monitorNewItems,
             };
             if (!sonarr) {
               const res = await fetch('/api/v1/settings/sonarr', {
@@ -963,6 +968,28 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                         intl.formatMessage(messages.notagoptions)
                       }
                     />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label htmlFor="monitorNewItems" className="text-label">
+                    {intl.formatMessage(messages.monitorNewItems)}
+                  </label>
+                  <div className="form-input-area">
+                    <div className="form-input-field">
+                      <Field
+                        as="select"
+                        id="monitorNewItems"
+                        name="monitorNewItems"
+                        disabled={!isValidated || isTesting}
+                      >
+                        <option value="all">
+                          {intl.formatMessage(messages.monitorNewItemsAll)}
+                        </option>
+                        <option value="none">
+                          {intl.formatMessage(messages.monitorNewItemsNone)}
+                        </option>
+                      </Field>
+                    </div>
                   </div>
                 </div>
                 <div className="form-row">


### PR DESCRIPTION
This PR adds a new setting to the Sonarr configuration that allows users to control the 'Monitor New Seasons' (monitorNewItems) option when adding a new series. Users can now choose between 'All Seasons' (default) and 'No Seasons', providing more granular control over future season monitoring.

This is necessary because currently, seerr always adds seasons requested by users to sonarr with the setting enabled, which leads to new seasons that weren't actually requested by anyone being downloaded. For example, if someone requests season 2, and season 3 comes out for a show before the season 2 request/show/etc are deleted, season 3 will be auto-downloaded/monitored but with no corresponding request in seerr. I am trying to support a flow where every season and movie has a corresponding seerr request for automation purposes.