### PR TITLE
feat(email): add German email templates (de)

### DIFF
--- a/server/templates/email/de/_helpers.pug
+++ b/server/templates/email/de/_helpers.pug
@@ -1,0 +1,85 @@
+//- DE email template helpers
+//- - Keeps parity with EN helpers where possible.
+//- - Provides helpers as callable functions *and* string-coercible values
+
+- var __isMovie = (typeof mediaType !== 'undefined' && mediaType === 'movie') || (typeof __isMovie !== 'undefined' && __isMovie)
+- var __isSeries = (typeof mediaType !== 'undefined' && mediaType === 'tv') || (typeof __isSeries !== 'undefined' && __isSeries)
+
+//- ---------------------------------------------------------------------------
+//- String-or-function helpers: usable as "#{__helper}" AND "#{__helper()}"
+//- ---------------------------------------------------------------------------
+- function __mkStrFn(s) {
+-   const f = function () { return s; };
+-   f.toString = function () { return s; };
+-   f.valueOf = function () { return s; };
+-   return f;
+- }
+
+- var __followingAcc = __mkStrFn(__isMovie ? 'den folgenden Film' : 'die folgende Serie')
+- var __mediaLabelAcc = __mkStrFn(__isMovie ? 'den Film' : 'die Serie')
+- var __mediaLabelDat = __mkStrFn(__isMovie ? 'dem Film' : 'der Serie')
+
+//- ---------------------------------------------------------------------------
+//- Subjects (DE) - must exist, used by many subject.pug templates
+//- ---------------------------------------------------------------------------
+- function __reqSubject(type) {
+-   const __prefix4k = (typeof is4k !== 'undefined' && is4k) ? '4K ' : '';
+-   if (type === 'MEDIA_REQUEST' || type === 'MEDIA_REQUEST_PENDING') return __prefix4k + (__isMovie ? 'Neue Film-Anfrage' : 'Neue Serien-Anfrage')
+-   if (type === 'MEDIA_REQUEST_APPROVED' || type === 'MEDIA_REQUEST_AUTO_APPROVED') return __prefix4k + (__isMovie ? 'Film-Anfrage genehmigt' : 'Serien-Anfrage genehmigt')
+-   if (type === 'MEDIA_REQUEST_DECLINED') return __prefix4k + (__isMovie ? 'Film-Anfrage abgelehnt' : 'Serien-Anfrage abgelehnt')
+-   if (type === 'MEDIA_REQUEST_AVAILABLE') return __prefix4k + (__isMovie ? 'Film jetzt verfügbar' : 'Serie jetzt verfügbar')
+-   if (type === 'MEDIA_REQUEST_FAILED') return __prefix4k + (__isMovie ? 'Film-Anfrage fehlgeschlagen' : 'Serien-Anfrage fehlgeschlagen')
+-   if (type === 'MEDIA_REQUEST_AUTO_REQUESTED') return __prefix4k + (__isMovie ? 'Film-Anfrage automatisch erstellt' : 'Serien-Anfrage automatisch erstellt')
+-   return __prefix4k + (__isMovie ? 'Film-Anfrage' : 'Serien-Anfrage')
+- }
+
+- function __issueSubject(type, issueTypeName) {
+-   const it = (issueTypeName && String(issueTypeName).trim()) ? String(issueTypeName).trim() : '';
+-   // Localize + format: "Audio-Problem ...", "Video-Problem ...", "Untertitel-Problem ..."; OTHER stays without prefix
+-   let label = '';
+-   if (it) {
+-     const low = it.toLowerCase();
+-     if (low === 'subtitle' || low === 'subtitles') label = 'Untertitel';
+-     else if (low === 'other') label = '';
+-     else label = it;
+-   }
+-   const base = label ? (label + '-') : '';
+-   if (type === 'ISSUE_CREATED' || type === 'ISSUE_REPORTED' || type === 'ISSUE') return base + 'Problem gemeldet'
+-   if (type === 'ISSUE_RESOLVED') return base + 'Problem gelöst'
+-   if (type === 'ISSUE_REOPENED') return base + 'Problem wieder geöffnet'
+-   if (type === 'ISSUE_COMMENT') return base + 'Neuer Kommentar zum Problem'
+-   return base + 'Problem'
+- }
+
+//- ---------------------------------------------------------------------------
+//- Extra labels (DE): supports both enum-like keys and historic human strings
+//- ---------------------------------------------------------------------------
+- function __extraLabel(name, value) {
+-   // Requested Seasons
+-   if (name === 'REQUESTED_SEASONS' || name === 'Requested Seasons') {
+-     // value can be: number (1), string ('1' or '15, 21'), or array ([1,2])
+-     if (typeof value === 'number') return value === 1 ? 'Angefragte Staffel' : 'Angefragte Staffeln'
+-     if (Array.isArray(value)) return value.length === 1 ? 'Angefragte Staffel' : 'Angefragte Staffeln'
+-     if (typeof value === 'string') {
+-       const parts = value.split(',').map(s => s.trim()).filter(Boolean)
+-       return parts.length === 1 ? 'Angefragte Staffel' : 'Angefragte Staffeln'
+-     }
+-     return 'Angefragte Staffeln'
+-   }
+-   // Affected Season
+-   if (name === 'AFFECTED_SEASON' || name === 'Affected Season') {
+-     return 'Betroffene Staffel'
+-   }
+-   // Affected Episode
+-   if (name === 'AFFECTED_EPISODE' || name === 'Affected Episode') {
+-     return 'Betroffene Episode'
+-   }
+-   return name
+- }
+- __obfuscateUser = function(str) {
+-   // Same behavior as EN: keep identity (can be expanded later)
+-   return `${str || ''}`
+- }
+
+
+- __helper = (typeof helper !== 'undefined' ? helper : function() { return '' })

