### PR TITLE
feat(webhooks): add Jellyfin webhook endpoint

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -2132,6 +2132,14 @@ components:
       type: apiKey
       in: header
       name: X-Api-Key
+    webhookApiKeyHeader:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    webhookApiKeyQuery:
+      type: apiKey
+      in: query
+      name: apiKey
 
 paths:
   /status:
@@ -7901,13 +7909,9 @@ paths:
         Authenticates via apiKey query parameter or X-API-Key header.
       tags:
         - webhook
-      security: []
-      parameters:
-        - in: query
-          name: apiKey
-          schema:
-            type: string
-          description: Seerr API key for authentication
+      security:
+        - webhookApiKeyHeader: []
+        - webhookApiKeyQuery: []
       requestBody:
         content:
           application/json:
@@ -7938,6 +7942,8 @@ paths:
           description: Missing or invalid request body
         '401':
           description: Invalid API key
+        '500':
+          description: Internal server error - item processing failed
 security:
   - cookieAuth: []
   - apiKey: []

--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -7892,6 +7892,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OverrideRule'
+  /webhook/jellyfin:
+    post:
+      summary: Jellyfin webhook endpoint
+      description: >-
+        Receives webhook notifications from the Jellyfin Webhook Plugin.
+        Processes ItemAdded and ItemUpdated events to sync library availability.
+        Authenticates via apiKey query parameter or X-API-Key header.
+      tags:
+        - webhook
+      security: []
+      parameters:
+        - in: query
+          name: apiKey
+          schema:
+            type: string
+          description: Seerr API key for authentication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ItemId:
+                  type: string
+                  description: Jellyfin item ID to process
+                ItemIds:
+                  type: array
+                  items:
+                    type: string
+                  description: Batch of Jellyfin item IDs to process
+                NotificationType:
+                  type: string
+                  description: Jellyfin notification event type
+          text/plain:
+            schema:
+              type: string
+              description: JSON-encoded body sent as text/plain
+      responses:
+        '200':
+          description: Item processed successfully
+        '207':
+          description: Batch processed with partial errors
+        '400':
+          description: Missing or invalid request body
+        '401':
+          description: Invalid API key
 security:
   - cookieAuth: []
   - apiKey: []

