### PR TITLE
fix(email): correctly classify final MIME header in PGP email encryption

### DIFF
--- a/server/lib/email/openpgpEncrypt.ts
+++ b/server/lib/email/openpgpEncrypt.ts
@@ -80,29 +80,24 @@ class PGPEncryptor extends Transform {
       let previousHeader: string[] = [];
       for (let i = 0; i < linesInHeader.length; i++) {
         const line = linesInHeader[i];
-        /**
-         * If it is a multi-line header (current line starts with whitespace)
-         * or it's the first line in the iteration
-         * add the current line with previous header and move on
-         */
+
         if (/^\s/.test(line) || i === 0) {
           previousHeader.push(line);
-          continue;
+        } else {
+          if (
+            /^(content-type|content-transfer-encoding):/i.test(
+              previousHeader[0]
+            )
+          ) {
+            contentHeaders.push(previousHeader);
+          } else {
+            emailHeaders.push(previousHeader);
+          }
+          previousHeader = [line];
         }
+      }
 
-        /**
-         * This is done to prevent the last header
-         * from being missed
-         */
-        if (i === linesInHeader.length - 1) {
-          previousHeader.push(line);
-        }
-
-        /**
-         * We need to seperate the actual content headers
-         * so that we can add it as a header for the encrypted content
-         * So that the content will be displayed properly after decryption
-         */
+      if (previousHeader.length > 0) {
         if (
           /^(content-type|content-transfer-encoding):/i.test(previousHeader[0])
         ) {
@@ -110,7 +105,6 @@ class PGPEncryptor extends Transform {
         } else {
           emailHeaders.push(previousHeader);
         }
-        previousHeader = [line];
       }
 
       // Generate a new boundary for the email content


### PR DESCRIPTION
## Description

OpenPGP encrypted emails were rendering as raw HTML and MIME source code in mail clients instead of formatted content after decryption.

The PGP encryptor splits outgoing email headers into two groups:
1. transport headers that stay on the outer message, 
2. and content headers that get included inside the encrypted payload.
 
The header parsing loop had a special case for the final header line that merged it into the previous header unconditionally, causing it to be misclassified. In practice this meant the Content-Type multipart/alternative header (which declares the MIME boundaries) ended up in the outer transport headers instead of inside the encrypted payload.

After decryption, mail clients had no Content-Type header to interpret the MIME structure, so they rendered the raw boundaries and HTML source as plain text. The parsing loop now classifies every header independently, including the final one, so the encrypted payload contains the correct content headers for proper rendering after decryption.

- Fixes #2599 

## How Has This Been Tested?


## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of email header processing logic in encryption operations. No changes to end-user functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->