### PR TITLE
feat(helm): Support sqlite to postgresql migration

### DIFF
--- a/charts/seerr-chart/Chart.yaml
+++ b/charts/seerr-chart/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: '>=1.23.0-0'
 name: seerr-chart
 description: Seerr helm chart for Kubernetes
 type: application
-version: 3.3.0
+version: 3.4.0
 # renovate: image=ghcr.io/seerr-team/seerr
 appVersion: 'v3.1.0'
 maintainers:

--- a/charts/seerr-chart/README.md
+++ b/charts/seerr-chart/README.md
@@ -73,6 +73,26 @@ If `replicaCount` value was used - remove it. Helm update should work fine after
 | podLabels | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` |  |
+| postgres.db_log_queries | bool | `false` |  |
+| postgres.db_name | string | `"seerr"` | Database name |
+| postgres.db_secret | string | `""` | Kubernetes basic-auth secret containing DB username and password |
+| postgres.enabled | bool | `false` | Specifies whether to use postgresql |
+| postgres.migration.enabled | bool | `false` | Enable SQLite to PostgreSQL migration initContainer using pgloader |
+| postgres.migration.image.pullPolicy | string | `"IfNotPresent"` |  |
+| postgres.migration.image.registry | string | `"ghcr.io"` |  |
+| postgres.migration.image.repository | string | `"ralgar/pgloader"` |  |
+| postgres.migration.image.tag | string | `"pr-1531"` |  |
+| postgres.network.db_host | string | `""` | IP or hostname of the database host |
+| postgres.network.db_port | int | `5432` | Database port |
+| postgres.socket.db_socket_path | string | `"/var/run/postgresql"` | Path to the postgresql socket if using socket connectivity |
+| postgres.ssl.db_ssl_ca | string | `""` |  |
+| postgres.ssl.db_ssl_ca_file | string | `""` |  |
+| postgres.ssl.db_ssl_cert | string | `""` |  |
+| postgres.ssl.db_ssl_cert_file | string | `""` |  |
+| postgres.ssl.db_ssl_key | string | `""` |  |
+| postgres.ssl.db_ssl_key_file | string | `""` |  |
+| postgres.ssl.db_ssl_reject_unauthorized | bool | `true` |  |
+| postgres.ssl.db_use_ssl | bool | `false` |  |
 | probes.livenessProbe | object | `{}` | Configure liveness probe |
 | probes.readinessProbe | object | `{}` | Configure readiness probe |
 | probes.startupProbe | string | `nil` | Configure startup probe |

--- a/charts/seerr-chart/templates/_helpers.tpl
+++ b/charts/seerr-chart/templates/_helpers.tpl
@@ -66,5 +66,9 @@ Create the name of the service account to use
 Create the name of the pvc config to use
 */}}
 {{- define "seerr.configPersistenceName" -}}
+{{- if .Values.config.persistence.existingClaim }}
+{{- .Values.config.persistence.existingClaim }}
+{{- else }}
 {{- default (printf "%s-config" (include "seerr.fullname" .)) .Values.config.persistence.name }}
+{{- end }}
 {{- end }}

--- a/charts/seerr-chart/templates/configmap-migration.yaml
+++ b/charts/seerr-chart/templates/configmap-migration.yaml
@@ -1,0 +1,74 @@
+{{- if and .Values.postgres.enabled .Values.postgres.migration.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "seerr.fullname" . }}-migration
+  labels:
+    {{- include "seerr.labels" . | nindent 4 }}
+data:
+  setup-schema.sh: |
+    #!/bin/sh
+    set -e
+
+    SEMAPHORE="/app/config/.migration-to-postgres-complete"
+
+    if [ -f "$SEMAPHORE" ]; then
+      echo "Schema setup already completed (semaphore file exists). Skipping."
+      exit 0
+    fi
+
+    echo "Starting Seerr to create PostgreSQL schema..."
+    npm start &
+    SEERR_PID=$!
+
+    echo "Waiting for Seerr to become ready on port 5055..."
+    TIMEOUT=120
+    ELAPSED=0
+    while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+      if wget -q --spider http://localhost:5055/ 2>/dev/null; then
+        echo "Seerr is ready. Schema should be created."
+        break
+      fi
+      sleep 2
+      ELAPSED=$((ELAPSED + 2))
+    done
+
+    if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+      echo "ERROR: Timed out waiting for Seerr to start."
+      kill "$SEERR_PID" 2>/dev/null || true
+      exit 1
+    fi
+
+    echo "Stopping Seerr..."
+    kill "$SEERR_PID" 2>/dev/null || true
+    wait "$SEERR_PID" 2>/dev/null || true
+    echo "Schema setup complete."
+  migrate.sh: |
+    #!/bin/sh
+    set -e
+
+    SEMAPHORE="/app/config/.migration-to-postgres-complete"
+
+    if [ -f "$SEMAPHORE" ]; then
+      echo "Migration already completed (semaphore file exists). Skipping."
+      exit 0
+    fi
+
+    SQLITE_DB="/app/config/db/db.sqlite3"
+    if [ ! -f "$SQLITE_DB" ]; then
+      echo "ERROR: SQLite database not found at $SQLITE_DB"
+      exit 1
+    fi
+
+    echo "Starting SQLite to PostgreSQL migration..."
+
+    PG_URI="postgresql://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+
+    pgloader --with "quote identifiers" \
+             --with "data only" \
+             "$SQLITE_DB" \
+             "$PG_URI"
+
+    echo "Migration completed successfully. Creating semaphore file."
+    touch "$SEMAPHORE"
+{{- end }}

--- a/charts/seerr-chart/templates/persistentvolumeclaim.yaml
+++ b/charts/seerr-chart/templates/persistentvolumeclaim.yaml
@@ -22,5 +22,5 @@ spec:
   {{- end }}
   resources:
     requests:
-      storage: "{{ .Values.config.persistence.size }}"
+      storage: {{ .Values.config.persistence.size | quote }}
 {{- end -}}

--- a/charts/seerr-chart/templates/statefulset.yaml
+++ b/charts/seerr-chart/templates/statefulset.yaml
@@ -103,7 +103,7 @@ spec:
       volumes:
         - name: config
           persistentVolumeClaim:
-            claimName: {{ if .Values.config.persistence.existingClaim }}{{ .Values.config.persistence.existingClaim }}{{- else }}{{ include "seerr.configPersistenceName" . }}{{- end }}
+            claimName: {{ include "seerr.configPersistenceName" . }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/seerr-chart/templates/statefulset.yaml
+++ b/charts/seerr-chart/templates/statefulset.yaml
@@ -28,6 +28,108 @@ spec:
       serviceAccountName: {{ include "seerr.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if and .Values.postgres.enabled .Values.postgres.migration.enabled }}
+      initContainers:
+        - name: setup-postgres-schema
+          {{- if .Values.image.sha }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
+          {{- else }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "/scripts/setup-schema.sh"]
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          env:
+            - name: DB_TYPE
+              value: postgres
+            - name: DB_NAME
+              value: {{ .Values.postgres.db_name }}
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.db_secret }}
+                  key: username
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.db_secret }}
+                  key: password
+            {{- if .Values.postgres.network.db_host }}
+            - name: DB_HOST
+              value: {{ .Values.postgres.network.db_host }}
+            - name: DB_PORT
+              value: {{ .Values.postgres.network.db_port | quote }}
+            {{- else }}
+            - name: DB_SOCKET_PATH
+              value: {{ .Values.postgres.socket.db_socket_path }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_use_ssl }}
+            - name: DB_USE_SSL
+              value: {{ .Values.postgres.ssl.db_use_ssl | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_reject_unauthorized }}
+            - name: DB_SSL_REJECT_UNAUTHORIZED
+              value: {{ .Values.postgres.ssl.db_ssl_reject_unauthorized | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_ca }}
+            - name: DB_SSL_CA
+              value: {{ .Values.postgres.ssl.db_ssl_ca | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_ca_file }}
+            - name: DB_SSL_CA_FILE
+              value: {{ .Values.postgres.ssl.db_ssl_ca_file | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_key }}
+            - name: DB_SSL_KEY
+              value: {{ .Values.postgres.ssl.db_ssl_key | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_key_file }}
+            - name: DB_SSL_KEY_FILE
+              value: {{ .Values.postgres.ssl.db_ssl_key_file | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_cert }}
+            - name: DB_SSL_CERT
+              value: {{ .Values.postgres.ssl.db_ssl_cert | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_cert_file }}
+            - name: DB_SSL_CERT_FILE
+              value: {{ .Values.postgres.ssl.db_ssl_cert_file | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+            - name: migration-script
+              mountPath: /scripts
+        - name: migrate-sqlite-to-postgres
+          image: "{{ .Values.postgres.migration.image.registry }}/{{ .Values.postgres.migration.image.repository }}:{{ .Values.postgres.migration.image.tag }}"
+          imagePullPolicy: {{ .Values.postgres.migration.image.pullPolicy }}
+          command: ["/bin/sh", "/scripts/migrate.sh"]
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.db_secret }}
+                  key: username
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.db_secret }}
+                  key: password
+            - name: DB_HOST
+              value: {{ .Values.postgres.network.db_host | quote }}
+            - name: DB_PORT
+              value: {{ .Values.postgres.network.db_port | quote }}
+            - name: DB_NAME
+              value: {{ .Values.postgres.db_name | quote }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+            - name: migration-script
+              mountPath: /scripts
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -86,9 +188,69 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.extraEnv }}
           env:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.postgres.enabled }}
+            - name: DB_TYPE
+              value: postgres
+            - name: DB_NAME
+              value: {{ .Values.postgres.db_name }}
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.db_secret }}
+                  key: username
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.db_secret }}
+                  key: password
+            {{- if .Values.postgres.network.db_host }}
+            - name: DB_HOST
+              value: {{ .Values.postgres.network.db_host }}
+            - name: DB_PORT
+              value: {{ .Values.postgres.network.db_port | quote }}
+            {{- else }}
+            - name: DB_SOCKET_PATH
+              value: {{ .Values.postgres.socket.db_socket_path }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_use_ssl }}
+            - name: DB_USE_SSL
+              value: {{ .Values.postgres.ssl.db_use_ssl | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_reject_unauthorized }}
+            - name: DB_SSL_REJECT_UNAUTHORIZED
+              value: {{ .Values.postgres.ssl.db_ssl_reject_unauthorized | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_ca }}
+            - name: DB_SSL_CA
+              value: {{ .Values.postgres.ssl.db_ssl_ca | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_ca_file }}
+            - name: DB_SSL_CA_FILE
+              value: {{ .Values.postgres.ssl.db_ssl_ca_file | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_key }}
+            - name: DB_SSL_KEY
+              value: {{ .Values.postgres.ssl.db_ssl_key | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_key_file }}
+            - name: DB_SSL_KEY_FILE
+              value: {{ .Values.postgres.ssl.db_ssl_key_file | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_cert }}
+            - name: DB_SSL_CERT
+              value: {{ .Values.postgres.ssl.db_ssl_cert | quote }}
+            {{- end }}
+            {{- if .Values.postgres.ssl.db_ssl_cert_file }}
+            - name: DB_SSL_CERT_FILE
+              value: {{ .Values.postgres.ssl.db_ssl_cert_file | quote }}
+            {{- end }}
+          {{- else }}
+            - name: DB_TYPE
+              value: sqlite
+            {{- with .Values.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.extraEnvFrom }}
           envFrom:
@@ -104,6 +266,12 @@ spec:
         - name: config
           persistentVolumeClaim:
             claimName: {{ include "seerr.configPersistenceName" . }}
+      {{- if and .Values.postgres.enabled .Values.postgres.migration.enabled }}
+        - name: migration-script
+          configMap:
+            name: {{ include "seerr.fullname" . }}-migration
+            defaultMode: 0555
+      {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/seerr-chart/values.yaml
+++ b/charts/seerr-chart/values.yaml
@@ -89,6 +89,40 @@ config:
     # -- Specify an existing `PersistentVolumeClaim` to use. If this value is provided, the default PVC will not be created
     existingClaim: ''
 
+postgres:
+  # -- Specifies whether to use postgresql
+  enabled: false
+  # -- Kubernetes basic-auth secret containing DB username and password
+  db_secret: ''
+  # -- Database name
+  db_name: seerr
+  db_log_queries: false
+  network:
+    # -- IP or hostname of the database host
+    db_host: ''
+    # -- Database port
+    db_port: 5432
+  socket:
+    # -- Path to the postgresql socket if using socket connectivity
+    db_socket_path: /var/run/postgresql
+  ssl:
+    db_use_ssl: false
+    db_ssl_reject_unauthorized: true
+    db_ssl_ca: ''
+    db_ssl_ca_file: ''
+    db_ssl_key: ''
+    db_ssl_key_file: ''
+    db_ssl_cert: ''
+    db_ssl_cert_file: ''
+  migration:
+    # -- Enable SQLite to PostgreSQL migration initContainer using pgloader
+    enabled: false
+    image:
+      registry: ghcr.io
+      repository: ralgar/pgloader
+      tag: pr-1531
+      pullPolicy: IfNotPresent
+
 ingress:
   enabled: false
   ingressClassName: ''


### PR DESCRIPTION
## Description

Adds explicit options for configuring a postgresql database as well migrating an existing sqlite database via initContainers.
There's also a trivial cleanup for determining the PVC name.

## How Has This Been Tested?

Tested locally with both sqlite database (default) and postgresql database with data migration.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)

`pnpm` steps skipped as not applicable.

## AI Disclosure

Claude assisted with writing the bash scripts in `templates/configmap-migration.yaml` and adding the initContainers in `templates/statefulset.yaml`. The overall approach to migration was directed by myself, and all generated code was reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL database support with comprehensive configuration options including credentials, network settings, socket paths, and SSL certificates.
  * Added automated SQLite-to-PostgreSQL migration capability.
  * Added support for existing PVC claims in persistence configuration.

* **Documentation**
  * Updated configuration documentation with PostgreSQL parameters.

* **Chores**
  * Bumped Helm chart version to 3.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->