--- a/server/index.ts
+++ b/server/index.ts
@@ -180,16 +180,24 @@ app
       }
     });
     if (settings.network.csrfProtection) {
-      server.use(
-        csurf({
-          cookie: {
-            httpOnly: true,
-            sameSite: true,
-            secure: !dev,
-          },
-        })
-      );
+      const csrfMiddleware = csurf({
+        cookie: {
+          httpOnly: true,
+          sameSite: true,
+          secure: !dev,
+        },
+      });
+      // Exempt webhook endpoints from CSRF — they use API key auth
       server.use((req, res, next) => {
+        if (req.path.startsWith('/api/v1/webhook/')) {
+          return next();
+        }
+        csrfMiddleware(req, res, next);
+      });
+      server.use((req, res, next) => {
+        if (req.path.startsWith('/api/v1/webhook/')) {
+          return next();
+        }
         res.cookie('XSRF-TOKEN', req.csrfToken(), {
           sameSite: true,
           secure: !dev,

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -30,6 +30,32 @@ interface JellyfinSyncStatus extends StatusBase {
   libraries: Library[];
 }
 
+export interface WebhookProcessResult {
+  itemId: string;
+  itemName: string;
+  itemType: string;
+  effectiveId: string;
+  skipped: boolean;
+}
+
+// Collapse queue for webhook processing.
+//
+// When a full season lands in Jellyfin it fires one ItemAdded webhook per
+// episode.  They all resolve to the same series ID ("effective ID").
+// Rather than scanning the series N times, we collapse them:
+//
+//   - First webhook for a given effective ID starts processing.
+//   - Subsequent webhooks while processing is active set a dirty flag
+//     and return immediately.
+//   - When the current processing finishes, if the dirty flag is set,
+//     we clear it and re-scan once more.  That re-scan sees the *latest*
+//     Jellyfin state (all newly added episodes), so nothing is missed.
+//   - If more webhooks arrive during the re-scan, they set dirty again,
+//     triggering one more re-scan, and so on until quiescence.
+//
+// Worst case for N near-simultaneous webhooks: ~2–3 full scans.
+const webhookCollapseQueue = new Map<string, { dirty: boolean }>();
+
 class JellyfinScanner
   extends BaseScanner<JellyfinLibraryItem>
   implements RunnableScanner<JellyfinSyncStatus>
@@ -535,6 +561,123 @@ class JellyfinScanner
     }
   }
 
+  /**
+   * Process a single Jellyfin item by ID (used by webhook endpoint).
+   *
+   * For TV content (Episode/Season), resolves to the parent Series and
+   * rescans all seasons/episodes so availability status is fully up to date.
+   *
+   * Uses a collapse queue with a dirty flag so that rapid-fire webhooks
+   * for the same series (e.g. a whole season being added) never cause
+   * missed items — see the `webhookCollapseQueue` comment above.
+   */
+  public async processItemById(itemId: string): Promise<WebhookProcessResult> {
+    const settings = getSettings();
+
+    if (
+      settings.main.mediaServerType != MediaServerType.JELLYFIN &&
+      settings.main.mediaServerType != MediaServerType.EMBY
+    ) {
+      throw new Error('Jellyfin/Emby is not configured as the media server');
+    }
+
+    const userRepository = getRepository(User);
+    const admin = await userRepository.findOne({
+      where: { id: 1 },
+      select: ['id', 'jellyfinUserId', 'jellyfinDeviceId'],
+      order: { id: 'ASC' },
+    });
+
+    if (!admin) {
+      throw new Error('No admin user configured');
+    }
+
+    // Create a Jellyfin client for this request
+    this.jfClient = new JellyfinAPI(
+      getHostname(),
+      settings.jellyfin.apiKey,
+      admin.jellyfinDeviceId
+    );
+    this.jfClient.setUserId(admin.jellyfinUserId ?? '');
+
+    // Fetch item to determine type and resolve series
+    const item = await this.jfClient.getItemData(itemId);
+    if (!item) {
+      throw new Error(`Item not found in Jellyfin: ${itemId}`);
+    }
+
+    // For TV content, the "effective ID" is the parent series — that's what
+    // actually gets scanned.  For movies it's the item itself.
+    const effectiveId =
+      item.Type === 'Episode' || item.Type === 'Season'
+        ? (item.SeriesId ?? item.SeasonId ?? item.Id)
+        : item.Id;
+
+    const result: WebhookProcessResult = {
+      itemId,
+      itemName: item.SeriesName ?? item.Name,
+      itemType: item.Type,
+      effectiveId,
+      skipped: false,
+    };
+
+    // ---- Collapse queue check (atomic — no await between check & set) ----
+    const existing = webhookCollapseQueue.get(effectiveId);
+    if (existing) {
+      existing.dirty = true;
+      this.log(
+        `Webhook: ${result.itemName} — re-scan queued (processing in progress)`,
+        'debug'
+      );
+      return { ...result, skipped: true };
+    }
+
+    const entry = { dirty: false };
+    webhookCollapseQueue.set(effectiveId, entry);
+
+    try {
+      do {
+        // Clear dirty *before* processing so any webhook that arrives
+        // during the await-heavy scan below will re-set it.
+        entry.dirty = false;
+
+        // Set up scanner state fresh each iteration
+        this.enable4kMovie = settings.radarr.some((radarr) => radarr.is4k);
+        this.enable4kShow = settings.sonarr.some((sonarr) => sonarr.is4k);
+        this.processedAnidbSeason = new Map();
+        await animeList.sync();
+
+        if (item.Type === 'Movie') {
+          await this.processJellyfinMovie(item);
+        } else if (
+          item.Type === 'Series' ||
+          item.Type === 'Season' ||
+          item.Type === 'Episode'
+        ) {
+          await this.processJellyfinShow(item);
+        } else {
+          throw new Error(`Unsupported item type: ${item.Type}`);
+        }
+
+        if (entry.dirty) {
+          this.log(
+            `Webhook: ${result.itemName} — dirty flag set during processing, re-scanning`,
+            'info'
+          );
+        }
+      } while (entry.dirty);
+
+      this.log(
+        `Webhook: Processed ${result.itemName} (${item.Type}${item.Type !== 'Movie' ? `, series: ${effectiveId}` : ''})`,
+        'info'
+      );
+
+      return result;
+    } finally {
+      webhookCollapseQueue.delete(effectiveId);
+    }
+  }
+
   public status(): JellyfinSyncStatus {
     return {
       running: this.running,
@@ -550,3 +693,15 @@ export const jellyfinFullScanner = new JellyfinScanner();
 export const jellyfinRecentScanner = new JellyfinScanner({
   isRecentOnly: true,
 });
+
+/**
+ * Process a single Jellyfin item by its ID, for use by the webhook endpoint.
+ * Creates a temporary scanner instance to avoid race conditions with
+ * scheduled scans.
+ */
+export async function processJellyfinItemById(
+  itemId: string
+): Promise<WebhookProcessResult> {
+  const scanner = new JellyfinScanner();
+  return await scanner.processItemById(itemId);
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -19,6 +19,7 @@ import { mapWatchProviderDetails } from '@server/models/common';
 import overrideRuleRoutes from '@server/routes/overrideRule';
 import settingsRoutes from '@server/routes/settings';
 import watchlistRoutes from '@server/routes/watchlist';
+import jellyfinWebhookRoutes from '@server/routes/webhooks/jellyfin';
 import {
   appDataPath,
   appDataPermissions,
@@ -44,6 +45,9 @@ import tvRoutes from './tv';
 import user from './user';
 
 const router = Router();
+
+// Webhook routes handle their own authentication
+router.use('/webhook/jellyfin', jellyfinWebhookRoutes);
 
 router.use(checkUser);
 

--- a/server/routes/webhooks/jellyfin.ts
+++ b/server/routes/webhooks/jellyfin.ts
@@ -1,0 +1,144 @@
+import type { WebhookProcessResult } from '@server/lib/scanners/jellyfin';
+import { processJellyfinItemById } from '@server/lib/scanners/jellyfin';
+import { getSettings } from '@server/lib/settings';
+import logger from '@server/logger';
+import express, { Router } from 'express';
+
+const jellyfinWebhookRoutes = Router();
+
+// Notification types that warrant re-scanning an item.
+// ItemAdded  = new file landed in library
+// ItemUpdated = metadata refreshed (provider IDs may now be available)
+const PROCESSABLE_TYPES = new Set(['ItemAdded', 'ItemUpdated']);
+
+// The Jellyfin Webhook Plugin's Generic destination defaults to
+// Content-Type: text/plain.  The global express.json() middleware only
+// parses application/json, so text/plain bodies arrive as undefined.
+// This local middleware catches text bodies and attempts JSON.parse so
+// the handler works regardless of Content-Type configuration.
+jellyfinWebhookRoutes.use(express.text({ type: 'text/*' }));
+
+jellyfinWebhookRoutes.post('/', async (req, res) => {
+  // If the body arrived as a plain-text string, attempt JSON parse.
+  if (typeof req.body === 'string') {
+    try {
+      req.body = JSON.parse(req.body);
+    } catch {
+      return res.status(400).json({
+        status: 400,
+        error: 'Invalid JSON in request body',
+      });
+    }
+  }
+  // ---- Auth (API key via query param or header) ----
+  const settings = getSettings();
+  const apiKey = (req.query.apiKey as string) ?? req.header('X-API-Key') ?? '';
+
+  if (apiKey !== settings.main.apiKey) {
+    return res.status(401).json({ status: 401, error: 'Unauthorized' });
+  }
+
+  // ---- Extract item IDs (single or batch) ----
+  const itemIds: string[] = [];
+
+  if (typeof req.body?.ItemId === 'string' && req.body.ItemId.trim()) {
+    itemIds.push(req.body.ItemId.trim());
+  }
+  if (Array.isArray(req.body?.ItemIds)) {
+    for (const id of req.body.ItemIds) {
+      if (typeof id === 'string' && id.trim()) {
+        itemIds.push(id.trim());
+      }
+    }
+  }
+
+  if (itemIds.length === 0) {
+    return res.status(400).json({
+      status: 400,
+      error: 'Missing required field: ItemId (string) or ItemIds (string[])',
+    });
+  }
+
+  // ---- Filter by notification type ----
+  // When the Jellyfin Webhook Plugin sends an event, only ItemAdded and
+  // ItemUpdated are relevant for library sync.  Everything else (playback,
+  // auth, tasks, etc.) is acknowledged but not processed.
+  // When NotificationType is absent (e.g. a manual curl) we process anyway.
+  const notificationType: string | undefined = req.body?.NotificationType;
+  if (notificationType && !PROCESSABLE_TYPES.has(notificationType)) {
+    return res.status(200).json({
+      status: 200,
+      message: `Ignored event type: ${notificationType}`,
+    });
+  }
+
+  const uniqueIds = [...new Set(itemIds)];
+
+  logger.info(
+    `Jellyfin webhook: ${uniqueIds.length} item(s) [${notificationType ?? 'manual'}]`,
+    {
+      label: 'Jellyfin Webhook',
+      itemIds: uniqueIds,
+    }
+  );
+
+  // ---- Process each item ----
+  const results: {
+    itemId: string;
+    status: 'success' | 'skipped' | 'error';
+    itemName?: string;
+    itemType?: string;
+    effectiveId?: string;
+    message: string;
+  }[] = [];
+
+  for (const itemId of uniqueIds) {
+    let result: WebhookProcessResult | undefined;
+
+    try {
+      result = await processJellyfinItemById(itemId);
+
+      if (result.skipped) {
+        results.push({
+          itemId,
+          status: 'skipped',
+          itemName: result.itemName,
+          itemType: result.itemType,
+          effectiveId: result.effectiveId,
+          message: 'Already processing — re-scan queued',
+        });
+      } else {
+        results.push({
+          itemId,
+          status: 'success',
+          itemName: result.itemName,
+          itemType: result.itemType,
+          effectiveId: result.effectiveId,
+          message: 'Processed successfully',
+        });
+      }
+    } catch (e) {
+      logger.error(`Jellyfin webhook: Failed to process ${itemId}`, {
+        label: 'Jellyfin Webhook',
+        errorMessage: e.message,
+      });
+      results.push({
+        itemId,
+        status: 'error',
+        message: e.message,
+      });
+    }
+  }
+
+  // Single item → flat response; batch → array
+  if (uniqueIds.length === 1) {
+    const r = results[0];
+    const statusCode = r.status === 'error' ? 500 : 200;
+    return res.status(statusCode).json(r);
+  }
+
+  const hasErrors = results.some((r) => r.status === 'error');
+  return res.status(hasErrors ? 207 : 200).json({ results });
+});
+
+export default jellyfinWebhookRoutes;


### PR DESCRIPTION
## Description

Adds a webhook endpoint at `/webhook/jellyfin` that receives push notifications from the Jellyfin Webhook Plugin, giving event-driven library sync instead of waiting for the next scheduled scan.

### How it works

1. The Jellyfin Webhook Plugin fires an HTTP POST when library events occur (e.g. `ItemAdded`, `ItemUpdated`).
2. The endpoint authenticates the request via API key (query param or `X-API-Key` header). It also handles the plugin's default `text/plain` Content-Type by parsing it as JSON locally.
3. It extracts one or more item IDs from the body (`ItemId` or `ItemIds`), then filters by `NotificationType` — only `ItemAdded` and `ItemUpdated` are processed; everything else (playback, auth, tasks) is acknowledged and ignored.
4. For each item, it resolves the effective target: movies are processed directly, while episodes and seasons resolve up to their parent series so the entire show is rescanned.
5. A collapse queue prevents redundant work when a full season lands and Jellyfin fires one webhook per episode. The first webhook starts processing; subsequent ones for the same series set a dirty flag and return immediately. When processing finishes, if the flag is set, it rescans once more with the latest state. Worst case for N simultaneous webhooks is 2-3 full scans.
6. Processing reuses the existing `JellyfinScanner` internals (`processJellyfinMovie` / `processJellyfinShow`) — the same code path as scheduled scans — so availability status updates identically.

## How Has This Been Tested?

- Configured Jellyfin Webhook Plugin to POST `ItemAdded` and `ItemUpdated` events to `/webhook/jellyfin?apiKey=<key>`
- Verified new movies and series become available in Seerr within seconds of Jellyfin scanning them in. NOTE: Jellyfin by default can take up to a couple minutes to scan new items in and fetch their metadata. The hook fires when this is completed.
- Verified rapid-fire webhooks from a full season import collapse correctly
- Verified non-processable event types return 200 with "Ignored" message
- Verified invalid/missing API key returns 401

## Screenshots / Logs (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

> This PR was written primarily by Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Jellyfin webhook endpoint (POST) to process ItemAdded/ItemUpdated events, supporting single or batch IDs, JSON or text payloads, and API key auth via header or query. Returns per-item statuses (success, skipped, error) and uses 207 for mixed results.

* **Other Changes**
  * Webhook routes bypass CSRF token checks so API-key authenticated webhooks are accepted; improved input validation and error reporting for webhook requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->