### PR TITLE
refactor(email): add default body fallback for test notification template

### DIFF
--- a/server/templates/email/test-email/html.pug
+++ b/server/templates/email/test-email/html.pug
@@ -33,7 +33,7 @@ div(style='display: block; background-color: #111827; padding: 2.5rem 0;')
     tr
       td(style='text-align: center;')
         div(style='margin: 1rem 0 0; font-size: 1.25em;')
-          | #{body}
+          | #{body || 'Check check, 1, 2, 3. Are we coming in clear?'}
     if applicationUrl
       tr
         td


### PR DESCRIPTION
Description

This PR adds a small fallback for the test email notification template.

Currently the template renders `#{body}` directly.  
If the `body` variable is not provided, the email content may appear blank.

This change updates the template to:

#{body || 'Check check, 1, 2, 3. Are we coming in clear?'}

This ensures that a visible message is always rendered even if `body` is missing.

This change is intentionally minimal and only affects the **test notification template**.

It also helps prepare the template behavior for future improvements discussed around **multi-language email templates**, where template rendering may depend on localized content generation.

Modified file:

server/templates/email/test-email/html.pug


How Has This Been Tested?

- Template compiled successfully with `pug`
- Local development build succeeded
- Container started successfully
- Test email rendered correctly
- Verified that the fallback message appears when `body` is undefined


Screenshots / Logs (if applicable)

Test email rendered locally showing the fallback message.


Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] Disclosed any use of AI (see our policy).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test email template now displays a default message when the body field is empty, ensuring test emails always contain visible content instead of appearing blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->