### PR TITLE
ci(create-tag): correct quote style in commit message for tag preparation

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Commit updated files
         run: |
           git add package.json
-          git commit -m 'chore(release): prepare ${TAG_VERSION}'
+          git commit -m "chore(release): prepare ${TAG_VERSION}"
           git push
 
       - name: Create git tag


### PR DESCRIPTION
## Description
<img width="397" height="52" alt="image" src="https://github.com/user-attachments/assets/b4fac756-9f31-45e2-be67-322938126f70" />

Single quote wouldn't interpolate the variable. This PR fixes that by using double quotes when creating the commit message in create-tag workflow.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formatting in workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->