--- a/server/templates/email/de/generatedpassword/html.pug
+++ b/server/templates/email/de/generatedpassword/html.pug
@@ -1,0 +1,50 @@
+doctype html
+head
+  meta(charset='utf-8')
+  meta(name='x-apple-disable-message-reformatting')
+  meta(http-equiv='x-ua-compatible' content='ie=edge')
+  meta(name='viewport' content='width=device-width, initial-scale=1')
+  meta(name='format-detection' content='telephone=no, date=no, address=no, email=no')
+  link(href='https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap' rel='stylesheet' media='screen')
+  style.
+    .title:hover * {
+    text-decoration: underline;
+    }
+    @media only screen and (max-width:600px) {
+    table {
+    font-size: 20px !important;
+    width: 100% !important;
+    }
+    }
+div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
+  table(style='margin: 0 auto; font-family: Inter, Arial, sans-serif; color: #fff; font-size: 16px; width: 26rem;')
+    tr
+      td(style="text-align: center;")
+        if applicationUrl
+          a(href=applicationUrl style='margin: 0 1rem;')
+            img(src=applicationUrl +'/logo_full.png' style='width: 26rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        else
+          div(style='margin: 0 1rem 2.5rem; font-size: 3em; font-weight: 700;')
+            | #{applicationTitle}
+    if recipientName !== recipientEmail
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | Hallo, #{recipientName.replace(/\.|@/g, ((x) => x + '\ufeff'))}!
+    tr
+      td(style='text-align: center;')
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | Für dich wurde ein Konto bei #{applicationTitle} erstellt.
+    tr
+      td(style='text-align: center;')
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | Dein Passwort lautet:
+        div(style='font-size: 1.25em; font-weight: 500; line-height: 2.25em;')
+          span(style='padding: 0.5rem; font-weight: 500; border: 1px solid rgb(100,100,100); font-family: monospace;')
+            | #{password}
+    if applicationUrl
+      tr
+        td
+          a(href=applicationUrl style='display: block; margin: 1.5rem 3rem 0; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
+            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255,255,255,0.2);')
+              | #{applicationTitle} öffnen

--- a/server/templates/email/de/generatedpassword/subject.pug
+++ b/server/templates/email/de/generatedpassword/subject.pug
@@ -1,0 +1,2 @@
+include ../_helpers.pug
+!= `Kontoinformationen [${applicationTitle}]`

--- a/server/templates/email/de/media-issue/html.pug
+++ b/server/templates/email/de/media-issue/html.pug
@@ -1,0 +1,65 @@
+include ../_helpers.pug
+doctype html
+head
+  meta(charset='utf-8')
+  meta(name='x-apple-disable-message-reformatting')
+  meta(http-equiv='x-ua-compatible' content='ie=edge')
+  meta(name='viewport' content='width=device-width, initial-scale=1')
+  meta(name='format-detection' content='telephone=no, date=no, address=no, email=no')
+  link(href='https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap' rel='stylesheet' media='screen')
+  style.
+    .title:hover * {
+    text-decoration: underline;
+    }
+    @media only screen and (max-width:600px) {
+    table {
+    font-size: 20px !important;
+    width: 100% !important;
+    }
+    }
+div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
+  table(style='margin: 0 auto; font-family: Inter, Arial, sans-serif; color: #fff; font-size: 16px; width: 26rem;')
+    tr
+      td(style="text-align: center;")
+        if applicationUrl
+          a(href=applicationUrl style='margin: 0 1rem;')
+            img(src=applicationUrl +'/logo_full.png' style='width: 26rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        else
+          div(style='margin: 0 1rem 2.5rem; font-size: 3em; font-weight: 700;')
+            | #{applicationTitle}
+    if recipientName !== recipientEmail
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | Hallo, #{recipientName.replace(/\.|@/g, ((x) => x + '\ufeff'))}!
+    tr
+      td(style='text-align: center;')
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          - var __it = (typeof issueTypeName !== 'undefined' ? issueTypeName : '')
+          - var __t = (typeof type !== 'undefined' ? type : '')
+          - if (__t === 'ISSUE_CREATED')
+            | Ein neues Problem wurde von #{__obfuscateUser(issueCreatedBy)} für #{__mediaLabelAcc()} #{mediaName} gemeldet:
+          - else if (__t === 'ISSUE_COMMENT')
+            | #{__obfuscateUser(commentUser)} hat einen Kommentar zum Problem bei #{__mediaLabelDat()} #{mediaName} geschrieben:
+          - else if (__t === 'ISSUE_RESOLVED')
+            | Das Problem bei #{__mediaLabelDat()} #{mediaName} wurde von #{__obfuscateUser(issueModifiedBy)} als gelöst markiert!
+          - else if (__t === 'ISSUE_REOPENED')
+            | Das Problem bei #{__mediaLabelDat()} #{mediaName} wurde von #{__obfuscateUser(issueModifiedBy)} erneut geöffnet.
+          - else
+            | #{body}
+    if issueComment
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | #{issueComment}
+    else if issueDescription
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | #{issueDescription}
+    if actionUrl
+      tr
+        td
+          a(href=actionUrl style='display: block; margin: 1.5rem 3rem 0; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
+            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255,255,255,0.2);')
+              | Problem in #{applicationTitle} anzeigen

--- a/server/templates/email/de/media-issue/subject.pug
+++ b/server/templates/email/de/media-issue/subject.pug
@@ -1,0 +1,2 @@
+include ../_helpers.pug
+!= `${__issueSubject(notificationTypeKey, issueTypeName)} - ${mediaName} [${applicationTitle}]`

--- a/server/templates/email/de/media-request/body.pug
+++ b/server/templates/email/de/media-request/body.pug
@@ -1,0 +1,18 @@
+- const __nt = (typeof notificationType !== "undefined" ? String(notificationType) : "")
+case __nt
+  when "MEDIA_PENDING"
+    | Eine neue Anfrage für #{__followingAcc()} #{__prefix4k}wartet auf Freigabe:
+  when "MEDIA_AUTO_REQUESTED"
+    | Eine neue Anfrage für #{__followingAcc()} #{__prefix4k}wartet auf Freigabe:
+  when "MEDIA_APPROVED"
+    | Eine Anfrage für #{__followingAcc()} #{__prefix4k}wurde freigegeben:
+  when "MEDIA_AUTO_APPROVED"
+    | Eine Anfrage für #{__followingAcc()} #{__prefix4k}wurde automatisch freigegeben:
+  when "MEDIA_DECLINED"
+    | Eine Anfrage für #{__followingAcc()} #{__prefix4k}wurde abgelehnt:
+  when "MEDIA_AVAILABLE"
+    | #{__followingAcc()} #{__prefix4k}ist jetzt verfügbar:
+  when "MEDIA_FAILED"
+    | Bei #{((typeof is4k !== "undefined" && is4k) ? (__isMovie ? "dem 4K Film" : "der 4K Serie") : __mediaLabelDat())} ist ein Fehler aufgetreten:
+  default
+    | Eine Benachrichtigung zu #{__followingAcc()} #{__prefix4k}:

--- a/server/templates/email/de/media-request/html.pug
+++ b/server/templates/email/de/media-request/html.pug
@@ -1,0 +1,66 @@
+include ../_helpers.pug
+
+doctype html
+head
+  meta(charset='utf-8')
+  meta(name='x-apple-disable-message-reformatting')
+  meta(http-equiv='x-ua-compatible' content='ie=edge')
+  meta(name='viewport' content='width=device-width, initial-scale=1')
+  meta(name='format-detection' content='telephone=no, date=no, address=no, email=no')
+  link(href='https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap' rel='stylesheet' media='screen')
+  style.
+    .title:hover * {
+    text-decoration: underline;
+    }
+    @media only screen and (max-width:600px) {
+    table {
+    font-size: 20px !important;
+    width: 100% !important;
+    }
+    }
+div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
+  table(style='margin: 0 auto; font-family: Inter, Arial, sans-serif; color: #fff; font-size: 16px; width: 26rem;')
+    tr
+      td(style="text-align: center;")
+        if applicationUrl
+          a(href=applicationUrl style='margin: 0 1rem;')
+            img(src=applicationUrl +'/logo_full.png' style='width: 26rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        else
+          div(style='margin: 0 1rem 2.5rem; font-size: 3em; font-weight: 700;')
+            | #{applicationTitle}
+    if recipientName !== recipientEmail
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | Hallo, #{recipientName.replace(/\.|@/g, ((x) => x + '\ufeff'))}!
+    tr
+      td(style='text-align: center;')
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          include ./body.pug
+tr
+      td
+        div(style='box-sizing: border-box; margin: 1.5rem 0 0; width: 100%; color: #fff; border-radius: .75rem; padding: 1rem; border: 1px solid rgb(100,100,100); background: linear-gradient(135deg, rgba(17,24,39,0.47) 0%, rgb(17,24,39) 75%), url(' + imageUrl + ') center 25%/cover')
+          table(style='color: #fff; width: 100%;')
+            tr
+              td(style='vertical-align: top;')
+                a(href=actionUrl style='display: block; max-width: 20rem; color: #fff; font-weight: 700; text-decoration: none; margin: 0 1rem 0.25rem 0; font-size: 1.3em; line-height: 1.25em; margin-bottom: 5px;' class='title')
+                  | #{mediaName}
+                div(style='overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #d1d5db; font-size: .975em; line-height: 1.45em; padding-top: .25rem; padding-bottom: .25rem;')
+                  span(style='display: block;')
+                    b(style='color: #9ca3af; font-weight: 700;')
+                      | Angefragt von&nbsp;
+                    | #{requestedBy.replace(/\.|@/g, ((x) => x + '\ufeff'))}
+                  each extra in mediaExtra
+                    span(style='display: block;')
+                      b(style='color: #9ca3af; font-weight: 700;')
+                        | #{__extraLabel(extra.name, extra.value)}:&nbsp;
+                      | #{extra.value}
+              if imageUrl
+                td(rowspan='2' style='width: 7rem;')
+                  a(style='display: block; width: 7rem; overflow: hidden; border-radius: .375rem;' href=actionUrl)
+                    div(style='overflow: hidden; box-sizing: border-box; margin: 0px;')
+                      img(alt='' src=imageUrl style='box-sizing: border-box; padding: 0px; border: none; margin: auto; display: block; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;')
+            tr
+              td(style='font-size: .85em; color: #9ca3af; line-height: 1em; vertical-align: bottom; margin-right: 1rem')
+                span
+                  | #{timestamp}

--- a/server/templates/email/de/media-request/subject.pug
+++ b/server/templates/email/de/media-request/subject.pug
@@ -1,0 +1,22 @@
+- const __nt = (typeof notificationType !== "undefined" ? String(notificationType) : "")
+- const __isMovie = (typeof isMovie !== "undefined" ? !!isMovie : false)
+- const __kind = __isMovie ? "Film" : "Serie"
+- const __kindReq = __isMovie ? "Filmanfrage" : "Serienanfrage"
+
+case __nt
+  when "MEDIA_PENDING"
+    | Neue #{__kindReq} – #{mediaName} [#{applicationTitle}]
+  when "MEDIA_AUTO_REQUESTED"
+    | Neue #{__kindReq} – #{mediaName} [#{applicationTitle}]
+  when "MEDIA_APPROVED"
+    | #{__kindReq} genehmigt – #{mediaName} [#{applicationTitle}]
+  when "MEDIA_AUTO_APPROVED"
+    | #{__kindReq} genehmigt – #{mediaName} [#{applicationTitle}]
+  when "MEDIA_DECLINED"
+    | #{__kindReq} abgelehnt – #{mediaName} [#{applicationTitle}]
+  when "MEDIA_AVAILABLE"
+    | #{__kind} verfügbar – #{mediaName} [#{applicationTitle}]
+  when "MEDIA_FAILED"
+    | #{__kindReq} fehlgeschlagen – #{mediaName} [#{applicationTitle}]
+  default
+    | #{__kindReq} – #{mediaName} [#{applicationTitle}]

--- a/server/templates/email/de/resetpassword/html.pug
+++ b/server/templates/email/de/resetpassword/html.pug
@@ -1,0 +1,50 @@
+doctype html
+head
+  meta(charset='utf-8')
+  meta(name='x-apple-disable-message-reformatting')
+  meta(http-equiv='x-ua-compatible' content='ie=edge')
+  meta(name='viewport' content='width=device-width, initial-scale=1')
+  meta(name='format-detection' content='telephone=no, date=no, address=no, email=no')
+  link(href='https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap' rel='stylesheet' media='screen')
+  style.
+    .title:hover * {
+    text-decoration: underline;
+    }
+    @media only screen and (max-width:600px) {
+    table {
+    font-size: 20px !important;
+    width: 100% !important;
+    }
+    }
+div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
+  table(style='margin: 0 auto; font-family: Inter, Arial, sans-serif; color: #fff; font-size: 16px; width: 26rem;')
+    tr
+      td(style="text-align: center;")
+        if applicationUrl
+          a(href=applicationUrl style='margin: 0 1rem;')
+            img(src=applicationUrl +'/logo_full.png' style='width: 26rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        else
+          div(style='margin: 0 1rem 2.5rem; font-size: 3em; font-weight: 700;')
+            | #{applicationTitle}
+    if recipientName !== recipientEmail
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | Hallo, #{recipientName.replace(/\.|@/g, ((x) => x + '\ufeff'))}!
+    tr
+      td(style='text-align: center;')
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | Es wurde eine Anfrage gestellt, das Passwort für dein #{applicationTitle}-Konto zu ändern.
+    tr
+      td
+        a(href=resetPasswordLink style='display: block; margin: 1.5rem 3rem; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
+          span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255,255,255,0.2);')
+            | Passwort zurücksetzen
+    tr
+      td(style='text-align: center;')
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | Der obige Link ist 24 Stunden gültig.
+    tr
+      td(style='text-align: center;')
+        div(style='margin: 1rem 1rem 0; font-size: 1.25em;')
+          | Wenn du diese Anfrage nicht ausgelöst hast, kannst du diese Nachricht ignorieren.

--- a/server/templates/email/de/resetpassword/subject.pug
+++ b/server/templates/email/de/resetpassword/subject.pug
@@ -1,0 +1,2 @@
+include ../_helpers.pug
+!= `Passwort zurücksetzen [${applicationTitle}]`

--- a/server/templates/email/de/test-email/html.pug
+++ b/server/templates/email/de/test-email/html.pug
@@ -1,0 +1,43 @@
+doctype html
+head
+  meta(charset='utf-8')
+  meta(name='x-apple-disable-message-reformatting')
+  meta(http-equiv='x-ua-compatible' content='ie=edge')
+  meta(name='viewport' content='width=device-width, initial-scale=1')
+  meta(name='format-detection' content='telephone=no, date=no, address=no, email=no')
+  link(href='https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap' rel='stylesheet' media='screen')
+  style.
+    .title:hover * {
+    text-decoration: underline;
+    }
+    @media only screen and (max-width:600px) {
+    table {
+    font-size: 20px !important;
+    width: 100% !important;
+    }
+    }
+div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
+  table(style='margin: 0 auto; font-family: Inter, Arial, sans-serif; color: #fff; font-size: 16px; width: 26rem;')
+    tr
+      td(style="text-align: center;")
+        if applicationUrl
+          a(href=applicationUrl style='margin: 0 1rem;')
+            img(src=applicationUrl +'/logo_full.png' style='width: 26rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        else
+          div(style='margin: 0 1rem 2.5rem; font-size: 3em; font-weight: 700;')
+            | #{applicationTitle}
+    if recipientName !== recipientEmail
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | Hallo, #{recipientName.replace(/\.|@/g, ((x) => x + '\ufeff'))}!
+    tr
+      td(style='text-align: center;')
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | Check check, 1, 2, 3. Kommt das klar und deutlich an?
+    if applicationUrl
+      tr
+        td
+          a(href=applicationUrl style='display: block; margin: 1.5rem 3rem 0; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
+            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(99,102,241); color: #fff; display: block; border: 1px solid rgba(255,255,255,0.2);')
+              | #{applicationTitle} öffnen

--- a/server/templates/email/de/test-email/subject.pug
+++ b/server/templates/email/de/test-email/subject.pug
@@ -1,0 +1,2 @@
+include ../_helpers.pug
+!= `Testbenachrichtigung [${applicationTitle}]`


### PR DESCRIPTION
Adds German (de) email templates under server/templates/email/de.

Notes:
- No runtime / routing changes in this PR (templates only).
- English templates remain the reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive German language email templates for account management, including password generation and reset notifications.
  * Added German language email templates for media request updates and issue tracking notifications.
  * Implemented localized German subject lines and dynamic content for all user communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->