### PR TITLE
fix(issues): update issue timestamp when adding comments

### DIFF
--- a/server/routes/issue.ts
+++ b/server/routes/issue.ts
@@ -293,7 +293,7 @@ issueRoutes.post<{ issueId: string }, Issue, { message: string }>(
       });
 
       issue.comments = [...issue.comments, comment];
-
+      issue.updatedAt = new Date();
       await issueRepository.save(issue);
 
       return res.status(200).json(issue);


### PR DESCRIPTION
## Description

Adding a comment to an issue didn't update the issue's `updatedAt` timestamp because TypeORM only cascades the insert into the comments table without touching the issue row itself. This meant the "Last Modified" sort order wouldn't reflect recent comment activity. This fix explicitly sets `updatedAt` on the issue when a new comment is saved, restoring the expected behavior.

- Fixes #2608

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue last-updated timestamps now properly reflect when new comments are added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->