### PR TITLE
fix(setup): fix Plex login not proceeding after authentication

### DIFF
--- a/src/components/Setup/LoginWithPlex.tsx
+++ b/src/components/Setup/LoginWithPlex.tsx
@@ -25,11 +25,14 @@ const LoginWithPlex = ({ onComplete }: LoginWithPlexProps) => {
 
   useEffect(() => {
     const login = async () => {
-      const response = await axios.post('/api/v1/auth/plex', { authToken });
-
-      if (response.data?.id) {
-        const { data: user } = await axios.get('/api/v1/auth/me');
-        revalidate(user, false);
+      try {
+        const response = await axios.post('/api/v1/auth/plex', { authToken });
+        if (response.data?.id) {
+          const { data: user } = await axios.get('/api/v1/auth/me');
+          revalidate(user, false);
+        }
+      } catch {
+        // auth failed silently, user can retry again
       }
     };
     if (authToken) {

--- a/src/components/Setup/SetupLogin.tsx
+++ b/src/components/Setup/SetupLogin.tsx
@@ -45,8 +45,9 @@ const SetupLogin: React.FC<LoginWithMediaServerProps> = ({
         authToken: authToken,
       });
 
-      if (response.data?.email) {
-        revalidate();
+      if (response.data?.id) {
+        const { data: user } = await axios.get('/api/v1/auth/me');
+        revalidate(user, false);
       }
     };
     if (authToken && mediaServerType == MediaServerType.PLEX) {

--- a/src/components/Setup/SetupLogin.tsx
+++ b/src/components/Setup/SetupLogin.tsx
@@ -41,13 +41,17 @@ const SetupLogin: React.FC<LoginWithMediaServerProps> = ({
 
   useEffect(() => {
     const login = async () => {
-      const response = await axios.post('/api/v1/auth/plex', {
-        authToken: authToken,
-      });
+      try {
+        const response = await axios.post('/api/v1/auth/plex', {
+          authToken: authToken,
+        });
 
-      if (response.data?.id) {
-        const { data: user } = await axios.get('/api/v1/auth/me');
-        revalidate(user, false);
+        if (response.data?.id) {
+          const { data: user } = await axios.get('/api/v1/auth/me');
+          revalidate(user, false);
+        }
+      } catch {
+        // auth failed silently and user can attempt again
       }
     };
     if (authToken && mediaServerType == MediaServerType.PLEX) {


### PR DESCRIPTION
## Description

During initial setup, after completing Plex OAuth, the wizard gets stuck on step 2 and requires a manual page reload to proceed.

This is because the auth effect checks `response.data?.emai`l to determine if login succeeded, but the Plex auth endpoint doesn't return an email, so `revalidate()` never gets called. The [login page correctly checks .id](https://github.com/seerr-team/seerr/pull/2290) instead. Also when revalidation is triggered, a bare `revalidate()` relies on SWR to refetch `/api/v1/auth/me` in the background, but `useUser` [disables all automatic revalidation on setup pages](https://github.com/seerr-team/seerr/pull/2213), making this unreliable. 

The PR adds a fix to explicitly fetch the user after auth and injects it directly into the SWR cache with `revalidate(user, false)`. This should match the pattern used in the login page.

- Fixes #2585

## How Has This Been Tested?

- Choose login plex in setup page
- Login
- Observe it automatically proceeding to next step

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Plex sign-in validation for more reliable success detection.
  * Ensures current user info is refreshed immediately after successful sign-in.
  * Fails silently on authentication errors to avoid disrupting the user and allow retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->