### PR TITLE
feat(i18n): add Estonian language support

### DIFF
--- a/server/api/tvdb/interfaces.ts
+++ b/server/api/tvdb/interfaces.ts
@@ -166,6 +166,7 @@ const TMDB_TO_TVDB_MAPPING: Record<string, string> & {
   el: 'ell', // Greek
   en: 'eng', // English
   es: 'spa', // Spanish
+  et: 'est', // Estonian
   fi: 'fin', // Finnish
   fr: 'fra', // French
   he: 'heb', // Hebrew

--- a/server/types/languages.d.ts
+++ b/server/types/languages.d.ts
@@ -9,6 +9,7 @@ export type AvailableLocale =
   | 'el'
   | 'es'
   | 'es-MX'
+  | 'et'
   | 'fi'
   | 'fr'
   | 'hr'

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -39,6 +39,10 @@ export const availableLanguages: AvailableLanguageObject = {
     code: 'es-MX',
     display: 'Español (Latinoamérica)',
   },
+  et: {
+    code: 'et',
+    display: 'Eesti',
+  },
   fi: {
     code: 'fi',
     display: 'Finnish',

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -47,6 +47,8 @@ const loadLocaleData = (locale: AvailableLocale): Promise<any> => {
       return import('../i18n/locale/es.json');
     case 'es-MX':
       return import('../i18n/locale/es_MX.json');
+    case 'et':
+      return import('../i18n/locale/et.json');
     case 'fi':
       return import('../i18n/locale/fi.json');
     case 'fr':


### PR DESCRIPTION
## Description

This PR adds Estonian (et) language support infrastructure to the application. The changes include:

- **Type definitions**: Added 'et' locale to AvailableLocale type definition
- **TVDB language mapping**: Added Estonian to TMDB→TVDB language mapping (et: 'est')
- **Frontend language registration**: Registered Estonian in the language context
- **App initialization**: Added Estonian locale import in the app loader

The actual translation strings are managed through Weblate at https://translate.seerr.dev and are now 100% complete. This PR provides the necessary infrastructure for Estonian translations to be pulled in via Weblate PRs.

Fixes #2529

## How Has This Been Tested?

- Type definitions verified to align with locale code structure
- Language mapping follows existing TVDB ISO 639-3 code patterns
- Frontend language registration matches the pattern used for other locales
- App loader import structure is consistent with other language implementations

## Screenshots / Logs (if applicable)

N/A - Infrastructure/localization changes

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice)) - No AI assistance used
- [x] I have updated the documentation accordingly. - Translations managed via Weblate
- [x] All new and existing tests passed. - Type checking and build validation
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required) - Not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Estonian (Eesti) locale across the app: UI language and translations are now available.
  * Language handling updated so Estonian preferences are recognized and used for external content lookups and locale fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->