### PR TITLE
feat(i18n): add Luxembourgish language support

### DIFF
--- a/server/api/tvdb/interfaces.ts
+++ b/server/api/tvdb/interfaces.ts
@@ -175,6 +175,7 @@ const TMDB_TO_TVDB_MAPPING: Record<string, string> & {
   it: 'ita', // Italian
   ja: 'jpn', // Japanese
   ko: 'kor', // Korean
+  lb: 'ltz', // Luxembourgish
   lt: 'lit', // Lithuanian
   nl: 'nld', // Dutch
   pl: 'pol', // Polish

--- a/server/types/languages.d.ts
+++ b/server/types/languages.d.ts
@@ -18,6 +18,7 @@ export type AvailableLocale =
   | 'it'
   | 'ja'
   | 'ko'
+  | 'lb'
   | 'lt'
   | 'nb-NO'
   | 'nl'

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -63,6 +63,10 @@ export const availableLanguages: AvailableLanguageObject = {
     code: 'it',
     display: 'Italiano',
   },
+  lb: {
+    code: 'lb',
+    display: 'Lëtzebuergesch',
+  },
   lt: {
     code: 'lt',
     display: 'Lietuvių',

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -65,6 +65,8 @@ const loadLocaleData = (locale: AvailableLocale): Promise<any> => {
       return import('../i18n/locale/ja.json');
     case 'ko':
       return import('../i18n/locale/ko.json');
+    case 'lb':
+      return import('../i18n/locale/lb.json');
     case 'lt':
       return import('../i18n/locale/lt.json');
     case 'nb-NO':


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds the necessary keys to support Luxembourgish language.

- Fixes #2421

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Luxembourgish (Lëtzebuergesch) language support across the app: selectable UI language, included in available locales, and integrated into locale loading and external language mappings.
  * Locale resources now load for Luxembourgish at startup so translations are applied consistently.
  * External language mapping updated to allow direct conversion for "lb" where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->