### PR TITLE
feat: add setting to disable Sonarr new season monitoring

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -665,6 +665,10 @@ components:
         activeAnimeDirectory:
           type: string
           nullable: true
+        monitorNewItems:
+          type: string
+          enum: [all, none]
+          example: all
         is4k:
           type: boolean
           example: false

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -75,7 +75,9 @@ export interface SonarrSeries {
     ignoreEpisodesWithFiles?: boolean;
     ignoreEpisodesWithoutFiles?: boolean;
     searchForMissingEpisodes?: boolean;
+    monitor?: 'firstSeason' | 'latestSeason' | 'none';
   };
+  monitorNewItems?: string;
   statistics: {
     seasonCount: number;
     episodeFileCount: number;
@@ -99,6 +101,7 @@ export interface AddSeriesOptions {
   seriesType: SonarrSeries['seriesType'];
   monitored?: boolean;
   searchNow?: boolean;
+  monitorNewItems?: string;
 }
 
 export interface LanguageProfile {
@@ -269,6 +272,7 @@ class SonarrAPI extends ServarrBase<{
           tags: options.tags,
           seasonFolder: options.seasonFolder,
           monitored: options.monitored,
+          monitorNewItems: options.monitorNewItems,
           rootFolderPath: options.rootFolderPath,
           seriesType: options.seriesType,
           addOptions: {

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -93,6 +93,7 @@ export interface SonarrSettings extends DVRSettings {
   activeLanguageProfileId?: number;
   animeTags?: number[];
   enableSeasonFolders: boolean;
+  monitorNewItems?: 'all' | 'none';
 }
 
 interface Quota {

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -694,6 +694,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           tags,
           monitored: true,
           searchNow: !sonarrSettings.preventSearch,
+          monitorNewItems: sonarrSettings.monitorNewItems,
         };
 
         // Run entity asynchronously so we don't wait for it on the UI side

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -78,6 +78,9 @@ const messages = defineMessages('components.Settings.SonarrModal', {
   animeTags: 'Anime Tags',
   notagoptions: 'No tags.',
   selecttags: 'Select tags',
+  monitorNewItems: 'Monitor New Seasons',
+  monitorNewItemsAll: 'All Seasons',
+  monitorNewItemsNone: 'No Seasons',
 });
 
 interface SonarrModalProps {
@@ -247,6 +250,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
           syncEnabled: sonarr?.syncEnabled ?? false,
           enableSearch: !sonarr?.preventSearch,
           tagRequests: sonarr?.tagRequests ?? false,
+          monitorNewItems: sonarr?.monitorNewItems ?? 'all',
         }}
         validationSchema={SonarrSettingsSchema}
         onSubmit={async (values) => {
@@ -290,6 +294,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
               syncEnabled: values.syncEnabled,
               preventSearch: !values.enableSearch,
               tagRequests: values.tagRequests,
+              monitorNewItems: values.monitorNewItems,
             };
             if (!sonarr) {
               await axios.post('/api/v1/settings/sonarr', submission);
@@ -955,6 +960,28 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                         intl.formatMessage(messages.notagoptions)
                       }
                     />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label htmlFor="monitorNewItems" className="text-label">
+                    {intl.formatMessage(messages.monitorNewItems)}
+                  </label>
+                  <div className="form-input-area">
+                    <div className="form-input-field">
+                      <Field
+                        as="select"
+                        id="monitorNewItems"
+                        name="monitorNewItems"
+                        disabled={!isValidated || isTesting}
+                      >
+                        <option value="all">
+                          {intl.formatMessage(messages.monitorNewItemsAll)}
+                        </option>
+                        <option value="none">
+                          {intl.formatMessage(messages.monitorNewItemsNone)}
+                        </option>
+                      </Field>
+                    </div>
                   </div>
                 </div>
                 <div className="form-row">


### PR DESCRIPTION
This PR adds a new setting to the Sonarr configuration that allows users to control the 'Monitor New Seasons' (monitorNewItems) option when adding a new series. Users can now choose between 'All Seasons' (default) and 'No Seasons', providing more granular control over future season monitoring.

This addresses the need to prevent Sonarr from automatically monitoring future seasons for specific instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Monitor New Seasons" setting for Sonarr configuration, enabling you to choose whether new seasons are automatically monitored (all seasons or no seasons) when adding series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->