### PR TITLE
fix(region-selector): prevent empty region reporting during sync

### DIFF
--- a/src/components/RegionSelector/index.tsx
+++ b/src/components/RegionSelector/index.tsx
@@ -83,19 +83,14 @@ const RegionSelector = ({
     }
   }, [value, regions, allRegion]);
 
-  useEffect(() => {
-    if (onChange && regions) {
-      if (selectedRegion) {
-        onChange(name, selectedRegion.iso_3166_1);
-      } else if (!value) {
-        onChange(name, '');
-      }
-    }
-  }, [onChange, selectedRegion, name, regions, value]);
+  const handleRegionSelect = (region: Region | null) => {
+    setSelectedRegion(region);
+    onChange?.(name, region?.iso_3166_1 ?? '');
+  };
 
   return (
     <div className="z-40 w-full">
-      <Listbox as="div" value={selectedRegion} onChange={setSelectedRegion}>
+      <Listbox as="div" value={selectedRegion} onChange={handleRegionSelect}>
         {({ open }) => (
           <div className="relative">
             <span className="inline-block w-full rounded-md shadow-sm">

--- a/src/components/RegionSelector/index.tsx
+++ b/src/components/RegionSelector/index.tsx
@@ -87,11 +87,11 @@ const RegionSelector = ({
     if (onChange && regions) {
       if (selectedRegion) {
         onChange(name, selectedRegion.iso_3166_1);
-      } else {
+      } else if (!value) {
         onChange(name, '');
       }
     }
-  }, [onChange, selectedRegion, name, regions]);
+  }, [onChange, selectedRegion, name, regions, value]);
 
   return (
     <div className="z-40 w-full">


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes an issue where reopening the filter panel could clear the selected streaming service filters.

The problem was caused by `RegionSelector` emitting `onChange('watchRegion', '')` during its initial state sync, before the region value from the parent was applied. `WatchProviderSelector` interpreted this as a real change and cleared the selected providers, which also removed the filter from the URL.

- Fixes #2622 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Region selector now handles selections more reliably and consistently notifies the parent of changes, ensuring external value updates are reflected correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->