### PR TITLE
fix(settings): remove beta info banner

### DIFF
--- a/src/components/Settings/SettingsAbout/index.tsx
+++ b/src/components/Settings/SettingsAbout/index.tsx
@@ -7,7 +7,6 @@ import Releases from '@app/components/Settings/SettingsAbout/Releases';
 import globalMessages from '@app/i18n/globalMessages';
 import Error from '@app/pages/_error';
 import defineMessages from '@app/utils/defineMessages';
-import { InformationCircleIcon } from '@heroicons/react/24/solid';
 import type {
   SettingsAboutResponse,
   StatusResponse,
@@ -30,8 +29,6 @@ const messages = defineMessages('components.Settings.SettingsAbout', {
   documentation: 'Documentation',
   outofdate: 'Out of Date',
   uptodate: 'Up to Date',
-  betawarning:
-    'This is BETA software. Features may be broken and/or unstable. Please report any issues on GitHub!',
   runningDevelop:
     'You are running the <code>develop</code> branch of Seerr, which is only recommended for those contributing to development or assisting with bleeding-edge testing.',
 });
@@ -60,28 +57,6 @@ const SettingsAbout = () => {
           intl.formatMessage(globalMessages.settings),
         ]}
       />
-      <div className="mt-6 rounded-md border border-indigo-500 bg-indigo-400/20 p-4 backdrop-blur">
-        <div className="flex">
-          <div className="flex-shrink-0">
-            <InformationCircleIcon className="h-5 w-5 text-gray-100" />
-          </div>
-          <div className="ml-3 flex-1 md:flex md:justify-between">
-            <p className="text-sm leading-5 text-gray-100">
-              {intl.formatMessage(messages.betawarning)}
-            </p>
-            <p className="mt-3 text-sm leading-5 md:ml-6 md:mt-0">
-              <a
-                href="http://github.com/seerr-team/seerr"
-                className="whitespace-nowrap font-medium text-gray-100 transition duration-150 ease-in-out hover:text-white"
-                target="_blank"
-                rel="noreferrer"
-              >
-                GitHub &rarr;
-              </a>
-            </p>
-          </div>
-        </div>
-      </div>
       <div className="section">
         <List title={intl.formatMessage(messages.aboutseerr)}>
           {data.version.startsWith('develop-') && (

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -861,7 +861,6 @@
   "components.Settings.SettingsAbout.about": "About",
   "components.Settings.SettingsAbout.aboutseerr": "About Seerr",
   "components.Settings.SettingsAbout.appDataPath": "Data Directory",
-  "components.Settings.SettingsAbout.betawarning": "This is BETA software. Features may be broken and/or unstable. Please report any issues on GitHub!",
   "components.Settings.SettingsAbout.contribute": "Make a Contribution",
   "components.Settings.SettingsAbout.documentation": "Documentation",
   "components.Settings.SettingsAbout.gettingsupport": "Getting Support",


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR removes the BETA software banner from the About page.

Seerr is no longer beta software, making this banner outdated and misleading; especially on stable releases, where it incorrectly suggests an unstable product.

On the develop branch (which includes previews), the banner was also redundant, as we already display a clear warning.

- Fixes #XXXX

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed the beta software warning from the Settings About section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->