### PR TITLE
fix(email): preserve newlines in PGP key textarea fields

### DIFF
--- a/src/components/Common/SensitiveInput/index.tsx
+++ b/src/components/Common/SensitiveInput/index.tsx
@@ -20,7 +20,7 @@ const SensitiveInput = ({ as = 'input', ...props }: SensitiveInputProps) => {
       ? props
       : {
           ...props,
-          as: props.type === 'textarea' && !isHidden ? 'textarea' : undefined,
+          as: props.type === 'textarea' ? 'textarea' : undefined,
         };
   return (
     <>
@@ -32,11 +32,18 @@ const SensitiveInput = ({ as = 'input', ...props }: SensitiveInputProps) => {
         {...componentProps}
         className={`rounded-l-only ${componentProps.className ?? ''}`}
         type={
-          isHidden
-            ? 'password'
-            : props.type !== 'password'
-              ? (props.type ?? 'text')
-              : 'text'
+          props.type === 'textarea'
+            ? undefined
+            : isHidden
+              ? 'password'
+              : props.type !== 'password'
+                ? (props.type ?? 'text')
+                : 'text'
+        }
+        style={
+          props.type === 'textarea' && isHidden
+            ? { WebkitTextSecurity: 'disc', ...props.style }
+            : props.style
         }
       />
       <button

--- a/src/components/Settings/Notifications/NotificationsEmail.tsx
+++ b/src/components/Settings/Notifications/NotificationsEmail.tsx
@@ -106,7 +106,7 @@ const NotificationsEmail = () => {
           otherwise: Yup.string().nullable(),
         })
         .matches(
-          /-----BEGIN PGP PRIVATE KEY BLOCK-----.+-----END PGP PRIVATE KEY BLOCK-----/,
+          /-----BEGIN PGP PRIVATE KEY BLOCK-----.+-----END PGP PRIVATE KEY BLOCK-----/s,
           intl.formatMessage(messages.validationPgpPrivateKey)
         ),
       pgpPassword: Yup.string().when('pgpPrivateKey', {


### PR DESCRIPTION
## Description

The PGP Private Key field in email notification settings was silently stripping newline characters, causing OpenPGP encryption to fail with a "Misformed armored text" error at send time.

When the sensitive input component was in its default hidden state, `textarea` fields were being rendered as single-line password inputs. The browser collapses all whitespace in password inputs, so the PGP armor block lost its required line structure. `Formik` then synced the destroyed value back into form state, making the damage permanent even after toggling visibility.

The sensitive input component now keeps `textarea` fields rendered as actual `textarea` elements regardless of visibility state, using CSS-based masking instead of switching the element type. The PGP key validation regex has also been updated to correctly match across newlines.

- Fixes #2598

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed sensitive textarea field rendering and styling when content is hidden.
  * Enabled PGP private key validation to correctly accept multi-line key blocks for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->