### PR TITLE
fix(migration): repair postgres blocklist id sequence

### DIFF
--- a/server/migration/postgres/1772000000000-FixBlocklistIdDefault.ts
+++ b/server/migration/postgres/1772000000000-FixBlocklistIdDefault.ts
@@ -9,7 +9,7 @@ export class FixBlocklistIdDefault1772000000000 implements MigrationInterface {
     );
 
     await queryRunner.query(
-      `SELECT setval('public."blocklist_id_seq"', COALESCE((SELECT MAX("id") FROM "blocklist"), 0), true)`
+      `SELECT setval('public."blocklist_id_seq"', COALESCE((SELECT MAX("id") FROM "blocklist"), 0) + 1, false)`
     );
   }
 

--- a/server/migration/postgres/1772000000000-FixBlocklistIdDefault.ts
+++ b/server/migration/postgres/1772000000000-FixBlocklistIdDefault.ts
@@ -1,0 +1,21 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixBlocklistIdDefault1772000000000 implements MigrationInterface {
+  name = 'FixBlocklistIdDefault1772000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" ALTER COLUMN "id" SET DEFAULT nextval('public."blocklist_id_seq"'::regclass)`
+    );
+
+    await queryRunner.query(
+      `SELECT setval('public."blocklist_id_seq"', COALESCE((SELECT MAX("id") FROM "blocklist"), 0), true)`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" ALTER COLUMN "id" DROP DEFAULT`
+    );
+  }
+}

--- a/server/migration/postgres/1772000000000-FixBlocklistIdDefault.ts
+++ b/server/migration/postgres/1772000000000-FixBlocklistIdDefault.ts
@@ -13,9 +13,8 @@ export class FixBlocklistIdDefault1772000000000 implements MigrationInterface {
     );
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE "blocklist" ALTER COLUMN "id" DROP DEFAULT`
-    );
+  public async down(): Promise<void> {
+    // Intentionally left empty: dropping the DEFAULT on blocklist.id would
+    // reintroduce the original bug and break blocklist inserts.
   }
 }


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On PostgreSQL, the `blocklist.id` column is `NOT NULL` but has no default, even though `public.blocklist_id_seq` exists.
As a result, all inserts into `blocklist` fail with a `null` value in column `id` error making blocklist feature unusable.

This seems to have been introduced as part of #2157 

- Fixes #2661

## How Has This Been Tested?

- Fresh Seerr install with postgresql as DBMS

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected blocklist ID generation so new entries receive the proper incremental IDs and avoid collisions with existing data. A database migration synchronizes the ID sequence with current records; the rollback is intentionally left empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->