### PR TITLE
feat(theme): add AMOLED-Strix theme with semantic CSS token system

### DIFF
--- a/src/components/Blocklist/index.tsx
+++ b/src/components/Blocklist/index.tsx
@@ -287,7 +287,7 @@ const BlocklistedItem = ({ item, revalidateList }: BlocklistedItemProps) => {
   if (!title && !error) {
     return (
       <div
-        className="h-64 w-full animate-pulse rounded-xl bg-gray-800 xl:h-28"
+        className="h-64 w-full animate-pulse rounded-xl bg-surface xl:h-28"
         ref={ref}
       />
     );
@@ -320,7 +320,7 @@ const BlocklistedItem = ({ item, revalidateList }: BlocklistedItemProps) => {
   };
 
   return (
-    <div className="relative flex w-full flex-col justify-between overflow-hidden rounded-xl bg-gray-800 py-4 text-gray-400 shadow-md ring-1 ring-gray-700 xl:h-28 xl:flex-row">
+    <div className="relative flex w-full flex-col justify-between overflow-hidden py-4 text-gray-400 xl:h-28 xl:flex-row rounded-xl bg-surface shadow-md ring-1 ring-ring-app/10">
       {title && title.backdropPath && (
         <div className="absolute inset-0 z-0 w-full bg-cover bg-center xl:w-2/3">
           <CachedImage
@@ -330,13 +330,7 @@ const BlocklistedItem = ({ item, revalidateList }: BlocklistedItemProps) => {
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}
             fill
           />
-          <div
-            className="absolute inset-0"
-            style={{
-              backgroundImage:
-                'linear-gradient(90deg, rgba(31, 41, 55, 0.47) 0%, rgba(31, 41, 55, 1) 100%)',
-            }}
-          />
+          <div className="absolute inset-0 bg-gradient-to-r from-surface/50 to-surface" />
         </div>
       )}
       <div className="relative flex w-full flex-col justify-between overflow-hidden sm:flex-row">

--- a/src/components/CollectionDetails/index.tsx
+++ b/src/components/CollectionDetails/index.tsx
@@ -210,13 +210,7 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
             fill
             priority
           />
-          <div
-            className="absolute inset-0"
-            style={{
-              backgroundImage:
-                'linear-gradient(180deg, rgba(17, 24, 39, 0.47) 0%, rgba(17, 24, 39, 1) 100%)',
-            }}
-          />
+          <div className="collection-backdrop-overlay absolute inset-0 bg-gradient-to-b from-gray-900/50 to-gray-900" />
         </div>
       )}
       <PageTitle title={data.name} />

--- a/src/components/Common/ButtonWithDropdown/index.tsx
+++ b/src/components/Common/ButtonWithDropdown/index.tsx
@@ -34,9 +34,9 @@ const ButtonWithDropdown = ({
       break;
     case 'glass':
       styleClasses.mainButtonClasses +=
-        ' bg-black/50 border-white/[0.12] text-white/70 backdrop-blur-md hover:text-white active:text-white';
+        ' bg-black/50 border-white/[0.12] text-white/70 backdrop-blur-md hover:text-white active:text-white focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black/60';
       styleClasses.dropdownSideButtonClasses =
-        'button-md border bg-black/50 border-white/[0.12] text-white/70 backdrop-blur-md hover:text-white active:text-white';
+        'button-md border bg-black/50 border-white/[0.12] text-white/70 backdrop-blur-md hover:text-white active:text-white focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black/60';
       break;
     default:
       styleClasses.mainButtonClasses +=

--- a/src/components/Common/ButtonWithDropdown/index.tsx
+++ b/src/components/Common/ButtonWithDropdown/index.tsx
@@ -7,7 +7,7 @@ import type { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
 type ButtonWithDropdownProps = {
   text: React.ReactNode;
   dropdownIcon?: React.ReactNode;
-  buttonType?: 'primary' | 'ghost';
+  buttonType?: 'primary' | 'ghost' | 'glass';
 } & (
   | ({ as?: 'button' } & ButtonHTMLAttributes<HTMLButtonElement>)
   | ({ as: 'a' } & AnchorHTMLAttributes<HTMLAnchorElement>)
@@ -31,6 +31,12 @@ const ButtonWithDropdown = ({
       styleClasses.mainButtonClasses +=
         ' bg-transparent border-gray-600 hover:border-gray-200 focus:border-gray-100 active:border-gray-100';
       styleClasses.dropdownSideButtonClasses = styleClasses.mainButtonClasses;
+      break;
+    case 'glass':
+      styleClasses.mainButtonClasses +=
+        ' bg-black/50 border-white/[0.12] text-white/70 backdrop-blur-md hover:text-white active:text-white';
+      styleClasses.dropdownSideButtonClasses =
+        'button-md border bg-black/50 border-white/[0.12] text-white/70 backdrop-blur-md hover:text-white active:text-white';
       break;
     default:
       styleClasses.mainButtonClasses +=

--- a/src/components/Common/Dropdown/index.tsx
+++ b/src/components/Common/Dropdown/index.tsx
@@ -26,7 +26,7 @@ const DropdownItem = ({
           buttonType === 'ghost'
             ? 'bg-transparent from-indigo-600 to-purple-600 hover:bg-gradient-to-br focus:border-gray-500'
             : buttonType === 'glass'
-              ? 'bg-black/70 hover:bg-black/80 backdrop-blur-md ring-1 ring-white/[0.12]'
+              ? 'bg-black/70 hover:bg-black/80 backdrop-blur-md ring-1 ring-white/[0.12] focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black/60'
               : 'bg-indigo-600 hover:bg-indigo-500 focus:border-indigo-700',
         ].join(' ')}
         {...props}

--- a/src/components/Common/Dropdown/index.tsx
+++ b/src/components/Common/Dropdown/index.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react';
 
 interface DropdownItemProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  buttonType?: 'primary' | 'ghost';
+  buttonType?: 'primary' | 'ghost' | 'glass';
 }
 
 const DropdownItem = ({
@@ -25,7 +25,9 @@ const DropdownItem = ({
           'button-md flex cursor-pointer items-center rounded px-4 py-2 text-sm leading-5 text-white focus:text-white focus:outline-none',
           buttonType === 'ghost'
             ? 'bg-transparent from-indigo-600 to-purple-600 hover:bg-gradient-to-br focus:border-gray-500'
-            : 'bg-indigo-600 hover:bg-indigo-500 focus:border-indigo-700',
+            : buttonType === 'glass'
+              ? 'bg-black/70 hover:bg-black/80 backdrop-blur-md ring-1 ring-white/[0.12]'
+              : 'bg-indigo-600 hover:bg-indigo-500 focus:border-indigo-700',
         ].join(' ')}
         {...props}
       >
@@ -36,7 +38,7 @@ const DropdownItem = ({
 };
 
 type DropdownItemsProps = HTMLAttributes<HTMLDivElement> & {
-  dropdownType: 'primary' | 'ghost';
+  dropdownType: 'primary' | 'ghost' | 'glass';
 };
 
 const DropdownItems = ({
@@ -59,7 +61,9 @@ const DropdownItems = ({
         className={[
           'absolute right-0 z-40 -mr-1 mt-2 w-56 origin-top-right rounded-md p-1 shadow-lg',
           dropdownType === 'ghost'
-            ? 'border border-gray-700 bg-gray-800/80 backdrop-blur'
+            ? 'border border-gray-700 bg-surface-raised/90 backdrop-blur'
+            : dropdownType === 'glass'
+              ? 'border border-white/[0.12] bg-black/80 backdrop-blur-md'
             : 'bg-indigo-600',
           className,
         ].join(' ')}
@@ -74,7 +78,7 @@ const DropdownItems = ({
 interface DropdownProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   text: React.ReactNode;
   dropdownIcon?: React.ReactNode;
-  buttonType?: 'primary' | 'ghost';
+  buttonType?: 'primary' | 'ghost' | 'glass';
 }
 
 const Dropdown = ({
@@ -95,6 +99,8 @@ const Dropdown = ({
           'button-md inline-flex h-full items-center space-x-2 rounded-md border px-4 py-2 text-sm font-medium leading-5 text-white transition duration-150 ease-in-out hover:z-20 focus:z-20 focus:outline-none',
           buttonType === 'ghost'
             ? 'border-gray-600 bg-transparent hover:border-gray-200 focus:border-gray-100 active:border-gray-100'
+            : buttonType === 'glass'
+              ? 'border-white/[0.12] bg-black/50 text-white/70 backdrop-blur-md hover:text-white active:text-white'
             : `focus:ring-blue border-indigo-500 bg-indigo-600/80 hover:border-indigo-500 hover:bg-indigo-600 active:border-indigo-700 active:bg-indigo-700`,
           className,
         ].join(' ')}

--- a/src/components/Common/ImageFader/index.tsx
+++ b/src/components/Common/ImageFader/index.tsx
@@ -1,4 +1,5 @@
 import CachedImage from '@app/components/Common/CachedImage';
+import useTheme from '@app/hooks/useTheme';
 import type { ForwardRefRenderFunction, HTMLAttributes } from 'react';
 import React, { useEffect, useState } from 'react';
 
@@ -22,6 +23,8 @@ const ImageFader: ForwardRefRenderFunction<HTMLDivElement, ImageFaderProps> = (
   ref
 ) => {
   const [activeIndex, setIndex] = useState(0);
+  const { theme } = useTheme();
+  const isAmoled = theme === 'amoled-strix';
 
   useEffect(() => {
     const interval = setInterval(
@@ -34,12 +37,14 @@ const ImageFader: ForwardRefRenderFunction<HTMLDivElement, ImageFaderProps> = (
     };
   }, [backgroundImages, rotationSpeed]);
 
-  let gradient =
-    'linear-gradient(180deg, rgba(45, 55, 72, 0.47) 0%, #1A202E 100%)';
+  let gradient = isAmoled
+    ? 'linear-gradient(180deg, rgba(0,0,0,0.5) 0%, rgba(0,0,0,1) 100%)'
+    : 'linear-gradient(180deg, rgba(45, 55, 72, 0.47) 0%, #1A202E 100%)';
 
   if (isDarker) {
-    gradient =
-      'linear-gradient(180deg, rgba(17, 24, 39, 0.47) 0%, rgba(17, 24, 39, 1) 100%)';
+    gradient = isAmoled
+      ? 'linear-gradient(180deg, rgba(0,0,0,0.6) 0%, rgba(0,0,0,1) 100%)'
+      : 'linear-gradient(180deg, rgba(17, 24, 39, 0.47) 0%, rgba(17, 24, 39, 1) 100%)';
   }
 
   let overrides = {};

--- a/src/components/Common/Modal/index.tsx
+++ b/src/components/Common/Modal/index.tsx
@@ -91,7 +91,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
       <Transition.Child
         appear
         as="div"
-        className="fixed bottom-0 left-0 right-0 top-0 z-50 flex h-full w-full items-center justify-center bg-gray-800/70"
+        className={`fixed bottom-0 left-0 right-0 top-0 z-50 flex h-full w-full items-center justify-center bg-gray-800/70`}
         enter="transition-opacity duration-300"
         enterFrom="opacity-0"
         enterTo="opacity-100"
@@ -116,7 +116,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
           </div>
         </Transition>
         <Transition
-          className={`hide-scrollbar relative inline-block w-full overflow-auto bg-gray-800 px-4 pb-4 pt-4 text-left align-bottom shadow-xl ring-1 ring-gray-700 transition-all sm:my-8 sm:max-w-3xl sm:rounded-lg sm:align-middle ${dialogClass}`}
+          className={`hide-scrollbar relative inline-block w-full overflow-auto px-4 pb-4 pt-4 text-left align-bottom shadow-xl ring-1 transition-all sm:my-8 sm:max-w-3xl sm:rounded-lg sm:align-middle bg-surface ring-gray-700 ${dialogClass}`}
           role="dialog"
           aria-modal="true"
           aria-labelledby="modal-headline"
@@ -144,13 +144,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                 fill
                 priority
               />
-              <div
-                className="absolute inset-0"
-                style={{
-                  backgroundImage:
-                    'linear-gradient(180deg, rgba(31, 41, 55, 0.75) 0%, rgba(31, 41, 55, 1) 100%)',
-                }}
-              />
+              <div className={`absolute inset-0 bg-gradient-to-b from-gray-800/75 to-gray-800`} />
             </div>
           )}
           <div className="relative -mx-4 overflow-x-hidden px-4 pt-0.5 sm:flex sm:items-center">

--- a/src/components/Common/PlayButton/index.tsx
+++ b/src/components/Common/PlayButton/index.tsx
@@ -18,11 +18,11 @@ const PlayButton = ({ links }: PlayButtonProps) => {
   return (
     <ButtonWithDropdown
       as="a"
-      buttonType="ghost"
+      buttonType="glass"
       text={
         <>
           {links[0].svg}
-          <span>{links[0].text}</span>
+          <span className="whitespace-nowrap">{links[0].text}</span>
         </>
       }
       href={links[0].url}
@@ -33,12 +33,12 @@ const PlayButton = ({ links }: PlayButtonProps) => {
           return (
             <ButtonWithDropdown.Item
               key={`play-button-dropdown-item-${i}`}
-              buttonType="ghost"
+              buttonType="glass"
               href={link.url}
               target="_blank"
             >
               {link.svg}
-              <span>{link.text}</span>
+              <span className="whitespace-nowrap">{link.text}</span>
             </ButtonWithDropdown.Item>
           );
         })}

--- a/src/components/Common/SettingsTabs/index.tsx
+++ b/src/components/Common/SettingsTabs/index.tsx
@@ -51,7 +51,7 @@ const SettingsLink = ({
     linkClasses =
       'px-3 py-2 text-sm font-medium transition duration-300 rounded-md whitespace-nowrap mx-2 my-1';
     activeLinkColor = 'bg-indigo-700';
-    inactiveLinkColor = 'bg-gray-800 hover:bg-gray-700 focus:bg-gray-700';
+    inactiveLinkColor = 'bg-surface hover:bg-surface-raised focus:bg-surface-raised';
   }
 
   return (

--- a/src/components/Common/SlideOver/index.tsx
+++ b/src/components/Common/SlideOver/index.tsx
@@ -71,7 +71,7 @@ const SlideOver = ({
                 ref={slideoverRef}
                 onClick={(e) => e.stopPropagation()}
               >
-                <div className="flex h-full flex-col rounded-lg bg-gray-800/80 shadow-xl ring-1 ring-gray-700 backdrop-blur">
+                <div className={`flex h-full flex-col rounded-lg shadow-xl ring-1 backdrop-blur bg-surface ring-gray-700`}>
                   <header className="space-y-1 border-b border-gray-700 px-4 py-4">
                     <div className="flex items-center justify-between space-x-3">
                       <h2 className="text-overseerr text-2xl font-bold leading-7">

--- a/src/components/Common/Table/index.tsx
+++ b/src/components/Common/Table/index.tsx
@@ -6,7 +6,7 @@ type TBodyProps = {
 
 const TBody = ({ children }: TBodyProps) => {
   return (
-    <tbody className="divide-y divide-gray-700 bg-gray-800">{children}</tbody>
+    <tbody className={`divide-y divide-border-default bg-surface`}>{children}</tbody>
   );
 };
 
@@ -16,7 +16,7 @@ const TH = ({
   ...props
 }: React.ComponentPropsWithoutRef<'th'>) => {
   const style = [
-    'px-4 py-3 bg-gray-500 text-left text-xs leading-4 font-medium text-gray-200 uppercase tracking-wider truncate',
+    `px-4 py-3 bg-surface-raised text-left text-xs leading-4 font-medium text-gray-200 uppercase tracking-wider truncate`,
   ];
 
   if (className) {

--- a/src/components/Common/Tag/index.tsx
+++ b/src/components/Common/Tag/index.tsx
@@ -8,7 +8,7 @@ type TagProps = {
 
 const Tag = ({ children, iconSvg }: TagProps) => {
   return (
-    <div className="inline-flex cursor-pointer items-center rounded-full bg-gray-800 px-2 py-1 text-sm text-gray-200 ring-1 ring-gray-600 transition hover:bg-gray-700">
+    <div className="inline-flex cursor-pointer items-center rounded-full px-2 py-1 text-sm text-gray-200 ring-1 transition bg-surface ring-border-default hover:bg-surface-raised">
       {iconSvg ? (
         React.cloneElement(iconSvg, {
           className: 'mr-1 h-4 w-4',

--- a/src/components/Common/Tooltip/index.tsx
+++ b/src/components/Common/Tooltip/index.tsx
@@ -25,7 +25,7 @@ const Tooltip = ({
     });
 
   const tooltipStyle = [
-    'z-50 text-sm absolute font-normal bg-gray-800 px-2 py-1 rounded border border-gray-600 shadow text-gray-100',
+    `z-50 text-sm absolute font-normal px-2 py-1 rounded border shadow text-gray-100 bg-surface-raised border-gray-600`,
   ];
 
   if (className) {

--- a/src/components/Discover/DiscoverMovies/index.tsx
+++ b/src/components/Discover/DiscoverMovies/index.tsx
@@ -16,7 +16,7 @@ import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
 import type { SortOptions as TMDBSortOptions } from '@server/api/themoviedb';
 import type { MovieResult } from '@server/models/Search';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 const messages = defineMessages('components.Discover.DiscoverMovies', {
@@ -64,6 +64,17 @@ const DiscoverMovies = () => {
     preparedFilters
   );
   const [showFilters, setShowFilters] = useState(false);
+  const [backdropPath, setBackdropPath] = useState<string | null>(null);
+  const pickedRef = useRef(false);
+
+  useEffect(() => {
+    if (pickedRef.current || !titles?.length) return;
+    const withBackdrop = titles.filter((t) => (t as MovieResult).backdropPath);
+    if (!withBackdrop.length) return;
+    const pick = withBackdrop[Math.floor(Math.random() * withBackdrop.length)] as MovieResult;
+    setBackdropPath(pick.backdropPath ?? null);
+    pickedRef.current = true;
+  }, [titles]);
 
   if (error) {
     return <ErrorPage statusCode={500} />;
@@ -74,8 +85,29 @@ const DiscoverMovies = () => {
   return (
     <>
       <PageTitle title={title} />
+      {backdropPath && (
+        <div className="discover-movies-amoled-backdrop pointer-events-none fixed inset-x-0 top-0 h-[52vh] overflow-hidden" style={{ zIndex: 0 }}>
+          <img
+            src={`https://image.tmdb.org/t/p/w1280${backdropPath}`}
+            alt=""
+            className="h-full w-full object-cover object-top"
+            style={{ filter: 'blur(3px)', transform: 'scale(1.04)' }}
+          />
+          <div className="absolute inset-0 bg-black/40" />
+          <div
+            className="absolute inset-0"
+            style={{
+              background: 'linear-gradient(to bottom, rgba(0,0,0,0.45) 0%, rgba(0,0,0,0.7) 40%, rgba(0,0,0,0.92) 70%, #000 100%)',
+            }}
+          />
+        </div>
+      )}
+      <div className="discover-movies-content-wrapper">
       <div className="mb-4 flex flex-col justify-between lg:flex-row lg:items-end">
-        <Header>{title}</Header>
+        <h1 className="discover-movies-amoled-heading mt-5 text-4xl font-bold tracking-tight text-blue-300">{title}</h1>
+        <div className="discover-movies-standard-heading">
+          <Header>{title}</Header>
+        </div>
         <div className="mt-2 flex flex-grow flex-col sm:flex-row lg:flex-grow-0">
           <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 lg:flex-grow-0">
             <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-gray-100 sm:text-sm">
@@ -141,6 +173,7 @@ const DiscoverMovies = () => {
         isReachingEnd={isReachingEnd}
         onScrollBottom={fetchMore}
       />
+      </div>
     </>
   );
 };

--- a/src/components/Discover/DiscoverMovies/index.tsx
+++ b/src/components/Discover/DiscoverMovies/index.tsx
@@ -16,6 +16,7 @@ import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
 import type { SortOptions as TMDBSortOptions } from '@server/api/themoviedb';
 import type { MovieResult } from '@server/models/Search';
 import { useRouter } from 'next/router';
+import useTheme from '@app/hooks/useTheme';
 import { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
@@ -66,15 +67,18 @@ const DiscoverMovies = () => {
   const [showFilters, setShowFilters] = useState(false);
   const [backdropPath, setBackdropPath] = useState<string | null>(null);
   const pickedRef = useRef(false);
+  const { theme } = useTheme();
+  const isAmoledTheme = theme === 'amoled-strix';
 
   useEffect(() => {
+    if (!isAmoledTheme) return;
     if (pickedRef.current || !titles?.length) return;
     const withBackdrop = titles.filter((t) => (t as MovieResult).backdropPath);
     if (!withBackdrop.length) return;
     const pick = withBackdrop[Math.floor(Math.random() * withBackdrop.length)] as MovieResult;
     setBackdropPath(pick.backdropPath ?? null);
     pickedRef.current = true;
-  }, [titles]);
+  }, [titles, isAmoledTheme]);
 
   if (error) {
     return <ErrorPage statusCode={500} />;
@@ -85,7 +89,7 @@ const DiscoverMovies = () => {
   return (
     <>
       <PageTitle title={title} />
-      {backdropPath && (
+      {isAmoledTheme && backdropPath && (
         <div className="discover-movies-amoled-backdrop pointer-events-none fixed inset-x-0 top-0 h-[52vh] overflow-hidden" style={{ zIndex: 0 }}>
           <img
             src={`https://image.tmdb.org/t/p/w1280${backdropPath}`}

--- a/src/components/Discover/DiscoverSliderEdit/index.tsx
+++ b/src/components/Discover/DiscoverSliderEdit/index.tsx
@@ -178,7 +178,7 @@ const DiscoverSliderEdit = ({
     <div
       key={`discover-slider-${slider.id}-editing`}
       data-testid="discover-slider-edit-mode"
-      className={`relative mb-4 rounded-lg bg-gray-800 shadow-md ${
+      className={`relative mb-4 rounded-lg shadow-md bg-surface ${
         isDragging ? 'opacity-0' : 'opacity-100'
       }`}
       {...dragProps}

--- a/src/components/Discover/DiscoverTv/index.tsx
+++ b/src/components/Discover/DiscoverTv/index.tsx
@@ -16,7 +16,7 @@ import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
 import type { SortOptions as TMDBSortOptions } from '@server/api/themoviedb';
 import type { TvResult } from '@server/models/Search';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 const messages = defineMessages('components.Discover.DiscoverTv', {
@@ -50,6 +50,8 @@ const DiscoverTv = () => {
   const [showFilters, setShowFilters] = useState(false);
   const preparedFilters = prepareFilterValues(router.query);
   const updateQueryParams = useUpdateQueryParams({});
+  const [backdropPath, setBackdropPath] = useState<string | null>(null);
+  const pickedRef = useRef(false);
 
   const {
     isLoadingInitialData,
@@ -63,6 +65,15 @@ const DiscoverTv = () => {
     ...preparedFilters,
   });
 
+  useEffect(() => {
+    if (pickedRef.current || !titles?.length) return;
+    const withBackdrop = titles.filter((t) => (t as TvResult).backdropPath);
+    if (!withBackdrop.length) return;
+    const pick = withBackdrop[Math.floor(Math.random() * withBackdrop.length)] as TvResult;
+    setBackdropPath(pick.backdropPath ?? null);
+    pickedRef.current = true;
+  }, [titles]);
+
   if (error) {
     return <ErrorPage statusCode={500} />;
   }
@@ -72,8 +83,29 @@ const DiscoverTv = () => {
   return (
     <>
       <PageTitle title={title} />
+      {backdropPath && (
+        <div className="discover-tv-amoled-backdrop pointer-events-none fixed inset-x-0 top-0 h-[52vh] overflow-hidden" style={{ zIndex: 0 }}>
+          <img
+            src={`https://image.tmdb.org/t/p/w1280${backdropPath}`}
+            alt=""
+            className="h-full w-full object-cover object-top"
+            style={{ filter: 'blur(3px)', transform: 'scale(1.04)' }}
+          />
+          <div className="absolute inset-0 bg-black/40" />
+          <div
+            className="absolute inset-0"
+            style={{
+              background: 'linear-gradient(to bottom, rgba(0,0,0,0.45) 0%, rgba(0,0,0,0.7) 40%, rgba(0,0,0,0.92) 70%, #000 100%)',
+            }}
+          />
+        </div>
+      )}
+      <div className="discover-tv-content-wrapper">
       <div className="mb-4 flex flex-col justify-between lg:flex-row lg:items-end">
-        <Header>{title}</Header>
+        <h1 className="discover-tv-amoled-heading mt-5 text-4xl font-bold tracking-tight text-violet-300">{title}</h1>
+        <div className="discover-tv-standard-heading">
+          <Header>{title}</Header>
+        </div>
         <div className="mt-2 flex flex-grow flex-col sm:flex-row lg:flex-grow-0">
           <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 lg:flex-grow-0">
             <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-gray-100 sm:text-sm">
@@ -139,6 +171,7 @@ const DiscoverTv = () => {
         }
         onScrollBottom={fetchMore}
       />
+      </div>
     </>
   );
 };

--- a/src/components/Discover/DiscoverTv/index.tsx
+++ b/src/components/Discover/DiscoverTv/index.tsx
@@ -16,6 +16,7 @@ import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
 import type { SortOptions as TMDBSortOptions } from '@server/api/themoviedb';
 import type { TvResult } from '@server/models/Search';
 import { useRouter } from 'next/router';
+import useTheme from '@app/hooks/useTheme';
 import { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
@@ -52,6 +53,8 @@ const DiscoverTv = () => {
   const updateQueryParams = useUpdateQueryParams({});
   const [backdropPath, setBackdropPath] = useState<string | null>(null);
   const pickedRef = useRef(false);
+  const { theme } = useTheme();
+  const isAmoledTheme = theme === 'amoled-strix';
 
   const {
     isLoadingInitialData,
@@ -66,13 +69,14 @@ const DiscoverTv = () => {
   });
 
   useEffect(() => {
+    if (!isAmoledTheme) return;
     if (pickedRef.current || !titles?.length) return;
     const withBackdrop = titles.filter((t) => (t as TvResult).backdropPath);
     if (!withBackdrop.length) return;
     const pick = withBackdrop[Math.floor(Math.random() * withBackdrop.length)] as TvResult;
     setBackdropPath(pick.backdropPath ?? null);
     pickedRef.current = true;
-  }, [titles]);
+  }, [titles, isAmoledTheme]);
 
   if (error) {
     return <ErrorPage statusCode={500} />;
@@ -83,7 +87,7 @@ const DiscoverTv = () => {
   return (
     <>
       <PageTitle title={title} />
-      {backdropPath && (
+      {isAmoledTheme && backdropPath && (
         <div className="discover-tv-amoled-backdrop pointer-events-none fixed inset-x-0 top-0 h-[52vh] overflow-hidden" style={{ zIndex: 0 }}>
           <img
             src={`https://image.tmdb.org/t/p/w1280${backdropPath}`}

--- a/src/components/Discover/HeroSlider/index.tsx
+++ b/src/components/Discover/HeroSlider/index.tsx
@@ -158,11 +158,13 @@ const HeroSlider = () => {
           setCurrentStatus(s);
           setShowRequestModal(false);
           setRequestTarget(null);
+          isPaused.current = false;
         }}
         onUpdating={() => void 0}
         onCancel={() => {
           setShowRequestModal(false);
           setRequestTarget(null);
+          isPaused.current = false;
         }}
       />
 
@@ -266,6 +268,7 @@ const HeroSlider = () => {
               <button
                 onClick={() => {
                   setRequestTarget({ id: featured.id, type: isMovie ? 'movie' : 'tv' });
+                  isPaused.current = true;
                   setShowRequestModal(true);
                 }}
                 className="flex items-center gap-1.5 rounded-lg bg-indigo-600/90 px-4 py-2 text-xs font-semibold text-white shadow-lg shadow-indigo-500/20 ring-1 ring-indigo-500/50 transition hover:bg-indigo-500"

--- a/src/components/Discover/HeroSlider/index.tsx
+++ b/src/components/Discover/HeroSlider/index.tsx
@@ -1,0 +1,340 @@
+import CachedImage from '@app/components/Common/CachedImage';
+import RequestModal from '@app/components/RequestModal';
+import { Permission, useUser } from '@app/hooks/useUser';
+import defineMessages from '@app/utils/defineMessages';
+import globalMessages from '@app/i18n/globalMessages';
+import {
+  ArrowDownTrayIcon,
+  StarIcon,
+} from '@heroicons/react/24/solid';
+import { MediaStatus } from '@server/constants/media';
+import type { MovieResult, TvResult } from '@server/models/Search';
+import Link from 'next/link';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useIntl } from 'react-intl';
+import useSWR from 'swr';
+
+interface TrendingResponse {
+  results: (MovieResult | TvResult)[];
+}
+
+const messages = defineMessages('components.Discover.HeroSlider', {
+  viewDetails: 'View Details',
+  goToSlide: 'Go to slide {n}',
+});
+
+const ROTATE_INTERVAL = 7000;
+
+const HeroSlider = () => {
+  const intl = useIntl();
+  const { hasPermission } = useUser();
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [showRequestModal, setShowRequestModal] = useState(false);
+  const [currentStatus, setCurrentStatus] = useState<MediaStatus | undefined>();
+  const [requestTarget, setRequestTarget] = useState<{
+    id: number;
+    type: 'movie' | 'tv';
+  } | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isPaused = useRef(false);
+  const touchStartX = useRef<number | null>(null);
+  const isAnimating = useRef(false);
+
+  const { data } = useSWR<TrendingResponse>('/api/v1/discover/trending');
+
+  const items = (data?.results ?? [])
+    .filter(
+      (r): r is MovieResult | TvResult =>
+        (r.mediaType === 'movie' || r.mediaType === 'tv') && !!r.backdropPath
+    )
+    .slice(0, 8);
+
+  const goTo = useCallback(
+    (index: number) => {
+      if (isAnimating.current || index === currentIndex) return;
+      isAnimating.current = true;
+
+      setTimeout(() => {
+        setCurrentIndex(index);
+        setCurrentStatus(undefined);
+        setTimeout(() => {
+          isAnimating.current = false;
+        }, 200);
+      }, 150);
+    },
+    [currentIndex]
+  );
+
+  const next = useCallback(() => {
+    if (items.length === 0) return;
+    goTo((currentIndex + 1) % items.length);
+  }, [currentIndex, items.length, goTo]);
+
+  const prev = useCallback(() => {
+    if (items.length === 0) return;
+    goTo((currentIndex - 1 + items.length) % items.length);
+  }, [currentIndex, items.length, goTo]);
+
+  const startInterval = useCallback(() => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    intervalRef.current = setInterval(() => {
+      if (!isPaused.current) next();
+    }, ROTATE_INTERVAL);
+  }, [next]);
+
+  useEffect(() => {
+    if (items.length > 1) startInterval();
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [items.length, startInterval]);
+
+  useEffect(() => {
+    if (items.length > 0 && currentIndex >= items.length) {
+      setCurrentIndex(items.length - 1);
+    }
+  }, [items.length, currentIndex]);
+
+  if (items.length === 0) return null;
+
+  const featured = items[currentIndex];
+  const isMovie = featured.mediaType === 'movie';
+  const title = isMovie
+    ? (featured as MovieResult).title
+    : (featured as TvResult).name;
+  const year = (
+    isMovie
+      ? (featured as MovieResult).releaseDate
+      : (featured as TvResult).firstAirDate
+  )?.slice(0, 4);
+  const detailUrl = isMovie ? `/movie/${featured.id}` : `/tv/${featured.id}`;
+  const status = currentStatus ?? featured.mediaInfo?.status;
+
+  const showRequestButton = hasPermission(
+    [
+      Permission.REQUEST,
+      isMovie ? Permission.REQUEST_MOVIE : Permission.REQUEST_TV,
+    ],
+    { type: 'or' }
+  );
+
+  const canRequest =
+    showRequestButton &&
+    (!status ||
+      status === MediaStatus.UNKNOWN ||
+      status === MediaStatus.DELETED);
+
+  return (
+    <div
+      className="hero-slider-root relative -mx-4 -mt-16 mb-14 h-[48vw] max-h-[520px] min-h-[320px] overflow-hidden lg:mb-16"
+      onMouseEnter={() => {
+        isPaused.current = true;
+      }}
+      onMouseLeave={() => {
+        isPaused.current = false;
+      }}
+      onTouchStart={(e) => {
+        touchStartX.current = e.touches[0].clientX;
+      }}
+      onTouchEnd={(e) => {
+        if (touchStartX.current === null) return;
+        const diff = touchStartX.current - e.changedTouches[0].clientX;
+        if (Math.abs(diff) > 50) {
+          if (diff > 0) {
+            next();
+          } else {
+            prev();
+          }
+          startInterval();
+        }
+        touchStartX.current = null;
+      }}
+    >
+      <RequestModal
+        tmdbId={requestTarget?.id ?? featured.id}
+        show={showRequestModal}
+        type={requestTarget?.type ?? (isMovie ? 'movie' : 'tv')}
+        onComplete={(s) => {
+          setCurrentStatus(s);
+          setShowRequestModal(false);
+          setRequestTarget(null);
+        }}
+        onUpdating={() => void 0}
+        onCancel={() => {
+          setShowRequestModal(false);
+          setRequestTarget(null);
+        }}
+      />
+
+      {/* Crossfade backdrop stack */}
+      {items.map((item, i) => (
+        <div
+          key={`${item.mediaType}-${item.id}`}
+          className="absolute inset-0 transition-opacity duration-700 ease-in-out"
+          style={{ opacity: i === currentIndex ? 1 : 0 }}
+        >
+          <CachedImage
+            type="tmdb"
+            src={`https://image.tmdb.org/t/p/w1280${item.backdropPath}`}
+            alt=""
+            fill
+            style={{ objectFit: 'cover', objectPosition: 'center top' }}
+            priority={i === 0}
+          />
+        </div>
+      ))}
+
+      {/* Subtle left vignette for text contrast */}
+      <div className="absolute inset-0 bg-gradient-to-r from-black/50 via-black/10 to-transparent" />
+
+      {/* Blur layer — bottom to middle, fades out upward */}
+      <div
+        className="absolute inset-x-0 bottom-0 h-2/3"
+        style={{
+          backdropFilter: 'blur(18px)',
+          WebkitBackdropFilter: 'blur(18px)',
+          maskImage: 'linear-gradient(to top, black 0%, black 35%, transparent 100%)',
+          WebkitMaskImage: 'linear-gradient(to top, black 0%, black 35%, transparent 100%)',
+        }}
+      />
+
+      {/* Black hue over the blur zone */}
+      <div
+        className="absolute inset-x-0 bottom-0 h-2/3"
+        style={{
+          background: 'linear-gradient(to top, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0.3) 40%, transparent 100%)',
+          maskImage: 'linear-gradient(to top, black 0%, black 50%, transparent 100%)',
+          WebkitMaskImage: 'linear-gradient(to top, black 0%, black 50%, transparent 100%)',
+        }}
+      />
+
+      {/* Content — staggered slide-in from left */}
+      <div className="absolute inset-0 flex items-end pb-8 pl-6 pr-4 sm:pl-10 lg:pl-12">
+        <div className="max-w-lg">
+          <style>{`
+            @keyframes heroSlideIn {
+              from { opacity: 0; transform: translateX(22px); }
+              to   { opacity: 1; transform: translateX(0); }
+            }
+            @keyframes heroSlideOut {
+              from { opacity: 1; transform: translateX(0); }
+              to   { opacity: 0; transform: translateX(-14px); }
+            }
+            .hero-item {
+              animation-fill-mode: both;
+              animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+            }
+            .hero-item-in  { animation-name: heroSlideIn; animation-duration: 500ms; }
+            .hero-item-out { animation-name: heroSlideOut; animation-duration: 250ms; }
+          `}</style>
+          <div key={`hero-content-${currentIndex}`} style={{ display: 'contents' }}>
+
+          {/* Title */}
+          <h1
+            className="mb-2 font-bold leading-[1.15] tracking-tight text-white hero-item hero-item-in"
+            style={{ fontSize: 'clamp(1.4rem, 3vw, 2.2rem)', animationDelay: '60ms' }}
+          >
+            {title}
+          </h1>
+
+          {/* Overview */}
+          {featured.overview && (
+            <p
+              className="mb-5 text-xs leading-relaxed text-white/50 sm:text-sm hero-item hero-item-in"
+              style={{
+                display: '-webkit-box',
+                WebkitBoxOrient: 'vertical',
+                WebkitLineClamp: 2,
+                overflow: 'hidden',
+                maxWidth: '38ch',
+                animationDelay: '120ms',
+              }}
+            >
+              {featured.overview}
+            </p>
+          )}
+
+          {/* Actions */}
+          <div className="flex items-center gap-2.5">
+            <Link
+              href={detailUrl}
+              className="rounded-lg px-4 py-2 text-xs font-semibold text-white/80 ring-1 ring-white/15 backdrop-blur-sm transition hover:bg-white/10 hover:text-white"
+            >
+              {intl.formatMessage(messages.viewDetails)}
+            </Link>
+            {canRequest && (
+              <button
+                onClick={() => {
+                  setRequestTarget({ id: featured.id, type: isMovie ? 'movie' : 'tv' });
+                  setShowRequestModal(true);
+                }}
+                className="flex items-center gap-1.5 rounded-lg bg-indigo-600/90 px-4 py-2 text-xs font-semibold text-white shadow-lg shadow-indigo-500/20 ring-1 ring-indigo-500/50 transition hover:bg-indigo-500"
+              >
+                <ArrowDownTrayIcon className="h-3.5 w-3.5" />
+                {intl.formatMessage(globalMessages.request)}
+              </button>
+            )}
+          </div>
+          </div>{/* end key wrapper */}
+        </div>
+      </div>
+
+      {/* Meta col — bottom right, top-to-bottom */}
+      <div
+        key={`hero-meta-${currentIndex}`}
+        className="absolute bottom-8 right-6 flex flex-col items-end gap-1.5 hero-item hero-item-in"
+        style={{ animationDelay: '0ms' }}
+      >
+        {/* Tag */}
+        <span className="flex items-center gap-1.5">
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${isMovie ? 'bg-blue-400' : 'bg-violet-400'}`}
+            style={{ boxShadow: isMovie ? '0 0 6px rgba(96,165,250,0.8)' : '0 0 6px rgba(167,139,250,0.8)' }}
+          />
+          <span className={`text-[11px] font-semibold uppercase tracking-[0.18em] ${isMovie ? 'text-blue-300' : 'text-violet-300'}`}>
+            {isMovie
+              ? intl.formatMessage(globalMessages.movie)
+              : intl.formatMessage(globalMessages.tvshow)}
+          </span>
+        </span>
+
+        {/* Rating | Year */}
+        <span className="flex items-center gap-1.5 text-[11px] font-medium text-white/50">
+          {featured.voteAverage > 0 && (
+            <span className="flex items-center gap-1">
+              <StarIcon className="h-3 w-3 text-yellow-400/70" />
+              <span className="text-yellow-400/70">{featured.voteAverage.toFixed(1)}</span>
+            </span>
+          )}
+          {featured.voteAverage > 0 && year && (
+            <span className="text-white/25">|</span>
+          )}
+          {year && <span>{year}</span>}
+        </span>
+      </div>
+
+      {/* Dot indicators */}
+      {items.length > 1 && (
+        <div className="absolute bottom-4 right-6 flex gap-1.5">
+          {items.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => {
+                goTo(i);
+                startInterval();
+              }}
+              aria-label={intl.formatMessage(messages.goToSlide, { n: i + 1 })}
+              className={`h-1.5 rounded-full transition-all duration-300 ${
+                i === currentIndex
+                  ? 'w-6 bg-white'
+                  : 'w-1.5 bg-white/40 hover:bg-white/70'
+              }`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HeroSlider;

--- a/src/components/Discover/Trending.tsx
+++ b/src/components/Discover/Trending.tsx
@@ -52,7 +52,7 @@ const Trending = () => {
         <Header>{intl.formatMessage(messages.trending)}</Header>
         <div className="mt-2 flex flex-grow flex-col sm:flex-row lg:flex-grow-0">
           <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 lg:flex-grow-0">
-            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">
+            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 text-sm text-gray-100 border-border-default bg-input">
               <CircleStackIcon className="h-6 w-6" />
             </span>
             <select
@@ -74,7 +74,7 @@ const Trending = () => {
             </select>
           </div>
           <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 lg:flex-grow-0">
-            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">
+            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 text-sm text-gray-100 border-border-default bg-input">
               <FunnelIcon className="h-6 w-6" />
             </span>
             <select

--- a/src/components/Discover/index.tsx
+++ b/src/components/Discover/index.tsx
@@ -1,4 +1,5 @@
 import Button from '@app/components/Common/Button';
+import HeroSlider from '@app/components/Discover/HeroSlider';
 import ConfirmButton from '@app/components/Common/ConfirmButton';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import PageTitle from '@app/components/Common/PageTitle';
@@ -15,6 +16,7 @@ import StudioSlider from '@app/components/Discover/StudioSlider';
 import TvGenreSlider from '@app/components/Discover/TvGenreSlider';
 import MediaSlider from '@app/components/MediaSlider';
 import { encodeURIExtraParams } from '@app/hooks/useDiscover';
+import useTheme from '@app/hooks/useTheme';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
@@ -54,6 +56,7 @@ const messages = defineMessages('components.Discover', {
 
 const Discover = () => {
   const intl = useIntl();
+  const { theme } = useTheme();
   const { hasPermission } = useUser();
   const { addToast } = useToasts();
   const {
@@ -123,6 +126,7 @@ const Discover = () => {
   return (
     <>
       <PageTitle title={intl.formatMessage(messages.discover)} />
+      {theme === 'amoled-strix' && <HeroSlider />}
       {hasPermission(Permission.ADMIN) && (
         <>
           {isEditing && (

--- a/src/components/IssueDetails/IssueComment/index.tsx
+++ b/src/components/IssueDetails/IssueComment/index.tsx
@@ -97,7 +97,7 @@ const IssueComment = ({
         />
       </Link>
       <div className="relative flex-1">
-        <div className="w-full rounded-md shadow ring-1 ring-gray-500">
+        <div className={`w-full rounded-md shadow ring-1 ring-ring-app/10`}>
           {(isActiveUser || hasPermission(Permission.MANAGE_ISSUES)) && (
             <Menu
               as="div"
@@ -127,7 +127,7 @@ const IssueComment = ({
                   >
                     <Menu.Items
                       static
-                      className="absolute right-0 mt-2 w-56 origin-top-right rounded-md bg-gray-700 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+                      className={`absolute right-0 mt-2 w-56 origin-top-right rounded-md shadow-lg ring-1 ring-opacity-5 focus:outline-none bg-surface-raised ring-black`}
                     >
                       <div className="py-1">
                         {isActiveUser && (
@@ -168,11 +168,11 @@ const IssueComment = ({
             </Menu>
           )}
           <div
-            className={`absolute top-3 z-10 h-3 w-3 rotate-45 bg-gray-800 shadow ring-1 ring-gray-500 ${
+            className={`absolute top-3 z-10 h-3 w-3 rotate-45 shadow ring-1 bg-surface ring-gray-500 ${
               isReversed ? '-left-1' : '-right-1'
             }`}
           />
-          <div className="relative z-20 w-full rounded-md bg-gray-800 py-4 pl-4 pr-8">
+          <div className={`relative z-20 w-full rounded-md py-4 pl-4 pr-8 bg-surface`}>
             {isEditing ? (
               <Formik
                 initialValues={{ newMessage: comment.message }}

--- a/src/components/IssueDetails/index.tsx
+++ b/src/components/IssueDetails/index.tsx
@@ -216,13 +216,7 @@ const IssueDetails = () => {
             fill
             priority
           />
-          <div
-            className="absolute inset-0"
-            style={{
-              backgroundImage:
-                'linear-gradient(180deg, rgba(17, 24, 39, 0.47) 0%, rgba(17, 24, 39, 1) 100%)',
-            }}
-          />
+          <div className="issue-backdrop-overlay absolute inset-0 bg-gradient-to-b from-gray-900/50 to-gray-900" />
         </div>
       )}
       <div className="media-header">

--- a/src/components/IssueList/IssueItem/index.tsx
+++ b/src/components/IssueList/IssueItem/index.tsx
@@ -55,7 +55,7 @@ const IssueItem = ({ issue }: IssueItemProps) => {
   if (!title && !error) {
     return (
       <div
-        className="h-64 w-full animate-pulse rounded-xl bg-gray-800 xl:h-28"
+        className="h-64 w-full animate-pulse rounded-xl bg-surface xl:h-28"
         ref={ref}
       />
     );
@@ -117,7 +117,7 @@ const IssueItem = ({ issue }: IssueItemProps) => {
     : description;
 
   return (
-    <div className="relative flex w-full flex-col justify-between overflow-hidden rounded-xl bg-gray-800 py-4 text-gray-400 shadow-md ring-1 ring-gray-700 xl:flex-row">
+    <div className="relative flex w-full flex-col justify-between overflow-hidden py-4 text-gray-400 xl:flex-row rounded-xl bg-surface shadow-md ring-1 ring-ring-app/10">
       {title.backdropPath && (
         <div className="absolute inset-0 z-0 w-full bg-cover bg-center xl:w-2/3">
           <CachedImage
@@ -127,13 +127,7 @@ const IssueItem = ({ issue }: IssueItemProps) => {
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}
             fill
           />
-          <div
-            className="absolute inset-0"
-            style={{
-              backgroundImage:
-                'linear-gradient(90deg, rgba(31, 41, 55, 0.47) 0%, rgba(31, 41, 55, 1) 100%)',
-            }}
-          />
+          <div className="absolute inset-0 bg-gradient-to-r from-surface/50 to-surface" />
         </div>
       )}
       <div className="relative flex w-full flex-col justify-between overflow-hidden sm:flex-row">

--- a/src/components/IssueList/index.tsx
+++ b/src/components/IssueList/index.tsx
@@ -98,7 +98,7 @@ const IssueList = () => {
         <Header>{intl.formatMessage(messages.issues)}</Header>
         <div className="mt-2 flex flex-grow flex-col sm:flex-row lg:flex-grow-0">
           <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 lg:flex-grow-0">
-            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">
+            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-border-default bg-input px-3 text-sm text-gray-100">
               <FunnelIcon className="h-6 w-6" />
             </span>
             <select
@@ -128,7 +128,7 @@ const IssueList = () => {
             </select>
           </div>
           <div className="mb-2 flex flex-grow sm:mb-0 lg:flex-grow-0">
-            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-gray-100 sm:text-sm">
+            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-border-default bg-input px-3 text-gray-100 sm:text-sm">
               <BarsArrowDownIcon className="h-6 w-6" />
             </span>
             <select

--- a/src/components/IssueModal/CreateIssueModal/index.tsx
+++ b/src/components/IssueModal/CreateIssueModal/index.tsx
@@ -244,7 +244,7 @@ const CreateIssueModal = ({
               <RadioGroup.Label className="sr-only">
                 Select an Issue
               </RadioGroup.Label>
-              <div className="-space-y-px overflow-hidden rounded-md bg-gray-800/30">
+              <div className="-space-y-px overflow-hidden rounded-md bg-surface/50">
                 {issueOptions.map((setting, index) => (
                   <RadioGroup.Option
                     key={`issue-type-${setting.issueType}`}

--- a/src/components/Layout/AmoledNavbar/index.tsx
+++ b/src/components/Layout/AmoledNavbar/index.tsx
@@ -54,7 +54,7 @@ const AmoledNavbar = () => {
       clear();
       setIsOpen(false);
     }
-  }, [searchExpanded, isDesktop]);
+  }, [searchExpanded, isDesktop, clear, setIsOpen]);
 
   // Close profile menu on outside click
   useEffect(() => {

--- a/src/components/Layout/AmoledNavbar/index.tsx
+++ b/src/components/Layout/AmoledNavbar/index.tsx
@@ -1,0 +1,235 @@
+import CachedImage from '@app/components/Common/CachedImage';
+import useSearchInput from '@app/hooks/useSearchInput';
+import { Permission, useUser } from '@app/hooks/useUser';
+import defineMessages from '@app/utils/defineMessages';
+import {
+  ArrowRightOnRectangleIcon,
+  ClockIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+import {
+  CogIcon,
+  MagnifyingGlassIcon,
+  UserIcon,
+} from '@heroicons/react/24/solid';
+import axios from 'axios';
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { useIntl } from 'react-intl';
+
+const messages = defineMessages('components.Layout.AmoledNavbar', {
+  searchPlaceholder: 'Search Movies & TV',
+  myprofile: 'Profile',
+  settings: 'Settings',
+  requests: 'Requests',
+  signout: 'Sign Out',
+});
+
+const AmoledNavbar = () => {
+  const intl = useIntl();
+  const { user, revalidate, hasPermission } = useUser();
+  const { searchValue, setSearchValue, setIsOpen, clear } = useSearchInput();
+  const [searchExpanded, setSearchExpanded] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const profileRef = useRef<HTMLDivElement>(null);
+
+  const expanded = isDesktop || searchExpanded;
+
+  // Track desktop breakpoint
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 1024px)');
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    setIsDesktop(mq.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  // Auto-focus search input when expanded
+  useEffect(() => {
+    if (searchExpanded && !isDesktop) {
+      setTimeout(() => searchInputRef.current?.focus(), 50);
+    } else if (!searchExpanded && !isDesktop) {
+      clear();
+      setIsOpen(false);
+    }
+  }, [searchExpanded, isDesktop]);
+
+  // Close profile menu on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (profileRef.current && !profileRef.current.contains(e.target as Node)) {
+        setProfileOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const logout = async () => {
+    try {
+      const response = await axios.post('/api/v1/auth/logout');
+      if (response.data?.status === 'ok') revalidate();
+    } catch {
+      // logout failure is non-critical; ignore silently
+    }
+  };
+
+  return (
+    <div className="pointer-events-none fixed left-0 right-0 top-0 z-20 flex items-start justify-between px-4 pt-4 lg:left-64">
+      {/* Search pill */}
+      <div className="pointer-events-auto flex items-center">
+        <div
+          className="flex items-center overflow-hidden rounded-full transition-all duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)]"
+          style={{
+            width: expanded ? '280px' : '44px',
+            height: '44px',
+            background: 'rgba(0,0,0,0.45)',
+            backdropFilter: 'blur(16px)',
+            WebkitBackdropFilter: 'blur(16px)',
+            boxShadow: expanded
+              ? '0 0 0 1px rgba(255,255,255,0.18), 0 8px 32px rgba(0,0,0,0.4)'
+              : '0 0 0 1px rgba(255,255,255,0.18)',
+          }}
+        >
+          <button
+            className={`flex h-11 w-11 flex-shrink-0 items-center justify-center text-white/80 transition hover:text-white ${isDesktop ? 'pointer-events-none' : ''}`}
+            onClick={() => !isDesktop && setSearchExpanded((v) => !v)}
+          >
+            <style>{`
+              @keyframes iconPop {
+                from { opacity: 0; transform: scale(0.6) rotate(-15deg); }
+                to   { opacity: 1; transform: scale(1) rotate(0deg); }
+              }
+              .icon-pop {
+                animation: iconPop 250ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+              }
+            `}</style>
+            {searchExpanded && !isDesktop ? (
+              <XMarkIcon key="x" className="h-5 w-5 icon-pop" />
+            ) : (
+              <MagnifyingGlassIcon key="search" className="h-5 w-5 icon-pop" />
+            )}
+          </button>
+
+          <input
+            ref={searchInputRef}
+            type="search"
+            autoComplete="off"
+            value={searchValue}
+            placeholder={intl.formatMessage(messages.searchPlaceholder)}
+            className="h-full flex-1 bg-transparent pr-4 text-sm text-white placeholder-white/40 outline-none ring-0 border-none focus:ring-0 focus:border-none focus:outline-none"
+            style={{
+              opacity: expanded ? 1 : 0,
+              pointerEvents: expanded ? 'auto' : 'none',
+              transition: 'opacity 200ms ease',
+            }}
+            onChange={(e) => setSearchValue(e.target.value)}
+            onFocus={() => setIsOpen(true)}
+            onBlur={() => {
+              if (!searchValue) setIsOpen(false);
+            }}
+            onKeyUp={(e) => {
+              if (e.key === 'Escape') setSearchExpanded(false);
+              if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Profile circle */}
+      <div className="pointer-events-auto relative" ref={profileRef}>
+        <button
+          onClick={() => setProfileOpen((v) => !v)}
+          className="flex h-11 w-11 items-center justify-center overflow-hidden rounded-full transition-all duration-300"
+          style={{
+            boxShadow: profileOpen
+              ? '0 0 0 2px rgba(139,92,246,0.7)'
+              : '0 0 0 1px rgba(255,255,255,0.12)',
+          }}
+        >
+          <CachedImage
+            type="avatar"
+            className="h-11 w-11 rounded-full object-cover"
+            src={user ? user.avatar : ''}
+            alt=""
+            width={44}
+            height={44}
+          />
+        </button>
+
+        {/* Dropdown */}
+        <div
+          className="absolute right-0 mt-2 w-64 origin-top-right overflow-hidden rounded-2xl transition-all duration-300"
+          style={{
+            background: 'rgba(0,0,0,0.55)',
+            backdropFilter: 'blur(24px)',
+            WebkitBackdropFilter: 'blur(24px)',
+            boxShadow: '0 0 0 1px rgba(139,92,246,0.2), 0 16px 48px rgba(0,0,0,0.6)',
+            opacity: profileOpen ? 1 : 0,
+            transform: profileOpen ? 'scale(1) translateY(0)' : 'scale(0.95) translateY(-8px)',
+            pointerEvents: profileOpen ? 'auto' : 'none',
+          }}
+        >
+          {/* User info */}
+          <div className="flex items-center gap-3 px-4 py-4">
+            <CachedImage
+              type="avatar"
+              className="h-9 w-9 rounded-full object-cover ring-1 ring-purple-500/40"
+              src={user ? user.avatar : ''}
+              alt=""
+              width={36}
+              height={36}
+            />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-white">
+                {user?.displayName}
+              </p>
+              {user?.displayName?.toLowerCase() !== user?.email?.toLowerCase() && (
+                <p className="truncate text-xs text-white/50">{user?.email}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="border-t border-white/[0.06] p-1.5">
+            {[
+              { href: '/profile', icon: UserIcon, label: intl.formatMessage(messages.myprofile) },
+              {
+                href: hasPermission(
+                  [Permission.MANAGE_REQUESTS, Permission.REQUEST_VIEW],
+                  { type: 'or' }
+                )
+                  ? `/users/${user?.id}/requests?filter=all`
+                  : '/requests',
+                icon: ClockIcon,
+                label: intl.formatMessage(messages.requests),
+              },
+              { href: '/profile/settings', icon: CogIcon, label: intl.formatMessage(messages.settings) },
+            ].map(({ href, icon: Icon, label }) => (
+              <Link
+                key={href}
+                href={href}
+                onClick={() => setProfileOpen(false)}
+                className="flex items-center gap-3 rounded-xl px-3 py-2 text-sm text-white/80 transition hover:bg-white/[0.07] hover:text-white"
+              >
+                <Icon className="h-4 w-4 flex-shrink-0" />
+                {label}
+              </Link>
+            ))}
+
+            <button
+              onClick={logout}
+              className="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm text-white/80 transition hover:bg-red-500/10 hover:text-red-400"
+            >
+              <ArrowRightOnRectangleIcon className="h-4 w-4 flex-shrink-0" />
+              {intl.formatMessage(messages.signout)}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AmoledNavbar;

--- a/src/components/Layout/PullToRefresh/index.tsx
+++ b/src/components/Layout/PullToRefresh/index.tsx
@@ -117,7 +117,7 @@ const PullToRefresh = () => {
       <div
         className={`${
           refreshDiv.current?.classList.contains('loading') && 'animate-spin'
-        } relative -top-28 h-9 w-9 rounded-full border-4 border-gray-800 bg-gray-800 shadow-md shadow-black ring-1 ring-gray-700`}
+        } relative -top-28 h-9 w-9 rounded-full border-4 shadow-md shadow-black ring-1 border-border-default bg-surface-raised ring-ring-app/20`}
         style={{ animationDirection: 'reverse' }}
       >
         <ArrowPathIcon

--- a/src/components/Layout/UserDropdown/index.tsx
+++ b/src/components/Layout/UserDropdown/index.tsx
@@ -74,7 +74,7 @@ const UserDropdown = () => {
         appear
       >
         <Menu.Items className="absolute right-0 mt-2 w-72 origin-top-right rounded-md shadow-lg">
-          <div className="divide-y divide-gray-700 rounded-md bg-gray-800/80 ring-1 ring-gray-700 backdrop-blur">
+          <div className={`divide-y divide-gray-700 rounded-md ring-1 backdrop-blur bg-surface-raised ring-gray-700`}>
             <div className="flex flex-col space-y-4 px-4 py-4">
               <div className="flex items-center space-x-2">
                 <CachedImage

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,3 +1,4 @@
+import AmoledNavbar from '@app/components/Layout/AmoledNavbar';
 import MobileMenu from '@app/components/Layout/MobileMenu';
 import PullToRefresh from '@app/components/Layout/PullToRefresh';
 import SearchInput from '@app/components/Layout/SearchInput';
@@ -87,8 +88,11 @@ const Layout = ({ children }: LayoutProps) => {
 
       <div className="relative mb-16 flex w-0 min-w-0 flex-1 flex-col lg:ml-64">
         <PullToRefresh />
+        <div className="layout-amoled-navbar">
+          <AmoledNavbar />
+        </div>
         <div
-          className={`searchbar fixed left-0 right-0 top-0 z-10 flex flex-shrink-0 transition duration-300 ${
+          className={`layout-standard-navbar searchbar fixed left-0 right-0 top-0 z-10 flex flex-shrink-0 transition duration-300 ${
             isScrolled ? 'bg-gray-700/80' : 'bg-transparent'
           } lg:left-64`}
           style={{
@@ -122,9 +126,9 @@ const Layout = ({ children }: LayoutProps) => {
           </div>
         </div>
 
-        <main className="relative top-16 z-0 focus:outline-none" tabIndex={0}>
+        <main className="layout-main relative z-0 top-16 focus:outline-none" tabIndex={0}>
           <div className="mb-6">
-            <div className="max-w-8xl mx-auto px-4">{children}</div>
+            <div className="layout-main-inner max-w-8xl mx-auto px-4">{children}</div>
           </div>
         </main>
       </div>

--- a/src/components/Login/JellyfinLogin.tsx
+++ b/src/components/Login/JellyfinLogin.tsx
@@ -128,7 +128,7 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
                         name="username"
                         type="text"
                         placeholder={intl.formatMessage(messages.username)}
-                        className="!bg-gray-700/80 placeholder:text-gray-400"
+                        className="!bg-input placeholder:text-gray-400"
                         data-form-type="username"
                       />
                     </div>
@@ -154,7 +154,7 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
                         type="password"
                         autoComplete="current-password"
                         placeholder={intl.formatMessage(messages.password)}
-                        className="!bg-gray-700/80 placeholder:text-gray-400"
+                        className="!bg-input placeholder:text-gray-400"
                         data-form-type="password"
                         data-1pignore="false"
                         data-lpignore="false"

--- a/src/components/Login/LocalLogin.tsx
+++ b/src/components/Login/LocalLogin.tsx
@@ -91,7 +91,7 @@ const LocalLogin = ({ revalidate }: LocalLoginProps) => {
                       inputMode="email"
                       data-testid="email"
                       data-form-type="username,email"
-                      className="!bg-gray-700/80 placeholder:text-gray-400"
+                      className="!bg-input placeholder:text-gray-400"
                     />
                   </div>
                   {touched.email && values.email.match(/\s$/) && (
@@ -119,7 +119,7 @@ const LocalLogin = ({ revalidate }: LocalLoginProps) => {
                       autoComplete="current-password"
                       data-testid="password"
                       data-form-type="password"
-                      className="!bg-gray-700/80 placeholder:text-gray-400"
+                      className="!bg-input placeholder:text-gray-400"
                       data-1pignore="false"
                       data-lpignore="false"
                     />

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -150,7 +150,7 @@ const Login = () => {
   ].filter((o): o is JSX.Element => !!o);
 
   return (
-    <div className="relative flex min-h-screen flex-col bg-gray-900 py-14">
+    <div className="relative flex min-h-screen flex-col py-14 bg-app">
       <PageTitle title={intl.formatMessage(messages.signin)} />
       <ImageFader
         backgroundImages={
@@ -169,7 +169,7 @@ const Login = () => {
       </div>
       <div className="relative z-50 mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <div
-          className="bg-gray-800/50 shadow sm:rounded-lg"
+          className="shadow sm:rounded-lg bg-surface/80 ring-1 ring-ring-app/10"
           style={{ backdropFilter: 'blur(5px)' }}
         >
           <>

--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -4,7 +4,8 @@ import Slider from '@app/components/Slider';
 import TitleCard from '@app/components/TitleCard';
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
-import { ArrowRightCircleIcon } from '@heroicons/react/24/outline';
+import defineMessages from '@app/utils/defineMessages';
+import { ArrowRightCircleIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { MediaStatus } from '@server/constants/media';
 import { Permission } from '@server/lib/permissions';
 import type {
@@ -14,7 +15,12 @@ import type {
 } from '@server/models/Search';
 import Link from 'next/link';
 import { useEffect } from 'react';
+import { useIntl } from 'react-intl';
 import useSWRInfinite from 'swr/infinite';
+
+const messages = defineMessages('components.MediaSlider', {
+  seeAll: 'See All',
+});
 
 interface MixedResult {
   page: number;
@@ -42,6 +48,7 @@ const MediaSlider = ({
   hideWhenEmpty = false,
   onNewTitles,
 }: MediaSliderProps) => {
+  const intl = useIntl();
   const settings = useSettings();
   const { hasPermission } = useUser();
   const { data, error, setSize, size } = useSWRInfinite<MixedResult>(
@@ -177,7 +184,24 @@ const MediaSlider = ({
 
   return (
     <>
-      <div className="slider-header">
+      <div className="media-slider-amoled-header relative mb-3 mt-8 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="h-4 w-0.5 rounded-full bg-indigo-500" />
+          <span className="text-sm font-semibold uppercase tracking-[0.14em] text-white/70">
+            {title}
+          </span>
+        </div>
+        {linkUrl && (
+          <Link
+            href={linkUrl}
+            className="flex items-center gap-1 text-xs font-medium text-white/35 transition hover:text-white/70"
+          >
+            {intl.formatMessage(messages.seeAll)}
+            <ChevronRightIcon className="h-3.5 w-3.5" />
+          </Link>
+        )}
+      </div>
+      <div className="media-slider-standard-header slider-header">
         {linkUrl ? (
           <Link href={linkUrl} className="slider-title min-w-0 pr-16">
             <span className="truncate">{title}</span>

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -179,6 +179,9 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
     iOSPlexUrl4k: data?.mediaInfo?.iOSPlexUrl4k,
   });
 
+  const { theme } = useTheme();
+  const isAmoledTheme = theme === 'amoled-strix';
+
   if (!data && !error) {
     return <LoadingSpinner />;
   }
@@ -434,9 +437,6 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
   const showHideButton = hasPermission([Permission.MANAGE_BLOCKLIST], {
     type: 'or',
   });
-
-  const { theme } = useTheme();
-  const isAmoledTheme = theme === 'amoled-strix';
 
   return (
     <>
@@ -1297,6 +1297,8 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                   data?.mediaInfo?.status !== MediaStatus.BLOCKLISTED && (
                     <Tooltip content={intl.formatMessage(globalMessages.addToBlocklist)}>
                       <button
+                        type="button"
+                        aria-label={intl.formatMessage(globalMessages.addToBlocklist)}
                         onClick={() => setShowBlocklistModal(true)}
                         className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
                       >
@@ -1310,6 +1312,8 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                       {toggleWatchlist ? (
                         <Tooltip content={intl.formatMessage(messages.addtowatchlist)}>
                           <button
+                            type="button"
+                            aria-label={intl.formatMessage(messages.addtowatchlist)}
                             onClick={onClickWatchlistBtn}
                             className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
                           >
@@ -1319,6 +1323,8 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                       ) : (
                         <Tooltip content={intl.formatMessage(messages.removefromwatchlist)}>
                           <button
+                            type="button"
+                            aria-label={intl.formatMessage(messages.removefromwatchlist)}
                             onClick={onClickDeleteWatchlistBtn}
                             className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
                           >

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -1144,7 +1144,6 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
       <div className="extra-bottom-space relative" />
       </div>
       ) : (
-      {/* ── AMOLED full-bleed layout ── */}
       <div className="relative bg-black">
         <PageTitle title={data.title} />
         <IssueModal

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -63,6 +63,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
 import useSWR from 'swr';
+import useTheme from '@app/hooks/useTheme';
 
 const messages = defineMessages('components.MovieDetails', {
   originaltitle: 'Original Title',
@@ -434,8 +435,12 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
     type: 'or',
   });
 
+  const { theme } = useTheme();
+  const isAmoledTheme = theme === 'amoled-strix';
+
   return (
     <>
+      {!isAmoledTheme ? (
       <div
         className="movie-details-backdrop-section media-page"
         style={{
@@ -1139,7 +1144,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
       <div className="extra-bottom-space relative" />
       </div>
       ) : (
-      /* ── AMOLED full-bleed layout ── */
+      {/* ── AMOLED full-bleed layout ── */}
       <div className="relative bg-black">
         <PageTitle title={data.title} />
         <IssueModal
@@ -1704,6 +1709,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
         />
         <div className="extra-bottom-space relative" />
       </div>
+      )}
     </>
   );
 };

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -33,6 +33,7 @@ import defineMessages from '@app/utils/defineMessages';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
 import {
   ArrowRightCircleIcon,
+  ChevronDownIcon,
   CloudIcon,
   CogIcon,
   ExclamationTriangleIcon,
@@ -79,6 +80,10 @@ const messages = defineMessages('components.MovieDetails', {
   overviewunavailable: 'Overview unavailable.',
   studio: '{studioCount, plural, one {Studio} other {Studios}}',
   viewfullcrew: 'View Full Crew',
+  crew: 'Crew',
+  keywords: 'Keywords',
+  ratings: 'Ratings',
+  details: 'Details',
   openradarr: 'Open Movie in Radarr',
   openradarr4k: 'Open Movie in 4K Radarr',
   downloadstatus: 'Download Status',
@@ -430,12 +435,13 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
   });
 
   return (
-    <div
-      className="media-page"
-      style={{
-        height: 493,
-      }}
-    >
+    <>
+      <div
+        className="movie-details-backdrop-section media-page"
+        style={{
+          height: 493,
+        }}
+      >
       {data.backdropPath && (
         <div className="media-page-bg-image">
           <CachedImage
@@ -446,13 +452,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
             fill
             priority
           />
-          <div
-            className="absolute inset-0"
-            style={{
-              backgroundImage:
-                'linear-gradient(180deg, rgba(17, 24, 39, 0.47) 0%, rgba(17, 24, 39, 1) 100%)',
-            }}
-          />
+          <div className="absolute inset-0 bg-gradient-to-b from-gray-900/50 to-gray-900" />
         </div>
       )}
       <PageTitle title={data.title} />
@@ -745,13 +745,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
                       }}
                       fill
                     />
-                    <div
-                      className="absolute inset-0"
-                      style={{
-                        backgroundImage:
-                          'linear-gradient(180deg, rgba(31, 41, 55, 0.47) 0%, rgba(31, 41, 55, 0.80) 100%)',
-                      }}
-                    />
+                    <div className="absolute inset-0 bg-gradient-to-b from-gray-800/50 to-gray-800/80" />
                   </div>
                   <div className="relative z-10 flex h-full items-center justify-between p-4 text-gray-200 transition duration-300 group-hover:text-white">
                     <div>{data.collection.name}</div>
@@ -1143,7 +1137,574 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
         hideWhenEmpty
       />
       <div className="extra-bottom-space relative" />
-    </div>
+      </div>
+      ) : (
+      /* ── AMOLED full-bleed layout ── */
+      <div className="relative bg-black">
+        <PageTitle title={data.title} />
+        <IssueModal
+          onCancel={() => setShowIssueModal(false)}
+          show={showIssueModal}
+          mediaType="movie"
+          tmdbId={data.id}
+        />
+        <ManageSlideOver
+          data={data}
+          mediaType="movie"
+          onClose={() => {
+            setShowManager(false);
+            router.push({
+              pathname: router.pathname,
+              query: { movieId: router.query.movieId },
+            });
+          }}
+          revalidate={() => revalidate()}
+          show={showManager}
+        />
+        <BlocklistModal
+          tmdbId={data.id}
+          type="movie"
+          show={showBlocklistModal}
+          onCancel={closeBlocklistModal}
+          onComplete={onClickHideItemBtn}
+          isUpdating={isBlocklistUpdating}
+        />
+
+        {/* Hero — cinematic full-bleed */}
+        <div className="relative -mx-4 -mt-16 min-h-[100svh] sm:h-[82vh] sm:min-h-[520px]">
+          {/* Background elements clipped to hero bounds */}
+          <div className="absolute inset-0 overflow-hidden">
+            <CachedImage
+              type="tmdb"
+              alt=""
+              src={
+                data.backdropPath
+                  ? `https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${data.backdropPath}`
+                  : data.posterPath
+                    ? `https://image.tmdb.org/t/p/w600_and_h900_bestv2${data.posterPath}`
+                    : '/images/seerr_poster_not_found.png'
+              }
+              fill
+              style={{
+                objectFit: 'cover',
+                objectPosition: data.backdropPath ? 'center top' : 'center center',
+              }}
+              priority
+            />
+            <div className="absolute inset-0 bg-black/25" />
+            {/* Mobile: blur + black overlay from middle to bottom */}
+            <div
+              className="absolute inset-0 sm:hidden"
+              style={{
+                backdropFilter: 'blur(20px)',
+                WebkitBackdropFilter: 'blur(20px)',
+                background: 'rgba(0,0,0,0.55)',
+                maskImage: 'linear-gradient(to bottom, transparent 0%, black 50%)',
+                WebkitMaskImage: 'linear-gradient(to bottom, transparent 0%, black 50%)',
+              }}
+            />
+            {/* Desktop top vignette */}
+            <div className="absolute inset-x-0 top-0 h-48 bg-gradient-to-b from-black/70 to-transparent hidden sm:block" />
+            <div
+              className="absolute inset-x-0 bottom-0"
+              style={{
+                height: '65%',
+                background:
+                  'linear-gradient(to top, #000 0%, rgba(0,0,0,0.85) 30%, rgba(0,0,0,0.4) 70%, transparent 100%)',
+              }}
+            />
+          </div>
+
+          {/* Poster + title + actions */}
+          <div className="absolute inset-0 flex flex-col justify-center gap-3 px-4 pt-28 sm:inset-auto sm:bottom-0 sm:left-0 sm:right-0 sm:flex-row sm:items-end sm:gap-5 sm:pb-8 sm:pt-0 sm:px-6 lg:px-8">
+            <div className="w-2/5 flex-shrink-0 overflow-hidden rounded-xl ring-1 ring-white/15 shadow-2xl mt-[50px] sm:mt-0 sm:w-32 lg:w-36">
+              <CachedImage
+                type="tmdb"
+                src={
+                  data.posterPath
+                    ? `https://image.tmdb.org/t/p/w600_and_h900_bestv2${data.posterPath}`
+                    : '/images/seerr_poster_not_found.png'
+                }
+                alt=""
+                width={600}
+                height={900}
+                style={{ width: '100%', height: 'auto' }}
+                priority
+              />
+            </div>
+            <div className="flex-1 min-w-0 pb-1">
+              <div className="flex flex-wrap gap-2 mb-3">
+                <StatusBadge
+                  status={data.mediaInfo?.status}
+                  downloadItem={data.mediaInfo?.downloadStatus}
+                  title={data.title}
+                  inProgress={(data.mediaInfo?.downloadStatus ?? []).length > 0}
+                  tmdbId={data.mediaInfo?.tmdbId}
+                  mediaType="movie"
+                  plexUrl={plexUrl}
+                  serviceUrl={data.mediaInfo?.serviceUrl}
+                />
+                {settings.currentSettings.movie4kEnabled &&
+                  hasPermission(
+                    [Permission.MANAGE_REQUESTS, Permission.REQUEST_4K, Permission.REQUEST_4K_MOVIE],
+                    { type: 'or' }
+                  ) && (
+                    <StatusBadge
+                      status={data.mediaInfo?.status4k}
+                      downloadItem={data.mediaInfo?.downloadStatus4k}
+                      title={data.title}
+                      is4k
+                      inProgress={(data.mediaInfo?.downloadStatus4k ?? []).length > 0}
+                      tmdbId={data.mediaInfo?.tmdbId}
+                      mediaType="movie"
+                      plexUrl={plexUrl4k}
+                      serviceUrl={data.mediaInfo?.serviceUrl4k}
+                    />
+                  )}
+              </div>
+              <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white tracking-tight leading-tight mb-2">
+                {data.title}
+                {data.releaseDate && (
+                  <span className="ml-3 text-2xl sm:text-3xl font-normal text-white/40">
+                    ({data.releaseDate.slice(0, 4)})
+                  </span>
+                )}
+              </h1>
+              {movieAttributes.length > 0 && (
+                <div className="flex items-center flex-wrap text-sm text-white/60 mb-5">
+                  {movieAttributes
+                    .map((t, k) => <span key={k}>{t}</span>)
+                    .reduce((prev, curr) => (
+                      <>
+                        {prev}
+                        <span className="mx-2 text-white/20">|</span>
+                        {curr}
+                      </>
+                    ))}
+                </div>
+              )}
+              <div className="flex items-center gap-2 flex-wrap">
+                {showHideButton &&
+                  data?.mediaInfo?.status !== MediaStatus.PROCESSING &&
+                  data?.mediaInfo?.status !== MediaStatus.AVAILABLE &&
+                  data?.mediaInfo?.status !== MediaStatus.PARTIALLY_AVAILABLE &&
+                  data?.mediaInfo?.status !== MediaStatus.PENDING &&
+                  data?.mediaInfo?.status !== MediaStatus.BLOCKLISTED && (
+                    <Tooltip content={intl.formatMessage(globalMessages.addToBlocklist)}>
+                      <button
+                        onClick={() => setShowBlocklistModal(true)}
+                        className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
+                      >
+                        <EyeSlashIcon className="h-5 w-5" />
+                      </button>
+                    </Tooltip>
+                  )}
+                {data?.mediaInfo?.status !== MediaStatus.BLOCKLISTED &&
+                  user?.userType !== UserType.PLEX && (
+                    <>
+                      {toggleWatchlist ? (
+                        <Tooltip content={intl.formatMessage(messages.addtowatchlist)}>
+                          <button
+                            onClick={onClickWatchlistBtn}
+                            className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
+                          >
+                            {isUpdating ? <Spinner className="h-5 w-5" /> : <StarIcon className="h-5 w-5 text-amber-300" />}
+                          </button>
+                        </Tooltip>
+                      ) : (
+                        <Tooltip content={intl.formatMessage(messages.removefromwatchlist)}>
+                          <button
+                            onClick={onClickDeleteWatchlistBtn}
+                            className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
+                          >
+                            {isUpdating ? <Spinner className="h-5 w-5" /> : <MinusCircleIcon className="h-5 w-5" />}
+                          </button>
+                        </Tooltip>
+                      )}
+                    </>
+                  )}
+                <div className="z-20">
+                  <PlayButton links={mediaLinks} />
+                </div>
+                <RequestButton
+                  mediaType="movie"
+                  media={data.mediaInfo}
+                  tmdbId={data.id}
+                  onUpdate={() => revalidate()}
+                />
+                {(data.mediaInfo?.status === MediaStatus.AVAILABLE ||
+                  (settings.currentSettings.movie4kEnabled &&
+                    hasPermission([Permission.REQUEST_4K, Permission.REQUEST_4K_MOVIE], { type: 'or' }) &&
+                    data.mediaInfo?.status4k === MediaStatus.AVAILABLE)) &&
+                  hasPermission([Permission.CREATE_ISSUES, Permission.MANAGE_ISSUES], { type: 'or' }) && (
+                    <Tooltip content={intl.formatMessage(messages.reportissue)}>
+                      <Button buttonType="warning" onClick={() => setShowIssueModal(true)} className="ml-2 first:ml-0">
+                        <ExclamationTriangleIcon />
+                      </Button>
+                    </Tooltip>
+                  )}
+                {hasPermission(Permission.MANAGE_REQUESTS) &&
+                  data.mediaInfo &&
+                  (data.mediaInfo.jellyfinMediaId ||
+                    data.mediaInfo.jellyfinMediaId4k ||
+                    data.mediaInfo.status !== MediaStatus.UNKNOWN ||
+                    data.mediaInfo.status4k !== MediaStatus.UNKNOWN) && (
+                    <Tooltip content={intl.formatMessage(messages.managemovie)}>
+                      <Button buttonType="ghost" onClick={() => setShowManager(true)} className="relative ml-2 first:ml-0">
+                        <CogIcon className="!mr-0" />
+                        {hasPermission([Permission.MANAGE_ISSUES, Permission.VIEW_ISSUES], { type: 'or' }) &&
+                          (data.mediaInfo?.issues.filter((issue) => issue.status === IssueStatus.OPEN) ?? []).length > 0 && (
+                            <>
+                              <div className="absolute -right-1 -top-1 h-3 w-3 rounded-full bg-red-600" />
+                              <div className="absolute -right-1 -top-1 h-3 w-3 animate-ping rounded-full bg-red-600" />
+                            </>
+                          )}
+                      </Button>
+                    </Tooltip>
+                  )}
+              </div>
+              {/* Overview — mobile only, shown in hero */}
+              <div className="sm:hidden mt-8">
+                <div className="flex items-center gap-2 mb-1.5">
+                  <p className="text-xs font-semibold uppercase tracking-wider text-white/40">
+                    {intl.formatMessage(messages.overview)}
+                  </p>
+                  {data.tagline && (
+                    <>
+                      <span className="text-white/20">|</span>
+                      <p className="text-indigo-400/80 text-xs font-medium italic truncate">{data.tagline}</p>
+                    </>
+                  )}
+                </div>
+                <p className="text-xs leading-relaxed text-white/60">
+                  {data.overview || intl.formatMessage(messages.overviewunavailable)}
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="absolute absolute-bottom-shift inset-x-0 flex justify-center animate-bounce opacity-30 pointer-events-none">
+            <ChevronDownIcon className="h-5 w-5 text-white" />
+          </div>
+        </div>
+
+        {/* Content sections */}
+        <div className="divide-y divide-white/[0.06] pt-6 pb-8">
+          {/* Overview + crew */}
+          <div className="py-6">
+            <div className="hidden sm:flex items-center gap-2 mb-3">
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-white/40">
+                {intl.formatMessage(messages.overview)}
+              </h2>
+              {data.tagline && (
+                <>
+                  <span className="text-white/20">|</span>
+                  <p className="text-indigo-400/80 text-sm font-medium italic">
+                    {data.tagline}
+                  </p>
+                </>
+              )}
+            </div>
+            <p className="hidden sm:block text-white/70 text-sm leading-relaxed">
+              {data.overview || intl.formatMessage(messages.overviewunavailable)}
+            </p>
+            {sortedCrew.length > 0 && (
+              <div className="relative -mt-[50px] pt-6 sm:mt-3">
+                <div className="absolute inset-x-0 top-0 border-t border-white/[0.12]" />
+                <div className="relative">
+                  <div className="flex items-center justify-between mb-3">
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-white/30">{intl.formatMessage(messages.crew)}</h3>
+                    <Link
+                      href={`/movie/${data.id}/crew`}
+                      className="flex items-center gap-1 text-xs text-indigo-400/70 hover:text-indigo-300 transition-colors"
+                    >
+                      {intl.formatMessage(messages.viewfullcrew)}
+                      <ArrowRightCircleIcon className="h-3.5 w-3.5" />
+                    </Link>
+                  </div>
+                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-3">
+                    {sortedCrew.slice(0, 6).map((person) => (
+                      <div key={`crew-${person.job}-${person.id}`}>
+                        <div className="text-[11px] text-white/35 mb-0.5 uppercase tracking-wide">{person.job}</div>
+                        <Link href={`/person/${person.id}`} className="text-sm text-white/80 hover:text-indigo-300 transition-colors">
+                          {person.name}
+                        </Link>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+            {data.keywords.length > 0 && (
+              <div className="mt-5">
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-white/30 mb-2.5">{intl.formatMessage(messages.keywords)}</h3>
+                <div className="flex flex-wrap gap-1.5">
+                  {data.keywords.slice(0, 8).map((keyword) => (
+                    <Link
+                      href={`/discover/movies?keywords=${keyword.id}`}
+                      key={`keyword-id-${keyword.id}`}
+                      className="rounded-full px-2.5 py-0.5 text-xs text-white/50 ring-1 ring-white/10 hover:text-white/80 hover:ring-white/25 transition-colors"
+                    >
+                      {keyword.name}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Ratings + Facts */}
+          <div className="py-6 grid grid-cols-1 lg:grid-cols-2 gap-x-12 gap-y-8">
+            {(!!data.voteCount ||
+              (ratingData?.rt?.criticsRating && typeof ratingData?.rt?.criticsScore === 'number') ||
+              (ratingData?.rt?.audienceRating && !!ratingData?.rt?.audienceScore) ||
+              ratingData?.imdb?.criticsScore) && (
+              <div>
+                <h2 className="text-xs font-semibold uppercase tracking-wider text-white/40 mb-4">{intl.formatMessage(messages.ratings)}</h2>
+                <div className="flex flex-wrap gap-5">
+                  {ratingData?.rt?.criticsRating && typeof ratingData?.rt?.criticsScore === 'number' && (
+                    <Tooltip content={intl.formatMessage(messages.rtcriticsscore)}>
+                      <a href={ratingData.rt.url} className="flex items-center gap-2 text-sm text-white/70 hover:text-white transition-colors" target="_blank" rel="noreferrer">
+                        {ratingData.rt.criticsRating === 'Rotten' ? <RTRotten className="w-6" /> : <RTFresh className="w-6" />}
+                        <span>{ratingData.rt.criticsScore}%</span>
+                      </a>
+                    </Tooltip>
+                  )}
+                  {ratingData?.rt?.audienceRating && !!ratingData?.rt?.audienceScore && (
+                    <Tooltip content={intl.formatMessage(messages.rtaudiencescore)}>
+                      <a href={ratingData.rt.url} className="flex items-center gap-2 text-sm text-white/70 hover:text-white transition-colors" target="_blank" rel="noreferrer">
+                        {ratingData.rt.audienceRating === 'Spilled' ? <RTAudRotten className="w-6" /> : <RTAudFresh className="w-6" />}
+                        <span>{ratingData.rt.audienceScore}%</span>
+                      </a>
+                    </Tooltip>
+                  )}
+                  {ratingData?.imdb?.criticsScore && (
+                    <Tooltip content={intl.formatMessage(messages.imdbuserscore, { formattedCount: intl.formatNumber(ratingData.imdb.criticsScoreCount, { notation: 'compact', compactDisplay: 'short', maximumFractionDigits: 1 }) })}>
+                      <a href={ratingData.imdb.url} className="flex items-center gap-2 text-sm text-white/70 hover:text-white transition-colors" target="_blank" rel="noreferrer">
+                        <ImdbLogo className="mr-1 w-6" />
+                        <span>{ratingData.imdb.criticsScore}</span>
+                      </a>
+                    </Tooltip>
+                  )}
+                  {!!data.voteCount && (
+                    <Tooltip content={intl.formatMessage(messages.tmdbuserscore)}>
+                      <a href={`https://www.themoviedb.org/movie/${data.id}?language=${locale}`} className="flex items-center gap-2 text-sm text-white/70 hover:text-white transition-colors" target="_blank" rel="noreferrer">
+                        <TmdbLogo className="mr-1 w-6" />
+                        <span>{Math.round(data.voteAverage * 10)}%</span>
+                      </a>
+                    </Tooltip>
+                  )}
+                </div>
+              </div>
+            )}
+            <div>
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-white/40 mb-4">{intl.formatMessage(messages.details)}</h2>
+              <dl className="space-y-2.5">
+                {data.originalTitle && data.originalLanguage !== locale.slice(0, 2) && (
+                  <div className="flex justify-between text-sm">
+                    <dt className="text-white/40">{intl.formatMessage(messages.originaltitle)}</dt>
+                    <dd className="text-white/80 text-right ml-4">{data.originalTitle}</dd>
+                  </div>
+                )}
+                <div className="flex justify-between text-sm">
+                  <dt className="text-white/40">{intl.formatMessage(globalMessages.status)}</dt>
+                  <dd className="text-white/80">{data.status}</dd>
+                </div>
+                {filteredReleases && filteredReleases.length > 0 ? (
+                  <div className="flex justify-between text-sm">
+                    <dt className="text-white/40">{intl.formatMessage(messages.releasedate, { releaseCount: filteredReleases.length })}</dt>
+                    <dd className="text-white/80 text-right">
+                      {filteredReleases.map((r, i) => (
+                        <span className="flex items-center justify-end gap-1.5" key={`release-date-${i}`}>
+                          {r.type === 3 ? (
+                            <Tooltip content={intl.formatMessage(messages.theatricalrelease)}><TicketIcon className="h-4 w-4" /></Tooltip>
+                          ) : r.type === 4 ? (
+                            <Tooltip content={intl.formatMessage(messages.digitalrelease)}><CloudIcon className="h-4 w-4" /></Tooltip>
+                          ) : (
+                            <Tooltip content={intl.formatMessage(messages.physicalrelease)}>
+                              <svg className="h-4 w-4" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                <path d="m12 2c-5.5242 0-10 4.4758-10 10 0 5.5242 4.4758 10 10 10 5.5242 0 10-4.4758 10-10 0-5.5242-4.4758-10-10-10zm0 18.065c-4.4476 0-8.0645-3.6169-8.0645-8.0645 0-4.4476 3.6169-8.0645 8.0645-8.0645 4.4476 0 8.0645 3.6169 8.0645 8.0645 0 4.4476-3.6169 8.0645-8.0645 8.0645zm0-14.516c-3.5565 0-6.4516 2.8952-6.4516 6.4516h1.2903c0-2.8468 2.3145-5.1613 5.1613-5.1613zm0 2.9032c-1.9597 0-3.5484 1.5887-3.5484 3.5484s1.5887 3.5484 3.5484 3.5484 3.5484-1.5887 3.5484-3.5484-1.5887-3.5484-3.5484-3.5484zm0 4.8387c-0.71371 0-1.2903-0.57661-1.2903-1.2903s0.57661-1.2903 1.2903-1.2903 1.2903 0.57661 1.2903 1.2903-0.57661 1.2903-1.2903 1.2903z" fill="currentColor" />
+                              </svg>
+                            </Tooltip>
+                          )}
+                          <span>{intl.formatDate(r.release_date, { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</span>
+                        </span>
+                      ))}
+                    </dd>
+                  </div>
+                ) : (
+                  data.releaseDate && (
+                    <div className="flex justify-between text-sm">
+                      <dt className="text-white/40">{intl.formatMessage(messages.releasedate, { releaseCount: 1 })}</dt>
+                      <dd className="text-white/80">{intl.formatDate(data.releaseDate, { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</dd>
+                    </div>
+                  )
+                )}
+                {data.revenue > 0 && (
+                  <div className="flex justify-between text-sm">
+                    <dt className="text-white/40">{intl.formatMessage(messages.revenue)}</dt>
+                    <dd className="text-white/80">{intl.formatNumber(data.revenue, { currency: 'USD', style: 'currency' })}</dd>
+                  </div>
+                )}
+                {data.budget > 0 && (
+                  <div className="flex justify-between text-sm">
+                    <dt className="text-white/40">{intl.formatMessage(messages.budget)}</dt>
+                    <dd className="text-white/80">{intl.formatNumber(data.budget, { currency: 'USD', style: 'currency' })}</dd>
+                  </div>
+                )}
+                {data.originalLanguage && (
+                  <div className="flex justify-between text-sm">
+                    <dt className="text-white/40">{intl.formatMessage(messages.originallanguage)}</dt>
+                    <dd className="text-white/80">
+                      <Link href={`/discover/movies/language/${data.originalLanguage}`} className="hover:text-indigo-300 transition-colors">
+                        {intl.formatDisplayName(data.originalLanguage, { type: 'language', fallback: 'none' }) ??
+                          data.spokenLanguages.find((lng) => lng.iso_639_1 === data.originalLanguage)?.name}
+                      </Link>
+                    </dd>
+                  </div>
+                )}
+                {data.productionCountries.length > 0 && (
+                  <div className="flex justify-between text-sm">
+                    <dt className="text-white/40">{intl.formatMessage(messages.productioncountries, { countryCount: data.productionCountries.length })}</dt>
+                    <dd className="text-white/80 text-right">
+                      {data.productionCountries.map((c) => (
+                        <span className="flex items-center justify-end" key={`prodcountry-${c.iso_3166_1}`}>
+                          {countries.includes(c.iso_3166_1) && <span className={`mr-1.5 text-xs leading-5 flag:${c.iso_3166_1}`} />}
+                          <span>{intl.formatDisplayName(c.iso_3166_1, { type: 'region', fallback: 'none' }) ?? c.name}</span>
+                        </span>
+                      ))}
+                    </dd>
+                  </div>
+                )}
+                {data.productionCompanies.length > 0 && (
+                  <div className="flex justify-between text-sm">
+                    <dt className="text-white/40">{intl.formatMessage(messages.studio, { studioCount: data.productionCompanies.length })}</dt>
+                    <dd className="text-white/80 text-right">
+                      {data.productionCompanies
+                        .slice(0, showAllStudios || showMoreStudios ? data.productionCompanies.length : minStudios)
+                        .map((s) => (
+                          <Link href={`/discover/movies/studio/${s.id}`} key={`studio-${s.id}`} className="block hover:text-indigo-300 transition-colors">
+                            {s.name}
+                          </Link>
+                        ))}
+                      {!showAllStudios && (
+                        <button type="button" onClick={() => setShowMoreStudios(!showMoreStudios)}>
+                          <span className="flex items-center text-white/40 hover:text-white/70">
+                            {intl.formatMessage(!showMoreStudios ? messages.showmore : messages.showless)}
+                            {!showMoreStudios ? <ChevronDoubleDownIcon className="ml-1 h-4 w-4" /> : <ChevronDoubleUpIcon className="ml-1 h-4 w-4" />}
+                          </span>
+                        </button>
+                      )}
+                    </dd>
+                  </div>
+                )}
+              </dl>
+            </div>
+          </div>
+
+          {/* Collection */}
+          {data.collection && (
+            <div className="py-6">
+            <Link href={`/collection/${data.collection.id}`}>
+              <div className="group relative overflow-hidden rounded-xl ring-1 ring-white/[0.08] cursor-pointer transition hover:ring-white/20">
+                <div className="absolute inset-0 z-0">
+                  <CachedImage
+                    type="tmdb"
+                    src={`https://image.tmdb.org/t/p/w1440_and_h320_multi_faces/${data.collection.backdropPath}`}
+                    alt=""
+                    fill
+                    style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                  />
+                  <div className="absolute inset-0 bg-black/60 group-hover:bg-black/50 transition" />
+                </div>
+                <div className="relative z-10 flex items-center justify-between p-5 text-white">
+                  <div className="font-semibold">{data.collection.name}</div>
+                  <Button buttonSize="sm">{intl.formatMessage(globalMessages.view)}</Button>
+                </div>
+              </div>
+            </Link>
+            </div>
+          )}
+
+          {/* Streaming providers */}
+          {!!streamingProviders.length && (
+            <div className="py-6">
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-white/40 mb-4">
+                {intl.formatMessage(messages.streamingproviders)}
+              </h2>
+              <div className="flex flex-wrap gap-4">
+                {streamingProviders.map((p) => (
+                  <Tooltip content={p.name} key={`provider-${p.id}`}>
+                    <span className="opacity-60 hover:opacity-100 transition-opacity">
+                      <CachedImage
+                        type="tmdb"
+                        src={'https://image.tmdb.org/t/p/w45/' + p.logoPath}
+                        alt={p.name}
+                        width={40}
+                        height={40}
+                        className="rounded-lg"
+                      />
+                    </span>
+                  </Tooltip>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* External links */}
+          <div className="py-6">
+            <ExternalLinkBlock
+              mediaType="movie"
+              tmdbId={data.id}
+              tvdbId={data.externalIds.tvdbId}
+              imdbId={data.externalIds.imdbId}
+              rtUrl={ratingData?.rt?.url}
+              mediaUrl={data.mediaInfo?.mediaUrl ?? data.mediaInfo?.mediaUrl4k}
+            />
+          </div>
+        </div>
+
+        {/* Cast */}
+        {data.credits.cast.length > 0 && (
+          <>
+            <div className="slider-header">
+              <Link href="/movie/[movieId]/cast" as={`/movie/${data.id}/cast`} className="slider-title">
+                <span>{intl.formatMessage(messages.cast)}</span>
+                <ArrowRightCircleIcon />
+              </Link>
+            </div>
+            <Slider
+              sliderKey="cast"
+              isLoading={false}
+              isEmpty={false}
+              items={data.credits.cast.slice(0, 20).map((person) => (
+                <PersonCard
+                  key={`cast-item-${person.id}`}
+                  personId={person.id}
+                  name={person.name}
+                  subName={person.character}
+                  profilePath={person.profilePath}
+                />
+              ))}
+            />
+          </>
+        )}
+        <MediaSlider
+          sliderKey="recommendations"
+          title={intl.formatMessage(messages.recommendations)}
+          url={`/api/v1/movie/${router.query.movieId}/recommendations`}
+          linkUrl={`/movie/${data.id}/recommendations`}
+          hideWhenEmpty
+        />
+        <MediaSlider
+          sliderKey="similar"
+          title={intl.formatMessage(messages.similar)}
+          url={`/api/v1/movie/${router.query.movieId}/similar`}
+          linkUrl={`/movie/${data.id}/similar`}
+          hideWhenEmpty
+        />
+        <div className="extra-bottom-space relative" />
+      </div>
+    </>
   );
 };
 

--- a/src/components/PersonDetails/index.tsx
+++ b/src/components/PersonDetails/index.tsx
@@ -241,33 +241,19 @@ const PersonDetails = () => {
     <>
       <PageTitle title={data.name} />
       {(sortedCrew || sortedCast) && (
-        <>
-          <div className="person-fader-standard absolute left-0 right-0 top-0 z-0 h-96">
-            <ImageFader
-              isDarker
-              backgroundImages={[...(sortedCast ?? []), ...(sortedCrew ?? [])]
-                .filter((media) => media.backdropPath)
-                .map(
-                  (media) =>
-                    `https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${media.backdropPath}`
-                )
-                .slice(0, 6)}
-            />
-          </div>
-          <div className="person-fader-amoled absolute left-0 right-0 top-0 z-0 h-96 overflow-hidden">
-            <ImageFader
-              isDarker
-              backgroundImages={[...(sortedCast ?? []), ...(sortedCrew ?? [])]
-                .filter((media) => media.backdropPath)
-                .map(
-                  (media) =>
-                    `https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${media.backdropPath}`
-                )
-                .slice(0, 6)}
-            />
-            <div className="absolute inset-0 bg-gradient-to-b from-black/60 to-gray-900" />
-          </div>
-        </>
+        <div className="absolute left-0 right-0 top-0 z-0 h-96 overflow-hidden">
+          <ImageFader
+            isDarker
+            backgroundImages={[...(sortedCast ?? []), ...(sortedCrew ?? [])]
+              .filter((media) => media.backdropPath)
+              .map(
+                (media) =>
+                  `https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${media.backdropPath}`
+              )
+              .slice(0, 6)}
+          />
+          <div className="person-fader-amoled-overlay absolute inset-0 bg-gradient-to-b from-black/60 to-gray-900" />
+        </div>
       )}
       <div
         className={`relative z-10 mb-8 mt-4 flex flex-col items-center lg:flex-row ${

--- a/src/components/PersonDetails/index.tsx
+++ b/src/components/PersonDetails/index.tsx
@@ -241,18 +241,33 @@ const PersonDetails = () => {
     <>
       <PageTitle title={data.name} />
       {(sortedCrew || sortedCast) && (
-        <div className="absolute left-0 right-0 top-0 z-0 h-96">
-          <ImageFader
-            isDarker
-            backgroundImages={[...(sortedCast ?? []), ...(sortedCrew ?? [])]
-              .filter((media) => media.backdropPath)
-              .map(
-                (media) =>
-                  `https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${media.backdropPath}`
-              )
-              .slice(0, 6)}
-          />
-        </div>
+        <>
+          <div className="person-fader-standard absolute left-0 right-0 top-0 z-0 h-96">
+            <ImageFader
+              isDarker
+              backgroundImages={[...(sortedCast ?? []), ...(sortedCrew ?? [])]
+                .filter((media) => media.backdropPath)
+                .map(
+                  (media) =>
+                    `https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${media.backdropPath}`
+                )
+                .slice(0, 6)}
+            />
+          </div>
+          <div className="person-fader-amoled absolute left-0 right-0 top-0 z-0 h-96 overflow-hidden">
+            <ImageFader
+              isDarker
+              backgroundImages={[...(sortedCast ?? []), ...(sortedCrew ?? [])]
+                .filter((media) => media.backdropPath)
+                .map(
+                  (media) =>
+                    `https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${media.backdropPath}`
+                )
+                .slice(0, 6)}
+            />
+            <div className="absolute inset-0 bg-gradient-to-b from-black/60 to-gray-900" />
+          </div>
+        </>
       )}
       <div
         className={`relative z-10 mb-8 mt-4 flex flex-col items-center lg:flex-row ${
@@ -260,7 +275,7 @@ const PersonDetails = () => {
         }`}
       >
         {data.profilePath && (
-          <div className="relative mb-6 mr-0 h-36 w-36 flex-shrink-0 overflow-hidden rounded-full ring-1 ring-gray-700 lg:mb-0 lg:mr-6 lg:h-44 lg:w-44">
+          <div className="person-profile-photo relative mb-6 mr-0 flex-shrink-0 overflow-hidden h-36 w-36 rounded-full ring-1 ring-gray-700 lg:mb-0 lg:mr-6 lg:h-44 lg:w-44">
             <CachedImage
               type="tmdb"
               src={`https://image.tmdb.org/t/p/w600_and_h900_bestv2${data.profilePath}`}

--- a/src/components/RegionSelector/index.tsx
+++ b/src/components/RegionSelector/index.tsx
@@ -94,7 +94,7 @@ const RegionSelector = ({
         {({ open }) => (
           <div className="relative">
             <span className="inline-block w-full rounded-md shadow-sm">
-              <Listbox.Button className="focus:shadow-outline-blue relative flex w-full cursor-default items-center rounded-md border border-gray-500 bg-gray-700 py-2 pl-3 pr-10 text-left text-white transition duration-150 ease-in-out focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5">
+              <Listbox.Button className="focus:shadow-outline-blue relative flex w-full cursor-default items-center rounded-md border border-border-default bg-input py-2 pl-3 pr-10 text-left text-white transition duration-150 ease-in-out focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5">
                 {((selectedRegion &&
                   countries.includes(selectedRegion?.iso_3166_1)) ||
                   (isUserSetting &&
@@ -131,7 +131,7 @@ const RegionSelector = ({
               leave="transition-opacity ease-in duration-100"
               leaveFrom="opacity-100"
               leaveTo="opacity-0"
-              className="absolute mt-1 w-full rounded-md bg-gray-800 shadow-lg"
+              className="absolute mt-1 w-full rounded-md bg-surface-raised shadow-lg"
             >
               <Listbox.Options
                 static

--- a/src/components/RequestBlock/index.tsx
+++ b/src/components/RequestBlock/index.tsx
@@ -288,7 +288,7 @@ const RequestBlock = ({ request, onUpdate }: RequestBlockProps) => {
             <div className="mb-1 mt-4 text-sm">
               {intl.formatMessage(messages.requestoverrides)}
             </div>
-            <ul className="divide-y divide-gray-700 rounded-md bg-gray-800 px-2 text-xs">
+            <ul className={`divide-y divide-border-default border border-border-default rounded-md px-2 text-xs`}>
               {server && (
                 <li className="flex justify-between px-1 py-2">
                   <span className="font-bold">

--- a/src/components/RequestButton/index.tsx
+++ b/src/components/RequestButton/index.tsx
@@ -391,28 +391,30 @@ const RequestButton = ({
         }}
         onCancel={() => setShowRequest4kModal(false)}
       />
-      <ButtonWithDropdown
-        text={
-          <>
-            {buttonOne.svg}
-            <span>{buttonOne.text}</span>
-          </>
-        }
-        onClick={buttonOne.action}
-        className="ml-2"
-      >
-        {others && others.length > 0
-          ? others.map((button) => (
-              <ButtonWithDropdown.Item
-                onClick={button.action}
-                key={`request-option-${button.id}`}
-              >
-                {button.svg}
-                <span>{button.text}</span>
-              </ButtonWithDropdown.Item>
-            ))
-          : null}
-      </ButtonWithDropdown>
+      <div className="min-w-max shrink-0">
+        <ButtonWithDropdown
+          text={
+            <>
+              {buttonOne.svg}
+              <span className="whitespace-nowrap">{buttonOne.text}</span>
+            </>
+          }
+          onClick={buttonOne.action}
+          className="whitespace-nowrap"
+        >
+          {others && others.length > 0
+            ? others.map((button) => (
+                <ButtonWithDropdown.Item
+                  onClick={button.action}
+                  key={`request-option-${button.id}`}
+                >
+                  {button.svg}
+                  <span className="whitespace-nowrap">{button.text}</span>
+                </ButtonWithDropdown.Item>
+              ))
+            : null}
+        </ButtonWithDropdown>
+      </div>
     </>
   );
 };

--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -330,7 +330,7 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
         }}
       />
       <div
-        className="relative flex w-72 overflow-hidden rounded-xl bg-gray-800 bg-cover bg-center p-4 text-gray-400 shadow ring-1 ring-gray-700 sm:w-96"
+        className="relative flex w-72 overflow-hidden bg-cover bg-center p-4 text-gray-400 shadow sm:w-96 rounded-xl bg-surface ring-1 ring-ring-app/10"
         data-testid="request-card"
       >
         {title.backdropPath && (
@@ -342,13 +342,7 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
               fill
             />
-            <div
-              className="absolute inset-0"
-              style={{
-                backgroundImage:
-                  'linear-gradient(135deg, rgba(17, 24, 39, 0.47) 0%, rgba(17, 24, 39, 1) 75%)',
-              }}
-            />
+            <div className="absolute inset-0 bg-gradient-to-br from-surface/50 to-surface" />
           </div>
         )}
         <div

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -375,7 +375,7 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
   if (!title && !error) {
     return (
       <div
-        className="h-64 w-full animate-pulse rounded-xl bg-gray-800 xl:h-28"
+        className="h-64 w-full animate-pulse rounded-xl bg-surface xl:h-28"
         ref={ref}
       />
     );
@@ -404,7 +404,7 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
           setShowEditModal(false);
         }}
       />
-      <div className="relative flex w-full flex-col justify-between overflow-hidden rounded-xl bg-gray-800 py-2 text-gray-400 shadow-md ring-1 ring-gray-700 xl:h-28 xl:flex-row">
+      <div className="relative flex w-full flex-col justify-between overflow-hidden py-2 text-gray-400 xl:h-28 xl:flex-row rounded-xl bg-surface shadow-md ring-1 ring-ring-app/10">
         {title.backdropPath && (
           <div className="absolute inset-0 z-0 w-full bg-cover bg-center xl:w-2/3">
             <CachedImage
@@ -414,13 +414,7 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
               fill
             />
-            <div
-              className="absolute inset-0"
-              style={{
-                backgroundImage:
-                  'linear-gradient(90deg, rgba(31, 41, 55, 0.47) 0%, rgba(31, 41, 55, 1) 100%)',
-              }}
-            />
+            <div className="absolute inset-0 bg-gradient-to-r from-surface/50 to-surface" />
           </div>
         )}
         <div className="relative flex w-full flex-col justify-between overflow-hidden sm:flex-row">

--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -167,7 +167,7 @@ const RequestList = () => {
         </Header>
         <div className="mt-2 flex flex-grow flex-col sm:flex-row lg:flex-grow-0">
           <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 lg:flex-grow-0">
-            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">
+            <span className={`inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 text-sm text-gray-100 border-border-default bg-input`}>
               <CircleStackIcon className="h-6 w-6" />
             </span>
             <select
@@ -197,7 +197,7 @@ const RequestList = () => {
             </select>
           </div>
           <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 lg:flex-grow-0">
-            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">
+            <span className={`inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 text-sm text-gray-100 border-border-default bg-input`}>
               <FunnelIcon className="h-6 w-6" />
             </span>
             <select
@@ -245,7 +245,7 @@ const RequestList = () => {
             </select>
           </div>
           <div className="mb-2 flex flex-grow sm:mb-0 lg:flex-grow-0">
-            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-gray-100 sm:text-sm">
+            <span className={`inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 text-gray-100 sm:text-sm border-border-default bg-input`}>
               <Bars3BottomLeftIcon className="h-6 w-6" />
             </span>
             <select
@@ -273,7 +273,7 @@ const RequestList = () => {
             <Tooltip content={intl.formatMessage(messages.sortDirection)}>
               <Button
                 buttonType="default"
-                className="z-40 mr-2 rounded-l-none border !border-gray-500 !bg-gray-800 !px-3 !text-gray-500 hover:!bg-gray-400 hover:!text-white"
+                className="z-40 mr-2 rounded-l-none border border-border-default !bg-input !px-3 !text-gray-500 hover:!bg-gray-400 hover:!text-white"
                 buttonSize="md"
                 onClick={() =>
                   setCurrentSortDirection(

--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -325,7 +325,7 @@ const AdvancedRequester = ({
                   value={selectedServer}
                   onChange={(e) => setSelectedServer(Number(e.target.value))}
                   onBlur={(e) => setSelectedServer(Number(e.target.value))}
-                  className="border-gray-700 bg-gray-800"
+                  className="border-border-default bg-input"
                 >
                   {data
                     .filter((server) => server.is4k === is4k)
@@ -357,7 +357,7 @@ const AdvancedRequester = ({
                   value={selectedProfile}
                   onChange={(e) => setSelectedProfile(Number(e.target.value))}
                   onBlur={(e) => setSelectedProfile(Number(e.target.value))}
-                  className="border-gray-700 bg-gray-800"
+                  className="border-border-default bg-input"
                   disabled={isValidating || !serverData}
                 >
                   {(isValidating || !serverData) && (
@@ -401,7 +401,7 @@ const AdvancedRequester = ({
                   value={selectedFolder}
                   onChange={(e) => setSelectedFolder(e.target.value)}
                   onBlur={(e) => setSelectedFolder(e.target.value)}
-                  className="border-gray-700 bg-gray-800"
+                  className="border-border-default bg-input"
                   disabled={isValidating || !serverData}
                 >
                   {(isValidating || !serverData) && (
@@ -459,7 +459,7 @@ const AdvancedRequester = ({
                     onBlur={(e) =>
                       setSelectedLanguage(parseInt(e.target.value))
                     }
-                    className="border-gray-700 bg-gray-800"
+                    className="border-border-default bg-input"
                     disabled={isValidating || !serverData}
                   >
                     {(isValidating || !serverData) && (
@@ -559,7 +559,7 @@ const AdvancedRequester = ({
                   </Listbox.Label>
                   <div className="relative">
                     <span className="inline-block w-full rounded-md shadow-sm">
-                      <Listbox.Button className="focus:shadow-outline-blue relative w-full cursor-default rounded-md border border-gray-700 bg-gray-800 py-2 pl-3 pr-10 text-left text-white transition duration-150 ease-in-out focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5">
+                      <Listbox.Button className="focus:shadow-outline-blue relative w-full cursor-default rounded-md border border-border-default bg-input py-2 pl-3 pr-10 text-left text-white transition duration-150 ease-in-out focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5">
                         <span className="flex items-center">
                           <CachedImage
                             type="avatar"
@@ -593,7 +593,7 @@ const AdvancedRequester = ({
                       leave="transition-opacity ease-in duration-100"
                       leaveFrom="opacity-100"
                       leaveTo="opacity-0"
-                      className="mt-1 w-full rounded-md border border-gray-700 bg-gray-800 shadow-lg"
+                      className="mt-1 w-full rounded-md border border-border-default bg-surface-raised shadow-lg"
                     >
                       <Listbox.Options
                         static

--- a/src/components/ResetPassword/RequestResetLink.tsx
+++ b/src/components/ResetPassword/RequestResetLink.tsx
@@ -39,7 +39,7 @@ const ResetPassword = () => {
   });
 
   return (
-    <div className="relative flex min-h-screen flex-col bg-gray-900 py-14">
+    <div className="relative flex min-h-screen flex-col py-14 bg-app">
       <PageTitle title={intl.formatMessage(messages.passwordreset)} />
       <ImageFader
         forceOptimize
@@ -65,7 +65,7 @@ const ResetPassword = () => {
       </div>
       <div className="relative z-50 mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <div
-          className="bg-gray-800/50 shadow sm:rounded-lg"
+          className="shadow sm:rounded-lg bg-surface/80 ring-1 ring-ring-app/10"
           style={{ backdropFilter: 'blur(5px)' }}
         >
           <div className="px-10 py-8">

--- a/src/components/ResetPassword/index.tsx
+++ b/src/components/ResetPassword/index.tsx
@@ -50,7 +50,7 @@ const ResetPassword = () => {
   });
 
   return (
-    <div className="relative flex min-h-screen flex-col bg-gray-900 py-14">
+    <div className="relative flex min-h-screen flex-col py-14 bg-app">
       <ImageFader
         forceOptimize
         backgroundImages={[
@@ -75,7 +75,7 @@ const ResetPassword = () => {
       </div>
       <div className="relative z-50 mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <div
-          className="bg-gray-800/50 shadow sm:rounded-lg"
+          className="shadow sm:rounded-lg bg-surface/80 ring-1 ring-ring-app/10"
           style={{ backdropFilter: 'blur(5px)' }}
         >
           <div className="px-10 py-8">

--- a/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
+++ b/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
@@ -140,7 +140,7 @@ const OverrideRuleTiles = ({
   return (
     <>
       {rules.map((rule) => (
-        <li className="flex h-full flex-col rounded-lg bg-gray-800 text-left shadow ring-1 ring-gray-500">
+        <li key={rule.id} className="flex h-full flex-col rounded-lg text-left shadow ring-1 bg-surface ring-ring-app/10">
           <div className="flex w-full flex-1 items-center justify-between space-x-6 p-6">
             <div className="flex-1 truncate">
               <span className="text-lg">
@@ -154,7 +154,7 @@ const OverrideRuleTiles = ({
                   <div className="inline-flex gap-2">
                     {rule.users.split(',').map((userId) => {
                       return (
-                        <span>
+                        <span key={userId}>
                           {
                             users?.find((user) => user.id === Number(userId))
                               ?.displayName
@@ -172,7 +172,7 @@ const OverrideRuleTiles = ({
                   </span>
                   <div className="inline-flex gap-2">
                     {rule.genre.split(',').map((genreId) => (
-                      <span>
+                      <span key={genreId}>
                         {genres?.find((g) => g.id === Number(genreId))?.name}
                       </span>
                     ))}
@@ -198,7 +198,7 @@ const OverrideRuleTiles = ({
                             type: 'language',
                             fallback: 'none',
                           }) ?? language.english_name;
-                        return <span>{languageName}</span>;
+                        return <span key={languageId}>{languageName}</span>;
                       })}
                   </div>
                 </p>
@@ -211,7 +211,7 @@ const OverrideRuleTiles = ({
                   <div className="inline-flex gap-2">
                     {rule.keywords.split(',').map((keywordId) => {
                       return (
-                        <span>
+                        <span key={keywordId}>
                           {
                             keywords?.find(
                               (keyword) => keyword.id === Number(keywordId)
@@ -257,7 +257,7 @@ const OverrideRuleTiles = ({
                   </span>
                   <div className="inline-flex gap-2">
                     {rule.tags.split(',').map((tag) => (
-                      <span>
+                      <span key={tag}>
                         {testResponses
                           .find(
                             (r) =>

--- a/src/components/Settings/SettingsAbout/Releases/index.tsx
+++ b/src/components/Settings/SettingsAbout/Releases/index.tsx
@@ -61,7 +61,7 @@ const Release = ({ currentVersion, release, isLatest }: ReleaseProps) => {
   const [isModalOpen, setModalOpen] = useState(false);
 
   return (
-    <div className="flex w-full flex-col space-y-3 rounded-md bg-gray-800 px-4 py-2 shadow-md ring-1 ring-gray-700 sm:flex-row sm:space-x-3 sm:space-y-0">
+    <div className="flex w-full flex-col space-y-3 px-4 py-2 shadow-md ring-1 sm:flex-row sm:space-x-3 sm:space-y-0 rounded-md bg-surface ring-ring-app/10">
       <Transition
         as={Fragment}
         enter="transition-opacity duration-300"

--- a/src/components/Settings/SettingsJellyfin.tsx
+++ b/src/components/Settings/SettingsJellyfin.tsx
@@ -320,7 +320,7 @@ const SettingsJellyfin: React.FC<SettingsJellyfinProps> = ({
         </p>
       </div>
       <div className="section">
-        <div className="rounded-md bg-gray-800 p-4">
+        <div className="rounded-md bg-surface p-4">
           <div className="relative mb-6 h-8 w-full overflow-hidden rounded-full bg-gray-600">
             {dataSync?.running && (
               <div
@@ -520,7 +520,7 @@ const SettingsJellyfin: React.FC<SettingsJellyfinProps> = ({
                     </label>
                     <div className="form-input-area">
                       <div className="form-input-field">
-                        <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-gray-100 sm:text-sm">
+                        <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-border-default bg-input px-3 text-gray-100 sm:text-sm">
                           {values.useSsl ? 'https://' : 'http://'}
                         </span>
                         <Field

--- a/src/components/Settings/SettingsLogs/index.tsx
+++ b/src/components/Settings/SettingsLogs/index.tsx
@@ -254,7 +254,7 @@ const SettingsLogs = () => {
         </p>
         <div className="mt-2 flex flex-grow flex-col sm:flex-grow-0 sm:flex-row sm:justify-end">
           <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 md:flex-grow-0">
-            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">
+            <span className={`inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 text-sm text-gray-100 border-border-default bg-input`}>
               <MagnifyingGlassIcon className="h-6 w-6" />
             </span>
             <input
@@ -278,7 +278,7 @@ const SettingsLogs = () => {
               </span>
             </Button>
             <div className="flex flex-grow">
-              <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">
+              <span className={`inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 text-sm text-gray-100 border-border-default bg-input`}>
                 <FunnelIcon className="h-6 w-6" />
               </span>
               <select

--- a/src/components/Settings/SettingsMetadata.tsx
+++ b/src/components/Settings/SettingsMetadata.tsx
@@ -277,7 +277,7 @@ const SettingsMetadata = () => {
         </p>
       </div>
 
-      <div className="mb-6 rounded-lg bg-gray-800 p-4">
+      <div className="mb-6 p-4 rounded-lg bg-surface ring-1 ring-ring-app/10">
         <h4 className="mb-3 text-lg font-medium">
           {intl.formatMessage(messages.providerStatus)}
         </h4>

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -513,7 +513,7 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
                 </label>
                 <div className="form-input-area">
                   <div className="form-input-field">
-                    <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-gray-100 sm:text-sm">
+                    <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 text-gray-100 sm:text-sm border-border-default bg-input">
                       {values.useSsl ? 'https://' : 'http://'}
                     </span>
                     <Field
@@ -664,7 +664,7 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
         </p>
       </div>
       <div className="section">
-        <div className="rounded-md bg-gray-800 p-4">
+        <div className="rounded-md bg-surface p-4">
           <div className="relative mb-6 h-8 w-full overflow-hidden rounded-full bg-gray-600">
             {dataSync?.running && (
               <div
@@ -801,7 +801,7 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
                     </label>
                     <div className="form-input-area">
                       <div className="form-input-field">
-                        <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-gray-100 sm:text-sm">
+                        <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 text-gray-100 sm:text-sm border-border-default bg-input">
                           {values.tautulliUseSsl ? 'https://' : 'http://'}
                         </span>
                         <Field

--- a/src/components/Settings/SettingsServices.tsx
+++ b/src/components/Settings/SettingsServices.tsx
@@ -113,7 +113,7 @@ const ServerInstance = ({
   const serviceUrl = externalUrl ?? internalUrl;
 
   return (
-    <li className="col-span-1 rounded-lg bg-gray-800 shadow ring-1 ring-gray-500">
+    <li className="col-span-1 rounded-lg shadow ring-1 bg-surface ring-ring-app/10">
       <div className="flex w-full items-center justify-between space-x-6 p-6">
         <div className="flex-1 truncate">
           <div className="mb-2 flex items-center space-x-2">

--- a/src/components/Setup/JellyfinSetup.tsx
+++ b/src/components/Setup/JellyfinSetup.tsx
@@ -172,7 +172,7 @@ function JellyfinSetup({
                 </label>
                 <div className="mb-2 mt-1 sm:col-span-2 sm:mb-0 sm:mt-0">
                   <div className="flex rounded-md shadow-sm">
-                    <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-gray-100 sm:text-sm">
+                    <span className={`inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 text-gray-100 sm:text-sm border-border-default bg-input`}>
                       {values.useSsl ? 'https://' : 'http://'}
                     </span>
                     <Field

--- a/src/components/Setup/index.tsx
+++ b/src/components/Setup/index.tsx
@@ -145,7 +145,7 @@ const Setup = () => {
   if (settings.currentSettings.initialized) return <></>;
 
   return (
-    <div className="relative flex min-h-screen flex-col justify-center bg-gray-900 py-12">
+    <div className="relative flex min-h-screen flex-col justify-center py-12 bg-app">
       <PageTitle title={intl.formatMessage(messages.setup)} />
       <ImageFader
         backgroundImages={
@@ -164,7 +164,7 @@ const Setup = () => {
         <AppDataWarning />
         <nav className="relative z-50">
           <ul
-            className="divide-y divide-gray-600 rounded-md border border-gray-600 bg-gray-800/50 md:flex md:divide-y-0"
+            className="divide-y divide-gray-600 rounded-md border border-gray-600 md:flex md:divide-y-0 bg-surface/80 ring-1 ring-ring-app/10"
             style={{ backdropFilter: 'blur(5px)' }}
           >
             <SetupSteps
@@ -193,7 +193,7 @@ const Setup = () => {
             />
           </ul>
         </nav>
-        <div className="mt-10 w-full rounded-md border border-gray-600 bg-gray-800/50 p-4 text-white">
+        <div className="mt-10 w-full rounded-md border border-gray-600 p-4 text-white bg-surface/80 ring-1 ring-ring-app/10">
           {currentStep === 1 && (
             <div className="flex flex-col items-center pb-6">
               <div className="mb-2 flex justify-center text-xl font-bold">

--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -149,28 +149,30 @@ const Slider = ({
 
   return (
     <div className="relative" data-testid="media-slider">
-      <div className="absolute right-0 -mt-10 flex text-gray-400">
-        <button
-          className={`${
-            scrollPos.isStart ? 'text-gray-800' : 'hover:text-white'
-          }`}
-          onClick={() => slide(Direction.LEFT)}
-          disabled={scrollPos.isStart}
-          type="button"
-        >
-          <ChevronLeftIcon className="h-6 w-6" />
-        </button>
-        <button
-          className={`${
-            scrollPos.isEnd ? 'text-gray-800' : 'hover:text-white'
-          }`}
-          onClick={() => slide(Direction.RIGHT)}
-          disabled={scrollPos.isEnd}
-          type="button"
-        >
-          <ChevronRightIcon className="h-6 w-6" />
-        </button>
-      </div>
+      <div className="slider-nav-arrows absolute right-0 -mt-10 flex text-gray-400">
+          <button
+            aria-label={intl.formatMessage(globalMessages.previous)}
+            className={`${
+              scrollPos.isStart ? 'text-gray-800' : 'hover:text-white'
+            }`}
+            onClick={() => slide(Direction.LEFT)}
+            disabled={scrollPos.isStart}
+            type="button"
+          >
+            <ChevronLeftIcon className="h-6 w-6" />
+          </button>
+          <button
+            aria-label={intl.formatMessage(globalMessages.next)}
+            className={`${
+              scrollPos.isEnd ? 'text-gray-800' : 'hover:text-white'
+            }`}
+            onClick={() => slide(Direction.RIGHT)}
+            disabled={scrollPos.isEnd}
+            type="button"
+          >
+            <ChevronRightIcon className="h-6 w-6" />
+          </button>
+        </div>
       <div
         className="hide-scrollbar relative -my-2 -ml-4 -mr-4 overflow-y-auto overflow-x-scroll overscroll-x-contain whitespace-nowrap px-2 py-2"
         ref={containerRef}

--- a/src/components/TitleCard/ErrorCard.tsx
+++ b/src/components/TitleCard/ErrorCard.tsx
@@ -36,7 +36,7 @@ const ErrorCard = ({ id, tmdbId, tvdbId, type, canExpand }: ErrorCardProps) => {
       data-testid="title-card"
     >
       <div
-        className="relative transform-gpu cursor-default overflow-hidden rounded-xl bg-gray-800 bg-cover shadow outline-none ring-1 ring-gray-700 transition duration-300"
+        className="relative transform-gpu cursor-default overflow-hidden rounded-xl bg-cover shadow outline-none ring-1 transition duration-300 bg-surface ring-ring-app/10"
         style={{
           paddingBottom: '150%',
         }}

--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -18,8 +18,8 @@ import {
   EyeIcon,
   EyeSlashIcon,
   MinusCircleIcon,
-  StarIcon,
 } from '@heroicons/react/24/outline';
+import { StarIcon } from '@heroicons/react/24/solid';
 import { MediaStatus } from '@server/constants/media';
 import type { Watchlist } from '@server/entity/Watchlist';
 import type { MediaType } from '@server/models/Search';
@@ -47,6 +47,7 @@ interface TitleCardProps {
 
 const messages = defineMessages('components.TitleCard', {
   addToWatchList: 'Add to watchlist',
+  removeFromWatchList: 'Remove from watchlist',
   watchlistSuccess:
     '<strong>{title}</strong> added to watchlist  successfully!',
   watchlistDeleted:
@@ -61,6 +62,7 @@ const TitleCard = ({
   summary,
   year,
   title,
+  userScore,
   status,
   mediaType,
   isAddedToWatchlist = false,
@@ -303,7 +305,7 @@ const TitleCard = ({
         isUpdating={isUpdating}
       />
       <div
-        className={`relative transform-gpu cursor-default overflow-hidden rounded-xl bg-gray-800 bg-cover outline-none ring-1 transition duration-300 ${
+        className={`title-card-inner relative transform-gpu cursor-default overflow-hidden rounded-xl bg-gray-800 bg-cover outline-none ring-1 transition duration-300 ${
           showDetail
             ? 'scale-105 shadow-lg ring-gray-500'
             : 'scale-100 shadow ring-gray-700'
@@ -339,9 +341,22 @@ const TitleCard = ({
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}
             fill
           />
+          {/* AMOLED circle badge — bottom left */}
+          <div className="title-card-amoled-badge pointer-events-none absolute bottom-2.5 left-2.5 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-black/60 backdrop-blur-md ring-1 ring-white/[0.12]">
+            <span
+              className={`text-[10px] font-semibold ${
+                mediaType === 'movie' || mediaType === 'collection'
+                  ? 'text-blue-300'
+                  : 'text-violet-300'
+              }`}
+            >
+              {mediaType === 'movie' ? 'M' : mediaType === 'collection' ? 'C' : 'S'}
+            </span>
+          </div>
+
           <div className="absolute left-0 right-0 flex items-center justify-between p-2">
             <div
-              className={`pointer-events-none z-40 self-start rounded-full border shadow-md ${
+              className={`title-card-media-type-badge pointer-events-none z-40 self-start rounded-full border shadow-md ${
                 mediaType === 'movie' || mediaType === 'collection'
                   ? 'border-blue-500 bg-blue-600/80'
                   : 'border-purple-600 bg-purple-600/80'
@@ -356,39 +371,52 @@ const TitleCard = ({
               </div>
             </div>
             {showDetail && currentStatus !== MediaStatus.BLOCKLISTED && (
-              <div className="flex flex-col gap-1">
+              <div className="flex flex-col gap-1.5">
                 {user?.userType !== UserType.PLEX &&
                   (toggleWatchlist ? (
-                    <Button
-                      buttonType={'ghost'}
-                      className="z-40"
-                      buttonSize={'sm'}
-                      onClick={onClickWatchlistBtn}
-                    >
-                      <StarIcon className={'h-3 text-amber-300'} />
-                    </Button>
+                    <>
+                      <button
+                        aria-label={intl.formatMessage(messages.addToWatchList)}
+                        className="title-card-amoled-icon-btn z-40 flex h-7 w-7 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] transition hover:bg-black/70"
+                        onClick={onClickWatchlistBtn}
+                      >
+                        <StarIcon className="h-3.5 w-3.5 text-amber-300" />
+                      </button>
+                      <Button buttonType={'ghost'} className="title-card-standard-icon-btn z-40" buttonSize={'sm'} onClick={onClickWatchlistBtn}>
+                        <StarIcon className={'h-3 text-amber-300'} />
+                      </Button>
+                    </>
                   ) : (
-                    <Button
-                      className="z-40"
-                      buttonSize={'sm'}
-                      onClick={onClickDeleteWatchlistBtn}
-                    >
-                      <MinusCircleIcon className={'h-3'} />
-                    </Button>
+                    <>
+                      <button
+                        aria-label={intl.formatMessage(messages.removeFromWatchList)}
+                        className="title-card-amoled-icon-btn z-40 flex h-7 w-7 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] transition hover:bg-black/70"
+                        onClick={onClickDeleteWatchlistBtn}
+                      >
+                        <MinusCircleIcon className="h-3.5 w-3.5 text-white/70" />
+                      </button>
+                      <Button className="title-card-standard-icon-btn z-40" buttonSize={'sm'} onClick={onClickDeleteWatchlistBtn}>
+                        <MinusCircleIcon className={'h-3'} />
+                      </Button>
+                    </>
                   ))}
                 {showHideButton &&
                   currentStatus !== MediaStatus.PROCESSING &&
                   currentStatus !== MediaStatus.AVAILABLE &&
                   currentStatus !== MediaStatus.PARTIALLY_AVAILABLE &&
                   currentStatus !== MediaStatus.PENDING && (
-                    <Button
-                      buttonType={'ghost'}
-                      className="z-40"
-                      buttonSize={'sm'}
-                      onClick={() => setShowBlocklistModal(true)}
-                    >
-                      <EyeSlashIcon className={'h-3'} />
-                    </Button>
+                    <>
+                      <button
+                        aria-label={intl.formatMessage(globalMessages.blocklist)}
+                        className="title-card-amoled-icon-btn z-40 flex h-7 w-7 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] transition hover:bg-black/70"
+                        onClick={() => setShowBlocklistModal(true)}
+                      >
+                        <EyeSlashIcon className="h-3.5 w-3.5 text-white/70" />
+                      </button>
+                      <Button buttonType={'ghost'} className="title-card-standard-icon-btn z-40" buttonSize={'sm'} onClick={() => setShowBlocklistModal(true)}>
+                        <EyeSlashIcon className={'h-3'} />
+                      </Button>
+                    </>
                   )}
               </div>
             )}
@@ -432,7 +460,7 @@ const TitleCard = ({
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="absolute inset-0 z-40 flex items-center justify-center rounded-xl bg-gray-800/75 text-white">
+            <div className="title-card-loading-overlay absolute inset-0 z-40 flex items-center justify-center rounded-xl bg-gray-800/75 text-white">
               <Spinner className="h-10 w-10" />
             </div>
           </Transition>
@@ -447,7 +475,7 @@ const TitleCard = ({
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="absolute inset-0 overflow-hidden rounded-xl">
+            <div className="title-card-detail-overlay absolute inset-0 overflow-hidden rounded-xl">
               <Link
                 href={
                   mediaType === 'movie'
@@ -456,55 +484,88 @@ const TitleCard = ({
                       ? `/collection/${id}`
                       : `/tv/${id}`
                 }
-                className="absolute inset-0 h-full w-full cursor-pointer overflow-hidden text-left"
+                className="title-card-detail-link absolute inset-0 h-full w-full cursor-pointer overflow-hidden text-left"
                 style={{
-                  background:
-                    'linear-gradient(180deg, rgba(45, 55, 72, 0.4) 0%, rgba(45, 55, 72, 0.9) 100%)',
+                  background: 'linear-gradient(180deg, rgba(45, 55, 72, 0.4) 0%, rgba(45, 55, 72, 0.9) 100%)',
                 }}
               >
                 <div className="flex h-full w-full items-end">
                   <div
-                    className={`px-2 text-white ${
+                    className={`px-2.5 text-white ${
                       !showRequestButton ||
                       (currentStatus &&
                         currentStatus !== MediaStatus.UNKNOWN &&
                         currentStatus !== MediaStatus.DELETED)
-                        ? 'pb-2'
-                        : 'pb-11'
+                        ? 'pb-2.5'
+                        : 'title-card-content-pb pb-11'
                     }`}
                   >
-                    {year && <div className="text-sm font-medium">{year}</div>}
-
-                    <h1
-                      className="whitespace-normal text-xl font-bold leading-tight"
-                      style={{
-                        WebkitLineClamp: 3,
-                        display: '-webkit-box',
-                        overflow: 'hidden',
-                        WebkitBoxOrient: 'vertical',
-                        wordBreak: 'break-word',
-                      }}
-                      data-testid="title-card-title"
-                    >
-                      {title}
-                    </h1>
-                    <div
-                      className="whitespace-normal text-xs"
-                      style={{
-                        WebkitLineClamp:
-                          !showRequestButton ||
-                          (currentStatus &&
-                            currentStatus !== MediaStatus.UNKNOWN &&
-                            currentStatus !== MediaStatus.DELETED)
-                            ? 5
-                            : 3,
-                        display: '-webkit-box',
-                        overflow: 'hidden',
-                        WebkitBoxOrient: 'vertical',
-                        wordBreak: 'break-word',
-                      }}
-                    >
-                      {summary}
+                    {/* AMOLED compact title layout */}
+                    <div className="title-card-amoled-title-block">
+                      <h1
+                        className="mb-1 whitespace-normal text-sm font-bold leading-tight text-white"
+                        style={{
+                          WebkitLineClamp: 2,
+                          display: '-webkit-box',
+                          overflow: 'hidden',
+                          WebkitBoxOrient: 'vertical',
+                          wordBreak: 'break-word',
+                        }}
+                        data-testid="title-card-title-amoled"
+                      >
+                        {title}
+                      </h1>
+                      <div className="flex items-center gap-1.5">
+                        {year && (
+                          <span className="text-[11px] font-medium text-white/50">{year}</span>
+                        )}
+                        {year && userScore != null && userScore > 0 && (
+                          <span className="text-white/25">·</span>
+                        )}
+                        {userScore != null && userScore > 0 && (
+                          <span className="flex items-center gap-0.5">
+                            <StarIcon className="h-2.5 w-2.5 text-yellow-400/80" />
+                            <span className="text-[11px] font-semibold text-yellow-400/80">
+                              {userScore.toFixed(1)}
+                            </span>
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    {/* Standard title layout */}
+                    <div className="title-card-standard-title-block">
+                      {year && <div className="text-sm font-medium">{year}</div>}
+                      <h1
+                        className="whitespace-normal text-xl font-bold leading-tight"
+                        style={{
+                          WebkitLineClamp: 3,
+                          display: '-webkit-box',
+                          overflow: 'hidden',
+                          WebkitBoxOrient: 'vertical',
+                          wordBreak: 'break-word',
+                        }}
+                        data-testid="title-card-title"
+                      >
+                        {title}
+                      </h1>
+                      <div
+                        className="whitespace-normal text-xs"
+                        style={{
+                          WebkitLineClamp:
+                            !showRequestButton ||
+                            (currentStatus &&
+                              currentStatus !== MediaStatus.UNKNOWN &&
+                              currentStatus !== MediaStatus.DELETED)
+                              ? 5
+                              : 3,
+                          display: '-webkit-box',
+                          overflow: 'hidden',
+                          WebkitBoxOrient: 'vertical',
+                          wordBreak: 'break-word',
+                        }}
+                      >
+                        {summary}
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -515,6 +576,17 @@ const TitleCard = ({
                   (!currentStatus ||
                     currentStatus === MediaStatus.UNKNOWN ||
                     currentStatus === MediaStatus.DELETED) && (
+                  <>
+                    <button
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setShowRequestModal(true);
+                      }}
+                      className="title-card-amoled-request-btn flex w-full items-center justify-center gap-1.5 rounded-xl bg-indigo-600/70 py-1.5 text-xs font-semibold text-white backdrop-blur-sm ring-1 ring-indigo-500/40 transition hover:bg-indigo-500/80"
+                    >
+                      <ArrowDownTrayIcon className="h-3.5 w-3.5" />
+                      {intl.formatMessage(globalMessages.request)}
+                    </button>
                     <Button
                       buttonType="primary"
                       buttonSize="sm"
@@ -522,12 +594,13 @@ const TitleCard = ({
                         e.preventDefault();
                         setShowRequestModal(true);
                       }}
-                      className="h-7 w-full"
+                      className="title-card-standard-request-btn h-7 w-full"
                     >
                       <ArrowDownTrayIcon />
                       <span>{intl.formatMessage(globalMessages.request)}</span>
                     </Button>
-                  )}
+                  </>
+                )}
               </div>
             </div>
           </Transition>

--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -382,7 +382,7 @@ const TitleCard = ({
                       >
                         <StarIcon className="h-3.5 w-3.5 text-amber-300" />
                       </button>
-                      <Button buttonType={'ghost'} className="title-card-standard-icon-btn z-40" buttonSize={'sm'} onClick={onClickWatchlistBtn}>
+                      <Button buttonType={'ghost'} className="title-card-standard-icon-btn z-40" buttonSize={'sm'} onClick={onClickWatchlistBtn} aria-label={intl.formatMessage(messages.addToWatchList)}>
                         <StarIcon className={'h-3 text-amber-300'} />
                       </Button>
                     </>
@@ -395,7 +395,7 @@ const TitleCard = ({
                       >
                         <MinusCircleIcon className="h-3.5 w-3.5 text-white/70" />
                       </button>
-                      <Button className="title-card-standard-icon-btn z-40" buttonSize={'sm'} onClick={onClickDeleteWatchlistBtn}>
+                      <Button className="title-card-standard-icon-btn z-40" buttonSize={'sm'} onClick={onClickDeleteWatchlistBtn} aria-label={intl.formatMessage(messages.removeFromWatchList)}>
                         <MinusCircleIcon className={'h-3'} />
                       </Button>
                     </>
@@ -413,7 +413,7 @@ const TitleCard = ({
                       >
                         <EyeSlashIcon className="h-3.5 w-3.5 text-white/70" />
                       </button>
-                      <Button buttonType={'ghost'} className="title-card-standard-icon-btn z-40" buttonSize={'sm'} onClick={() => setShowBlocklistModal(true)}>
+                      <Button buttonType={'ghost'} className="title-card-standard-icon-btn z-40" buttonSize={'sm'} onClick={() => setShowBlocklistModal(true)} aria-label={intl.formatMessage(globalMessages.blocklist)}>
                         <EyeSlashIcon className={'h-3'} />
                       </Button>
                     </>

--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -342,7 +342,7 @@ const TitleCard = ({
             fill
           />
           {/* AMOLED circle badge — bottom left */}
-          <div className="title-card-amoled-badge pointer-events-none absolute bottom-2.5 left-2.5 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-black/60 backdrop-blur-md ring-1 ring-white/[0.12]">
+          <div aria-hidden="true" className="title-card-amoled-badge pointer-events-none absolute bottom-2.5 left-2.5 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-black/60 backdrop-blur-md ring-1 ring-white/[0.12]">
             <span
               className={`text-[10px] font-semibold ${
                 mediaType === 'movie' || mediaType === 'collection'

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -27,7 +27,7 @@ const Toast = ({
         leaveFrom="opacity-100 scale-100"
         leaveTo="opacity-0 scale-90"
       >
-        <div className="pointer-events-auto w-full max-w-sm rounded-lg bg-gray-800 shadow-lg ring-1 ring-gray-500">
+        <div className={`pointer-events-auto w-full max-w-sm rounded-lg shadow-lg ring-1 bg-surface ring-gray-500`}>
           <div className="overflow-hidden rounded-lg ring-1 ring-black ring-opacity-5">
             <div className="p-4">
               <div className="flex items-start">

--- a/src/components/TvDetails/Season/index.tsx
+++ b/src/components/TvDetails/Season/index.tsx
@@ -44,19 +44,23 @@ const Season = ({ seasonNumber, tvId }: SeasonProps) => {
                 className="flex flex-col space-y-4 py-4 xl:flex-row xl:space-x-4 xl:space-y-4"
                 key={`season-${seasonNumber}-episode-${episode.episodeNumber}`}
               >
-                <div className="flex-1">
+                <div className="xl:min-w-0 xl:max-w-3xl">
                   <div className="flex flex-col space-y-2 xl:flex-row xl:items-center xl:space-x-2 xl:space-y-0">
-                    <h3 className="text-lg">
+                    <h3 className="text-lg text-white">
                       {episode.episodeNumber} - {episode.name}
                     </h3>
                     {episode.airDate && (
                       <AirDateBadge airDate={episode.airDate} />
                     )}
                   </div>
-                  {episode.overview && <p>{episode.overview}</p>}
+                  {episode.overview && (
+                    <p className="text-sm leading-relaxed text-white/70">
+                      {episode.overview}
+                    </p>
+                  )}
                 </div>
                 {episode.stillPath && (
-                  <div className="relative aspect-video xl:h-32">
+                  <div className="relative aspect-video xl:h-32 xl:flex-shrink-0">
                     <CachedImage
                       type="tmdb"
                       className="rounded-lg object-contain"

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -1367,7 +1367,6 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
       <div className="extra-bottom-space relative" />
     </div>
     ) : (
-    {/* ── AMOLED full-bleed layout ── */}
     <div className="relative bg-black">
       <PageTitle title={data.name} />
       <BlocklistModal

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -174,6 +174,9 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     iOSPlexUrl4k: data?.mediaInfo?.iOSPlexUrl4k,
   });
 
+  const { theme } = useTheme();
+  const isAmoledTheme = theme === 'amoled-strix';
+
   if (!data && !error) {
     return <LoadingSpinner />;
   }
@@ -465,9 +468,6 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
   const showHideButton = hasPermission([Permission.MANAGE_BLOCKLIST], {
     type: 'or',
   });
-
-  const { theme } = useTheme();
-  const isAmoledTheme = theme === 'amoled-strix';
 
   return (
     <>
@@ -1533,6 +1533,8 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                 data?.mediaInfo?.status !== MediaStatus.BLOCKLISTED && (
                   <Tooltip content={intl.formatMessage(globalMessages.addToBlocklist)}>
                     <button
+                      type="button"
+                      aria-label={intl.formatMessage(globalMessages.addToBlocklist)}
                       onClick={() => setShowBlocklistModal(true)}
                       className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
                     >
@@ -1546,6 +1548,8 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                     {toggleWatchlist ? (
                       <Tooltip content={intl.formatMessage(messages.addtowatchlist)}>
                         <button
+                          type="button"
+                          aria-label={intl.formatMessage(messages.addtowatchlist)}
                           onClick={onClickWatchlistBtn}
                           className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
                         >
@@ -1555,6 +1559,8 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                     ) : (
                       <Tooltip content={intl.formatMessage(messages.removefromwatchlist)}>
                         <button
+                          type="button"
+                          aria-label={intl.formatMessage(messages.removefromwatchlist)}
                           onClick={onClickDeleteWatchlistBtn}
                           className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
                         >
@@ -1589,6 +1595,8 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                 ) && (
                   <Tooltip content={intl.formatMessage(messages.reportissue)}>
                     <button
+                      type="button"
+                      aria-label={intl.formatMessage(messages.reportissue)}
                       onClick={() => setShowIssueModal(true)}
                       className="z-40 relative flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
                     >
@@ -1605,6 +1613,8 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
               {hasPermission(Permission.MANAGE_REQUESTS) && data.mediaInfo && (
                 <Tooltip content={intl.formatMessage(messages.manageseries)}>
                   <button
+                    type="button"
+                    aria-label={intl.formatMessage(messages.manageseries)}
                     onClick={() => setShowManager(true)}
                     className="z-40 relative flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
                   >

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -82,6 +82,10 @@ const messages = defineMessages('components.TvDetails', {
   anime: 'Anime',
   network: '{networkCount, plural, one {Network} other {Networks}}',
   viewfullcrew: 'View Full Crew',
+  crew: 'Crew',
+  keywords: 'Keywords',
+  ratings: 'Ratings',
+  details: 'Details',
   play: 'Play on {mediaServerName}',
   play4k: 'Play 4K on {mediaServerName}',
   seasons: '{seasonCount, plural, one {# Season} other {# Seasons}}',
@@ -462,8 +466,9 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
   });
 
   return (
+    <>
     <div
-      className="media-page"
+      className="tv-details-backdrop-section media-page"
       style={{
         height: 493,
       }}
@@ -478,13 +483,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
             fill
             priority
           />
-          <div
-            className="absolute inset-0"
-            style={{
-              backgroundImage:
-                'linear-gradient(180deg, rgba(17, 24, 39, 0.47) 0%, rgba(17, 24, 39, 1) 100%)',
-            }}
-          />
+          <div className="absolute inset-0 bg-gradient-to-b from-gray-900/50 to-gray-900" />
         </div>
       )}
       <PageTitle title={data.name} />
@@ -1362,6 +1361,891 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
       />
       <div className="extra-bottom-space relative" />
     </div>
+    ) : (
+    /* ── AMOLED full-bleed layout ── */
+    <div className="relative bg-black">
+      <PageTitle title={data.name} />
+      <BlocklistModal
+        tmdbId={data.id}
+        type="tv"
+        show={showBlocklistModal}
+        onCancel={closeBlocklistModal}
+        onComplete={onClickHideItemBtn}
+        isUpdating={isBlocklistUpdating}
+      />
+      <IssueModal
+        onCancel={() => setShowIssueModal(false)}
+        show={showIssueModal}
+        mediaType="tv"
+        tmdbId={data.id}
+      />
+      <RequestModal
+        tmdbId={data.id}
+        show={showRequestModal}
+        type="tv"
+        onComplete={() => {
+          revalidate();
+          setShowRequestModal(false);
+        }}
+        onCancel={() => setShowRequestModal(false)}
+      />
+      <ManageSlideOver
+        data={data}
+        mediaType="tv"
+        onClose={() => {
+          setShowManager(false);
+          router.push({
+            pathname: router.pathname,
+            query: { tvId: router.query.tvId },
+          });
+        }}
+        revalidate={() => revalidate()}
+        show={showManager}
+      />
+
+      {/* Hero — cinematic full-bleed */}
+      <div className="relative -mx-4 -mt-16 min-h-[100svh] sm:h-[82vh] sm:min-h-[520px] overflow-visible sm:overflow-hidden">
+        <CachedImage
+          type="tmdb"
+          alt=""
+          src={
+            data.backdropPath
+              ? `https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${data.backdropPath}`
+              : data.posterPath
+                ? `https://image.tmdb.org/t/p/w600_and_h900_bestv2${data.posterPath}`
+                : '/images/seerr_poster_not_found.png'
+          }
+          fill
+          style={{
+            objectFit: 'cover',
+            objectPosition: data.backdropPath ? 'center top' : 'center center',
+          }}
+          priority
+        />
+        <div className="absolute inset-0 bg-black/25" />
+        {/* Mobile: blur + black overlay from middle to bottom */}
+        <div
+          className="absolute inset-0 sm:hidden"
+          style={{
+            backdropFilter: 'blur(20px)',
+            WebkitBackdropFilter: 'blur(20px)',
+            background: 'rgba(0,0,0,0.55)',
+            maskImage: 'linear-gradient(to bottom, transparent 0%, black 50%)',
+            WebkitMaskImage: 'linear-gradient(to bottom, transparent 0%, black 50%)',
+          }}
+        />
+        {/* Desktop top vignette */}
+        <div className="absolute inset-x-0 top-0 h-48 bg-gradient-to-b from-black/70 to-transparent hidden sm:block" />
+        <div
+          className="absolute inset-x-0 bottom-0"
+          style={{
+            height: '65%',
+            background:
+              'linear-gradient(to top, #000 0%, rgba(0,0,0,0.85) 30%, rgba(0,0,0,0.4) 70%, transparent 100%)',
+          }}
+        />
+
+        {/* Poster + title + actions */}
+        <div className="absolute inset-0 flex flex-col justify-center gap-3 px-4 pt-28 sm:inset-auto sm:bottom-0 sm:left-0 sm:right-0 sm:flex-row sm:items-end sm:gap-5 sm:pb-8 sm:pt-0 sm:px-6 lg:px-8">
+          <div className="w-2/5 flex-shrink-0 overflow-hidden rounded-xl ring-1 ring-white/15 shadow-2xl mt-[50px] sm:mt-0 sm:w-32 lg:w-36">
+            <CachedImage
+              type="tmdb"
+              src={
+                data.posterPath
+                  ? `https://image.tmdb.org/t/p/w600_and_h900_bestv2${data.posterPath}`
+                  : '/images/seerr_poster_not_found.png'
+              }
+              alt=""
+              width={600}
+              height={900}
+              style={{ width: '100%', height: 'auto' }}
+              priority
+            />
+          </div>
+          <div className="flex-1 min-w-0 pb-1">
+            <div className="flex flex-wrap gap-2 mb-3">
+              <StatusBadge
+                status={data.mediaInfo?.status}
+                downloadItem={data.mediaInfo?.downloadStatus}
+                title={data.name}
+                inProgress={(data.mediaInfo?.downloadStatus ?? []).length > 0}
+                tmdbId={data.mediaInfo?.tmdbId}
+                mediaType="tv"
+                plexUrl={plexUrl}
+                serviceUrl={data.mediaInfo?.serviceUrl}
+              />
+              {settings.currentSettings.series4kEnabled &&
+                hasPermission(
+                  [
+                    Permission.MANAGE_REQUESTS,
+                    Permission.REQUEST_4K,
+                    Permission.REQUEST_4K_TV,
+                  ],
+                  { type: 'or' }
+                ) && (
+                  <StatusBadge
+                    status={data.mediaInfo?.status4k}
+                    downloadItem={data.mediaInfo?.downloadStatus4k}
+                    title={data.name}
+                    is4k
+                    inProgress={
+                      (data.mediaInfo?.downloadStatus4k ?? []).length > 0
+                    }
+                    tmdbId={data.mediaInfo?.tmdbId}
+                    mediaType="tv"
+                    plexUrl={plexUrl4k}
+                    serviceUrl={data.mediaInfo?.serviceUrl4k}
+                  />
+                )}
+            </div>
+            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white tracking-tight leading-tight mb-2" data-testid="media-title">
+              {data.name}
+              {data.firstAirDate && (
+                <span className="ml-3 text-2xl sm:text-3xl font-normal text-white/40">
+                  ({data.firstAirDate.slice(0, 4)})
+                </span>
+              )}
+            </h1>
+            {seriesAttributes.length > 0 && (
+              <div className="flex items-center flex-wrap text-sm text-white/60 mb-5">
+                {seriesAttributes
+                  .map((t, k) => <span key={k}>{t}</span>)
+                  .reduce((prev, curr) => (
+                    <>
+                      {prev}
+                      <span className="mx-2 text-white/20">|</span>
+                      {curr}
+                    </>
+                  ))}
+              </div>
+            )}
+            <div className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
+              {showHideButton &&
+                data?.mediaInfo?.status !== MediaStatus.PROCESSING &&
+                data?.mediaInfo?.status !== MediaStatus.AVAILABLE &&
+                data?.mediaInfo?.status !== MediaStatus.PARTIALLY_AVAILABLE &&
+                data?.mediaInfo?.status !== MediaStatus.PENDING &&
+                data?.mediaInfo?.status !== MediaStatus.BLOCKLISTED && (
+                  <Tooltip content={intl.formatMessage(globalMessages.addToBlocklist)}>
+                    <button
+                      onClick={() => setShowBlocklistModal(true)}
+                      className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
+                    >
+                      <EyeSlashIcon className="h-5 w-5" />
+                    </button>
+                  </Tooltip>
+                )}
+              {data?.mediaInfo?.status !== MediaStatus.BLOCKLISTED &&
+                user?.userType !== UserType.PLEX && (
+                  <>
+                    {toggleWatchlist ? (
+                      <Tooltip content={intl.formatMessage(messages.addtowatchlist)}>
+                        <button
+                          onClick={onClickWatchlistBtn}
+                          className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
+                        >
+                          {isUpdating ? <Spinner className="h-5 w-5" /> : <StarIcon className="h-5 w-5 text-amber-300" />}
+                        </button>
+                      </Tooltip>
+                    ) : (
+                      <Tooltip content={intl.formatMessage(messages.removefromwatchlist)}>
+                        <button
+                          onClick={onClickDeleteWatchlistBtn}
+                          className="z-40 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
+                        >
+                          {isUpdating ? <Spinner className="h-5 w-5" /> : <MinusCircleIcon className="h-5 w-5" />}
+                        </button>
+                      </Tooltip>
+                    )}
+                  </>
+                )}
+              <div className="z-20">
+                <PlayButton links={mediaLinks} />
+              </div>
+              <RequestButton
+                mediaType="tv"
+                onUpdate={() => revalidate()}
+                tmdbId={data?.id}
+                media={data?.mediaInfo}
+                isShowComplete={isComplete}
+                is4kShowComplete={is4kComplete}
+              />
+              {(data.mediaInfo?.status === MediaStatus.AVAILABLE ||
+                data.mediaInfo?.status === MediaStatus.PARTIALLY_AVAILABLE ||
+                (settings.currentSettings.series4kEnabled &&
+                  hasPermission([Permission.REQUEST_4K, Permission.REQUEST_4K_TV], {
+                    type: 'or',
+                  }) &&
+                  (data.mediaInfo?.status4k === MediaStatus.AVAILABLE ||
+                    data?.mediaInfo?.status4k === MediaStatus.PARTIALLY_AVAILABLE))) &&
+                hasPermission(
+                  [Permission.CREATE_ISSUES, Permission.MANAGE_ISSUES],
+                  { type: 'or' }
+                ) && (
+                  <Tooltip content={intl.formatMessage(messages.reportissue)}>
+                    <button
+                      onClick={() => setShowIssueModal(true)}
+                      className="z-40 relative flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
+                    >
+                      <ExclamationTriangleIcon className="h-5 w-5" />
+                      {(data.mediaInfo?.issues.filter((issue) => issue.status === IssueStatus.OPEN) ?? []).length > 0 && (
+                        <>
+                          <div className="absolute -right-1 -top-1 h-3 w-3 rounded-full bg-red-600" />
+                          <div className="absolute -right-1 -top-1 h-3 w-3 animate-ping rounded-full bg-red-600" />
+                        </>
+                      )}
+                    </button>
+                  </Tooltip>
+                )}
+              {hasPermission(Permission.MANAGE_REQUESTS) && data.mediaInfo && (
+                <Tooltip content={intl.formatMessage(messages.manageseries)}>
+                  <button
+                    onClick={() => setShowManager(true)}
+                    className="z-40 relative flex h-10 w-10 items-center justify-center rounded-full bg-black/50 backdrop-blur-md ring-1 ring-white/[0.12] text-white/70 hover:text-white transition"
+                  >
+                    <CogIcon className="h-5 w-5" />
+                    {hasPermission(
+                      [Permission.MANAGE_ISSUES, Permission.VIEW_ISSUES],
+                      { type: 'or' }
+                    ) &&
+                      (
+                        data.mediaInfo?.issues.filter(
+                          (issue) => issue.status === IssueStatus.OPEN
+                        ) ?? []
+                      ).length > 0 && (
+                        <>
+                          <div className="absolute -right-1 -top-1 h-3 w-3 rounded-full bg-red-600" />
+                          <div className="absolute -right-1 -top-1 h-3 w-3 animate-ping rounded-full bg-red-600" />
+                        </>
+                      )}
+                  </button>
+                </Tooltip>
+              )}
+            </div>
+            {/* Overview — mobile only, shown in hero */}
+            <div className="sm:hidden mt-4">
+              <div className="flex items-center gap-2 mb-1.5">
+                <p className="text-xs font-semibold uppercase tracking-wider text-white/40">
+                  {intl.formatMessage(messages.overview)}
+                </p>
+                {data.tagline && (
+                  <>
+                    <span className="text-white/20">|</span>
+                    <p className="text-violet-400/80 text-xs font-medium italic truncate">{data.tagline}</p>
+                  </>
+                )}
+              </div>
+              <p className="text-xs leading-relaxed text-white/60">
+                {data.overview || intl.formatMessage(messages.overviewunavailable)}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="absolute absolute-bottom-shift inset-x-0 flex justify-center animate-bounce opacity-30 pointer-events-none">
+          <ChevronDownIcon className="h-5 w-5 text-white" />
+        </div>
+      </div>
+
+      {/* Content sections */}
+      <div className="divide-y divide-white/[0.06] pt-6 pb-8">
+        {/* Overview + crew + keywords */}
+        <div className="py-6">
+          <div className="hidden sm:flex items-center gap-2 mb-3">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-white/40">
+              {intl.formatMessage(messages.overview)}
+            </h2>
+            {data.tagline && (
+              <>
+                <span className="text-white/20">|</span>
+                <p className="text-violet-400/80 text-sm font-medium italic">
+                  {data.tagline}
+                </p>
+              </>
+            )}
+          </div>
+          <p className="hidden sm:block text-white/70 text-sm leading-relaxed">
+            {data.overview || intl.formatMessage(messages.overviewunavailable)}
+          </p>
+          {sortedCrew.length > 0 && (
+            <div className="relative -mt-[50px] pt-6 sm:mt-3">
+              <div className="absolute inset-x-0 top-0 border-t border-white/[0.12]" />
+              <div className="relative">
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="text-xs font-semibold uppercase tracking-wider text-white/30">{intl.formatMessage(messages.crew)}</h3>
+                  <Link
+                    href={`/tv/${data.id}/crew`}
+                    className="flex items-center gap-1 text-xs text-violet-400/70 hover:text-violet-300 transition-colors"
+                  >
+                    {intl.formatMessage(messages.viewfullcrew)}
+                    <ArrowRightCircleIcon className="h-3.5 w-3.5" />
+                  </Link>
+                </div>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-3">
+                  {(data.createdBy.length > 0
+                    ? [
+                        ...data.createdBy.map(
+                          (person): Partial<Crew> => ({
+                            id: person.id,
+                            job: 'Creator',
+                            name: person.name,
+                          })
+                        ),
+                        ...sortedCrew,
+                      ]
+                    : sortedCrew
+                  )
+                    .slice(0, 6)
+                    .map((person) => (
+                      <div key={`crew-${person.job}-${person.id}`}>
+                        <div className="text-[11px] text-white/35 mb-0.5 uppercase tracking-wide">{person.job}</div>
+                        <Link href={`/person/${person.id}`} className="text-sm text-white/80 hover:text-violet-300 transition-colors">
+                          {person.name}
+                        </Link>
+                      </div>
+                    ))}
+                </div>
+              </div>
+            </div>
+          )}
+          {data.keywords.length > 0 && (
+            <div className="mt-5">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-white/30 mb-2.5">{intl.formatMessage(messages.keywords)}</h3>
+              <div className="flex flex-wrap gap-1.5">
+                {data.keywords.slice(0, 8).map((keyword) => (
+                  <Link
+                    href={`/discover/tv?keywords=${keyword.id}`}
+                    key={`keyword-id-${keyword.id}`}
+                    className="rounded-full px-2.5 py-0.5 text-xs text-white/50 ring-1 ring-white/10 hover:text-white/80 hover:ring-white/25 transition-colors"
+                  >
+                    {keyword.name}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Ratings + Facts */}
+        <div className="py-6 grid grid-cols-1 lg:grid-cols-2 gap-x-12 gap-y-8">
+          {(!!data.voteCount ||
+            (ratingData?.criticsRating && !!ratingData?.criticsScore) ||
+            (ratingData?.audienceRating && !!ratingData?.audienceScore)) && (
+            <div>
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-white/40 mb-4">{intl.formatMessage(messages.ratings)}</h2>
+              <div className="flex flex-wrap gap-5">
+                {ratingData?.criticsRating && !!ratingData?.criticsScore && (
+                  <Tooltip content={intl.formatMessage(messages.rtcriticsscore)}>
+                    <a
+                      href={ratingData.url}
+                      className="flex items-center gap-2 text-sm text-white/70 hover:text-white transition-colors"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {ratingData.criticsRating === 'Rotten' ? <RTRotten className="w-6" /> : <RTFresh className="w-6" />}
+                      <span>{ratingData.criticsScore}%</span>
+                    </a>
+                  </Tooltip>
+                )}
+                {ratingData?.audienceRating && !!ratingData?.audienceScore && (
+                  <Tooltip content={intl.formatMessage(messages.rtaudiencescore)}>
+                    <a
+                      href={ratingData.url}
+                      className="flex items-center gap-2 text-sm text-white/70 hover:text-white transition-colors"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {ratingData.audienceRating === 'Spilled' ? <RTAudRotten className="w-6" /> : <RTAudFresh className="w-6" />}
+                      <span>{ratingData.audienceScore}%</span>
+                    </a>
+                  </Tooltip>
+                )}
+                {!!data.voteCount && (
+                  <Tooltip content={intl.formatMessage(messages.tmdbuserscore)}>
+                    <a
+                      href={`https://www.themoviedb.org/tv/${data.id}?language=${locale}`}
+                      className="flex items-center gap-2 text-sm text-white/70 hover:text-white transition-colors"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <TmdbLogo className="mr-1 w-6" />
+                      <span>{Math.round(data.voteAverage * 10)}%</span>
+                    </a>
+                  </Tooltip>
+                )}
+              </div>
+            </div>
+          )}
+          <div>
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-white/40 mb-4">{intl.formatMessage(messages.details)}</h2>
+            <dl className="space-y-2.5">
+              {data.originalName && data.originalLanguage !== locale.slice(0, 2) && (
+                <div className="flex justify-between text-sm">
+                  <dt className="text-white/40">{intl.formatMessage(messages.originaltitle)}</dt>
+                  <dd className="text-white/80 text-right ml-4">{data.originalName}</dd>
+                </div>
+              )}
+              {data.keywords.some((keyword) => keyword.id === ANIME_KEYWORD_ID) && (
+                <div className="flex justify-between text-sm">
+                  <dt className="text-white/40">{intl.formatMessage(messages.showtype)}</dt>
+                  <dd className="text-white/80">{intl.formatMessage(messages.anime)}</dd>
+                </div>
+              )}
+              <div className="flex justify-between text-sm">
+                <dt className="text-white/40">{intl.formatMessage(globalMessages.status)}</dt>
+                <dd className="text-white/80">{data.status}</dd>
+              </div>
+              {data.firstAirDate && (
+                <div className="flex justify-between text-sm">
+                  <dt className="text-white/40">{intl.formatMessage(messages.firstAirDate)}</dt>
+                  <dd className="text-white/80">
+                    {intl.formatDate(data.firstAirDate, {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric',
+                      timeZone: 'UTC',
+                    })}
+                  </dd>
+                </div>
+              )}
+              {data.nextEpisodeToAir &&
+                data.nextEpisodeToAir.airDate &&
+                data.nextEpisodeToAir.airDate !== data.firstAirDate && (
+                  <div className="flex justify-between text-sm">
+                    <dt className="text-white/40">{intl.formatMessage(messages.nextAirDate)}</dt>
+                    <dd className="text-white/80">
+                      {intl.formatDate(data.nextEpisodeToAir.airDate, {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                        timeZone: 'UTC',
+                      })}
+                    </dd>
+                  </div>
+                )}
+              {data.episodeRunTime.length > 0 && (
+                <div className="flex justify-between text-sm">
+                  <dt className="text-white/40">{intl.formatMessage(messages.episodeRuntime)}</dt>
+                  <dd className="text-white/80">
+                    {intl.formatMessage(messages.episodeRuntimeMinutes, {
+                      runtime: data.episodeRunTime[0],
+                    })}
+                  </dd>
+                </div>
+              )}
+              {data.originalLanguage && (
+                <div className="flex justify-between text-sm">
+                  <dt className="text-white/40">{intl.formatMessage(messages.originallanguage)}</dt>
+                  <dd className="text-white/80">
+                    <Link href={`/discover/tv/language/${data.originalLanguage}`} className="hover:text-violet-300 transition-colors">
+                      {intl.formatDisplayName(data.originalLanguage, {
+                        type: 'language',
+                        fallback: 'none',
+                      }) ??
+                        data.spokenLanguages.find(
+                          (lng) => lng.iso_639_1 === data.originalLanguage
+                        )?.name}
+                    </Link>
+                  </dd>
+                </div>
+              )}
+              {data.productionCountries.length > 0 && (
+                <div className="flex justify-between text-sm">
+                  <dt className="text-white/40">
+                    {intl.formatMessage(messages.productioncountries, {
+                      countryCount: data.productionCountries.length,
+                    })}
+                  </dt>
+                  <dd className="text-white/80 text-right">
+                    {data.productionCountries.map((c) => (
+                      <span className="flex items-center justify-end" key={`prodcountry-${c.iso_3166_1}`}>
+                        {countries.includes(c.iso_3166_1) && (
+                          <span className={`mr-1.5 text-xs leading-5 flag:${c.iso_3166_1}`} />
+                        )}
+                        <span>
+                          {intl.formatDisplayName(c.iso_3166_1, {
+                            type: 'region',
+                            fallback: 'none',
+                          }) ?? c.name}
+                        </span>
+                      </span>
+                    ))}
+                  </dd>
+                </div>
+              )}
+              {data.networks.length > 0 && (
+                <div className="flex justify-between text-sm">
+                  <dt className="text-white/40">
+                    {intl.formatMessage(messages.network, {
+                      networkCount: data.networks.length,
+                    })}
+                  </dt>
+                  <dd className="text-white/80 text-right">
+                    {data.networks
+                      .map((n) => (
+                        <Link
+                          href={`/discover/tv/network/${n.id}`}
+                          key={`network-${n.id}`}
+                          className="block hover:text-violet-300 transition-colors"
+                        >
+                          {n.name}
+                        </Link>
+                      ))}
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        </div>
+
+        {/* Seasons */}
+        <div className="py-6">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-white/40 mb-4">
+            {intl.formatMessage(messages.seasonstitle)}
+          </h2>
+          <div className="flex w-full flex-col space-y-2">
+            {data.seasons
+              .slice()
+              .reverse()
+              .filter(
+                (season) =>
+                  settings.currentSettings.enableSpecialEpisodes ||
+                  season.seasonNumber !== 0
+              )
+              .map((season) => {
+                const show4k =
+                  settings.currentSettings.series4kEnabled &&
+                  hasPermission(
+                    [
+                      Permission.MANAGE_REQUESTS,
+                      Permission.REQUEST_4K,
+                      Permission.REQUEST_4K_TV,
+                    ],
+                    { type: 'or' }
+                  );
+                const mSeason = (data.mediaInfo?.seasons ?? []).find(
+                  (s) =>
+                    season.seasonNumber === s.seasonNumber &&
+                    s.status !== MediaStatus.UNKNOWN
+                );
+                const mSeason4k = (data.mediaInfo?.seasons ?? []).find(
+                  (s) =>
+                    season.seasonNumber === s.seasonNumber &&
+                    s.status4k !== MediaStatus.UNKNOWN
+                );
+                const request = (data.mediaInfo?.requests ?? [])
+                  .filter(
+                    (r) =>
+                      !!r.seasons.find(
+                        (s) => s.seasonNumber === season.seasonNumber
+                      ) && !r.is4k
+                  )
+                  .sort(
+                    (a, b) =>
+                      new Date(b.createdAt).getTime() -
+                      new Date(a.createdAt).getTime()
+                  )[0];
+                const request4k = (data.mediaInfo?.requests ?? [])
+                  .filter(
+                    (r) =>
+                      !!r.seasons.find(
+                        (s) => s.seasonNumber === season.seasonNumber
+                      ) && r.is4k
+                  )
+                  .sort(
+                    (a, b) =>
+                      new Date(b.createdAt).getTime() -
+                      new Date(a.createdAt).getTime()
+                  )[0];
+
+                if (season.episodeCount === 0) {
+                  return null;
+                }
+
+                return (
+                  <Disclosure key={`season-discoslure-${season.seasonNumber}`}>
+                    {({ open }) => (
+                      <>
+                        <Disclosure.Button
+                          className={`mt-2 flex w-full items-center justify-between space-x-2 border-gray-700 bg-gray-800 px-4 py-2 text-gray-200 ${
+                            open
+                              ? 'rounded-t-md border-l border-r border-t'
+                              : 'rounded-md border'
+                          }`}
+                        >
+                          <div className="flex flex-1 items-center space-x-2 text-lg">
+                            <span>
+                              {season.seasonNumber === 0
+                                ? intl.formatMessage(globalMessages.specials)
+                                : intl.formatMessage(messages.seasonnumber, {
+                                    seasonNumber: season.seasonNumber,
+                                  })}
+                            </span>
+                            <Badge badgeType="dark">
+                              {intl.formatMessage(messages.episodeCount, {
+                                episodeCount: season.episodeCount,
+                              })}
+                            </Badge>
+                          </div>
+                          {((!mSeason &&
+                            request?.status === MediaRequestStatus.APPROVED) ||
+                            mSeason?.status === MediaStatus.PROCESSING ||
+                            (request?.status === MediaRequestStatus.APPROVED &&
+                              mSeason?.status === MediaStatus.DELETED)) && (
+                            <>
+                              <div className="hidden md:flex">
+                                <Badge badgeType="primary">
+                                  {intl.formatMessage(globalMessages.requested)}
+                                </Badge>
+                              </div>
+                              <div className="flex md:hidden">
+                                <StatusBadgeMini status={MediaStatus.PROCESSING} />
+                              </div>
+                            </>
+                          )}
+                          {((!mSeason &&
+                            request?.status === MediaRequestStatus.PENDING) ||
+                            mSeason?.status === MediaStatus.PENDING) && (
+                            <>
+                              <div className="hidden md:flex">
+                                <Badge badgeType="warning">
+                                  {intl.formatMessage(globalMessages.pending)}
+                                </Badge>
+                              </div>
+                              <div className="flex md:hidden">
+                                <StatusBadgeMini status={MediaStatus.PENDING} />
+                              </div>
+                            </>
+                          )}
+                          {mSeason?.status === MediaStatus.PARTIALLY_AVAILABLE && (
+                            <>
+                              <div className="hidden md:flex">
+                                <Badge badgeType="success">
+                                  {intl.formatMessage(globalMessages.partiallyavailable)}
+                                </Badge>
+                              </div>
+                              <div className="flex md:hidden">
+                                <StatusBadgeMini status={MediaStatus.PARTIALLY_AVAILABLE} />
+                              </div>
+                            </>
+                          )}
+                          {mSeason?.status === MediaStatus.AVAILABLE && (
+                            <>
+                              <div className="hidden md:flex">
+                                <Badge badgeType="success">
+                                  {intl.formatMessage(globalMessages.available)}
+                                </Badge>
+                              </div>
+                              <div className="flex md:hidden">
+                                <StatusBadgeMini status={MediaStatus.AVAILABLE} />
+                              </div>
+                            </>
+                          )}
+                          {mSeason?.status === MediaStatus.DELETED &&
+                            request?.status !== MediaRequestStatus.APPROVED && (
+                              <>
+                                <div className="hidden md:flex">
+                                  <Badge badgeType="danger">
+                                    {intl.formatMessage(globalMessages.deleted)}
+                                  </Badge>
+                                </div>
+                                <div className="flex md:hidden">
+                                  <StatusBadgeMini status={MediaStatus.DELETED} />
+                                </div>
+                              </>
+                            )}
+                          {((!mSeason4k &&
+                            request4k?.status === MediaRequestStatus.APPROVED) ||
+                            mSeason4k?.status4k === MediaStatus.PROCESSING ||
+                            (request4k?.status === MediaRequestStatus.APPROVED &&
+                              mSeason4k?.status4k === MediaStatus.DELETED)) &&
+                            show4k && (
+                              <>
+                                <div className="hidden md:flex">
+                                  <Badge badgeType="primary">
+                                    {intl.formatMessage(messages.status4k, {
+                                      status: intl.formatMessage(globalMessages.requested),
+                                    })}
+                                  </Badge>
+                                </div>
+                                <div className="flex md:hidden">
+                                  <StatusBadgeMini status={MediaStatus.PROCESSING} is4k={true} />
+                                </div>
+                              </>
+                            )}
+                          {((!mSeason4k &&
+                            request4k?.status === MediaRequestStatus.PENDING) ||
+                            mSeason?.status4k === MediaStatus.PENDING) &&
+                            show4k && (
+                              <>
+                                <div className="hidden md:flex">
+                                  <Badge badgeType="warning">
+                                    {intl.formatMessage(messages.status4k, {
+                                      status: intl.formatMessage(globalMessages.pending),
+                                    })}
+                                  </Badge>
+                                </div>
+                                <div className="flex md:hidden">
+                                  <StatusBadgeMini status={MediaStatus.PENDING} is4k={true} />
+                                </div>
+                              </>
+                            )}
+                          {mSeason4k?.status4k === MediaStatus.PARTIALLY_AVAILABLE && show4k && (
+                            <>
+                              <div className="hidden md:flex">
+                                <Badge badgeType="success">
+                                  {intl.formatMessage(messages.status4k, {
+                                    status: intl.formatMessage(globalMessages.partiallyavailable),
+                                  })}
+                                </Badge>
+                              </div>
+                              <div className="flex md:hidden">
+                                <StatusBadgeMini status={MediaStatus.PARTIALLY_AVAILABLE} is4k={true} />
+                              </div>
+                            </>
+                          )}
+                          {mSeason4k?.status4k === MediaStatus.AVAILABLE && show4k && (
+                            <>
+                              <div className="hidden md:flex">
+                                <Badge badgeType="success">
+                                  {intl.formatMessage(messages.status4k, {
+                                    status: intl.formatMessage(globalMessages.available),
+                                  })}
+                                </Badge>
+                              </div>
+                              <div className="flex md:hidden">
+                                <StatusBadgeMini status={MediaStatus.AVAILABLE} is4k={true} />
+                              </div>
+                            </>
+                          )}
+                          {mSeason4k?.status4k === MediaStatus.DELETED &&
+                            request4k?.status !== MediaRequestStatus.APPROVED &&
+                            show4k && (
+                              <>
+                                <div className="hidden md:flex">
+                                  <Badge badgeType="danger">
+                                    {intl.formatMessage(messages.status4k, {
+                                      status: intl.formatMessage(globalMessages.deleted),
+                                    })}
+                                  </Badge>
+                                </div>
+                                <div className="flex md:hidden">
+                                  <StatusBadgeMini status={MediaStatus.DELETED} is4k={true} />
+                                </div>
+                              </>
+                            )}
+                          <ChevronDownIcon
+                            className={`${open ? 'rotate-180' : ''} h-6 w-6 text-gray-500`}
+                          />
+                        </Disclosure.Button>
+                        <Transition
+                          show={open}
+                          enter="transition-opacity duration-100 ease-out"
+                          enterFrom="opacity-0"
+                          enterTo="opacity-100"
+                          leave="transition-opacity duration-75 ease-out"
+                          leaveFrom="opacity-100"
+                          leaveTo="opacity-0"
+                          style={{ margin: '0px' }}
+                        >
+                          <Disclosure.Panel className="w-full rounded-b-md border-b border-l border-r border-gray-700 px-4 pb-2">
+                            <Season
+                              tvId={data.id}
+                              seasonNumber={season.seasonNumber}
+                            />
+                          </Disclosure.Panel>
+                        </Transition>
+                      </>
+                    )}
+                  </Disclosure>
+                );
+              })}
+          </div>
+        </div>
+
+        {/* Streaming providers */}
+        {!!streamingProviders.length && (
+          <div className="py-6">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-white/40 mb-4">
+              {intl.formatMessage(messages.streamingproviders)}
+            </h2>
+            <div className="flex flex-wrap gap-4">
+              {streamingProviders.map((p) => (
+                <Tooltip content={p.name} key={`provider-${p.id}`}>
+                  <span className="opacity-60 hover:opacity-100 transition-opacity">
+                    <CachedImage
+                      type="tmdb"
+                      src={'https://image.tmdb.org/t/p/w45/' + p.logoPath}
+                      alt={p.name}
+                      width={40}
+                      height={40}
+                      className="rounded-lg"
+                    />
+                  </span>
+                </Tooltip>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* External links */}
+        <div className="py-6">
+          <ExternalLinkBlock
+            mediaType="tv"
+            tmdbId={data.id}
+            tvdbId={data.externalIds.tvdbId}
+            imdbId={data.externalIds.imdbId}
+            rtUrl={ratingData?.url}
+            mediaUrl={plexUrl ?? plexUrl4k}
+          />
+        </div>
+      </div>
+
+      {/* Cast */}
+      {data.credits.cast.length > 0 && (
+        <>
+          <div className="slider-header">
+            <Link
+              href="/tv/[tvId]/cast"
+              as={`/tv/${data.id}/cast`}
+              className="slider-title"
+            >
+              <span>{intl.formatMessage(messages.cast)}</span>
+              <ArrowRightCircleIcon />
+            </Link>
+          </div>
+          <Slider
+            sliderKey="cast"
+            isLoading={false}
+            isEmpty={false}
+            items={data.credits.cast.slice(0, 20).map((person) => (
+              <PersonCard
+                key={`cast-item-${person.id}`}
+                personId={person.id}
+                name={person.name}
+                subName={person.character}
+                profilePath={person.profilePath}
+              />
+            ))}
+          />
+        </>
+      )}
+      <MediaSlider
+        sliderKey="recommendations"
+        title={intl.formatMessage(messages.recommendations)}
+        url={`/api/v1/tv/${router.query.tvId}/recommendations`}
+        linkUrl={`/tv/${data.id}/recommendations`}
+        hideWhenEmpty
+      />
+      <MediaSlider
+        sliderKey="similar"
+        title={intl.formatMessage(messages.similar)}
+        url={`/api/v1/tv/${router.query.tvId}/similar`}
+        linkUrl={`/tv/${data.id}/similar`}
+        hideWhenEmpty
+      />
+      <div className="extra-bottom-space relative" />
+    </div>
+    </>
   );
 };
 

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -66,6 +66,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
 import useSWR from 'swr';
+import useTheme from '@app/hooks/useTheme';
 
 const messages = defineMessages('components.TvDetails', {
   firstAirDate: 'First Air Date',
@@ -465,8 +466,12 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     type: 'or',
   });
 
+  const { theme } = useTheme();
+  const isAmoledTheme = theme === 'amoled-strix';
+
   return (
     <>
+    {!isAmoledTheme ? (
     <div
       className="tv-details-backdrop-section media-page"
       style={{
@@ -1362,7 +1367,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
       <div className="extra-bottom-space relative" />
     </div>
     ) : (
-    /* ── AMOLED full-bleed layout ── */
+    {/* ── AMOLED full-bleed layout ── */}
     <div className="relative bg-black">
       <PageTitle title={data.name} />
       <BlocklistModal
@@ -2245,6 +2250,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
       />
       <div className="extra-bottom-space relative" />
     </div>
+    )}
     </>
   );
 };

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -547,7 +547,7 @@ const UserList = () => {
             </Button>
           </div>
           <div className="mb-2 flex flex-grow lg:mb-0 lg:flex-grow-0">
-            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">
+            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-border-default bg-input px-3 text-sm text-gray-100">
               <BarsArrowDownIcon className="h-6 w-6" />
             </span>
             <select

--- a/src/components/UserProfile/UserSettings/UserAppearanceSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserAppearanceSettings/index.tsx
@@ -11,8 +11,13 @@ const messages = defineMessages(
     appearancesettings: 'Appearance Settings',
     themeLabel: 'Theme',
     themeTip: 'Choose how Seerr looks to you. This setting is stored locally in your browser.',
+    themeDefaultName: 'Default',
+    themeDefaultDescription: 'Classic dark theme',
+    themeAmoledStrixName: 'AMOLED Strix',
+    themeAmoledStrixDescription: 'Pure black with violet accents, optimized for OLED displays',
   }
 );
+
 
 const UserAppearanceSettings = () => {
   const intl = useIntl();
@@ -49,7 +54,7 @@ const UserAppearanceSettings = () => {
                 type="button"
                 aria-pressed={isActive}
                 onClick={() => setTheme(t.id)}
-                className={`relative flex flex-col overflow-hidden rounded-xl border-2 text-left transition duration-200 focus:outline-none ${
+                className={`relative flex flex-col overflow-hidden rounded-xl border-2 text-left transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 ${
                   isActive
                     ? 'border-indigo-500 shadow-lg shadow-indigo-500/20'
                     : 'border-gray-700 hover:border-gray-500'
@@ -109,8 +114,16 @@ const UserAppearanceSettings = () => {
                   style={{ background: surfaceColor }}
                 >
                   <div>
-                    <p className="text-sm font-semibold text-gray-100">{t.name}</p>
-                    <p className="text-xs text-gray-400">{t.description}</p>
+                    <p className="text-sm font-semibold text-gray-100">
+                      {t.id === 'default'
+                        ? intl.formatMessage(messages.themeDefaultName)
+                        : intl.formatMessage(messages.themeAmoledStrixName)}
+                    </p>
+                    <p className="text-xs text-gray-400">
+                      {t.id === 'default'
+                        ? intl.formatMessage(messages.themeDefaultDescription)
+                        : intl.formatMessage(messages.themeAmoledStrixDescription)}
+                    </p>
                   </div>
                   {/* Color swatches */}
                   <div className="flex gap-1">

--- a/src/components/UserProfile/UserSettings/UserAppearanceSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserAppearanceSettings/index.tsx
@@ -46,6 +46,8 @@ const UserAppearanceSettings = () => {
             return (
               <button
                 key={t.id}
+                type="button"
+                aria-pressed={isActive}
                 onClick={() => setTheme(t.id)}
                 className={`relative flex flex-col overflow-hidden rounded-xl border-2 text-left transition duration-200 focus:outline-none ${
                   isActive

--- a/src/components/UserProfile/UserSettings/UserAppearanceSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserAppearanceSettings/index.tsx
@@ -1,0 +1,133 @@
+import PageTitle from '@app/components/Common/PageTitle';
+import { THEMES } from '@app/context/ThemeContext';
+import useTheme from '@app/hooks/useTheme';
+import defineMessages from '@app/utils/defineMessages';
+import { useIntl } from 'react-intl';
+
+const messages = defineMessages(
+  'components.UserProfile.UserSettings.UserAppearanceSettings',
+  {
+    appearance: 'Appearance',
+    appearancesettings: 'Appearance Settings',
+    themeLabel: 'Theme',
+    themeTip: 'Choose how Seerr looks to you. This setting is stored locally in your browser.',
+  }
+);
+
+const UserAppearanceSettings = () => {
+  const intl = useIntl();
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <>
+      <PageTitle
+        title={[
+          intl.formatMessage(messages.appearance),
+          intl.formatMessage(messages.appearancesettings),
+        ]}
+      />
+      <div className="section">
+        <h3 className="heading">
+          {intl.formatMessage(messages.appearancesettings)}
+        </h3>
+        <p className="description">
+          {intl.formatMessage(messages.themeTip)}
+        </p>
+      </div>
+
+      <div className="section">
+        <h4 className="mb-4 text-sm font-bold uppercase tracking-wider text-gray-400">
+          {intl.formatMessage(messages.themeLabel)}
+        </h4>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {THEMES.map((t) => {
+            const isActive = theme === t.id;
+            const [bgColor = '#1f2937', surfaceColor = '#374151', accentColor = '#6366f1'] = t.swatches;
+            return (
+              <button
+                key={t.id}
+                onClick={() => setTheme(t.id)}
+                className={`relative flex flex-col overflow-hidden rounded-xl border-2 text-left transition duration-200 focus:outline-none ${
+                  isActive
+                    ? 'border-indigo-500 shadow-lg shadow-indigo-500/20'
+                    : 'border-gray-700 hover:border-gray-500'
+                }`}
+                style={{ background: bgColor }}
+              >
+                {/* Preview area */}
+                <div
+                  className="relative h-24 w-full overflow-hidden"
+                  style={{ background: bgColor }}
+                >
+                  {/* Mock sidebar strip */}
+                  <div
+                    className="absolute left-0 top-0 h-full w-10"
+                    style={{ background: surfaceColor, borderRight: `1px solid ${accentColor}22` }}
+                  />
+                  {/* Mock content bars */}
+                  <div className="absolute left-14 top-4 space-y-2">
+                    <div
+                      className="h-2 w-24 rounded"
+                      style={{ background: accentColor, opacity: 0.8 }}
+                    />
+                    <div
+                      className="h-2 w-16 rounded"
+                      style={{ background: surfaceColor }}
+                    />
+                    <div
+                      className="h-2 w-20 rounded"
+                      style={{ background: surfaceColor }}
+                    />
+                  </div>
+                  {/* Mock card */}
+                  <div
+                    className="absolute bottom-3 right-3 h-10 w-16 rounded-lg"
+                    style={{ background: surfaceColor, border: `1px solid ${accentColor}33` }}
+                  />
+                  {/* Active check badge */}
+                  {isActive && (
+                    <div
+                      className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full"
+                      style={{ background: accentColor }}
+                    >
+                      <svg className="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                        <path
+                          fillRule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  )}
+                </div>
+
+                {/* Info area */}
+                <div
+                  className="flex items-center justify-between px-3 py-2"
+                  style={{ background: surfaceColor }}
+                >
+                  <div>
+                    <p className="text-sm font-semibold text-gray-100">{t.name}</p>
+                    <p className="text-xs text-gray-400">{t.description}</p>
+                  </div>
+                  {/* Color swatches */}
+                  <div className="flex gap-1">
+                    {t.swatches.map((color, i) => (
+                      <span
+                        key={i}
+                        className="h-3 w-3 rounded-full border border-gray-600"
+                        style={{ background: color }}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default UserAppearanceSettings;

--- a/src/components/UserProfile/UserSettings/UserLinkedAccountsSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserLinkedAccountsSettings/index.tsx
@@ -212,7 +212,7 @@ const UserLinkedAccountsSettings = () => {
           {accounts.map((acct, i) => (
             <li
               key={i}
-              className="flex items-center gap-4 overflow-hidden rounded-lg bg-gray-800/50 px-4 py-5 shadow ring-1 ring-gray-700 sm:p-6"
+              className="flex items-center gap-4 overflow-hidden px-4 py-5 sm:p-6 rounded-lg bg-surface shadow ring-1 ring-ring-app/10"
             >
               <div className="w-12">
                 {acct.type === LinkedAccountType.Plex ? (

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/DeviceItem.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/DeviceItem.tsx
@@ -44,7 +44,7 @@ const DeviceItem = ({
   const parsedUserAgent = UAParser(device.userAgent);
 
   return (
-    <div className="relative flex w-full flex-col justify-between overflow-hidden rounded-xl bg-gray-800 py-4 text-gray-400 shadow-md ring-1 ring-gray-700 xl:h-28 xl:flex-row">
+    <div className="relative flex w-full flex-col justify-between overflow-hidden py-4 text-gray-400 xl:h-28 xl:flex-row rounded-xl bg-surface shadow-md ring-1 ring-ring-app/10">
       <div className="relative flex w-full flex-col justify-between overflow-hidden sm:flex-row">
         <div className="relative z-10 flex w-full items-center overflow-hidden pl-4 pr-4 sm:pr-0 xl:w-7/12 2xl:w-2/3">
           <div className="relative h-auto w-12 flex-shrink-0 scale-100 transform-gpu overflow-hidden rounded-md transition duration-300 hover:scale-105">

--- a/src/components/UserProfile/UserSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/index.tsx
@@ -21,6 +21,7 @@ const messages = defineMessages('components.UserProfile.UserSettings', {
   menuLinkedAccounts: 'Linked Accounts',
   menuNotifications: 'Notifications',
   menuPermissions: 'Permissions',
+  menuAppearance: 'Appearance',
   unauthorizedDescription:
     "You do not have permission to modify this user's settings.",
 });
@@ -86,6 +87,11 @@ const UserSettings = ({ children }: UserSettingsProps) => {
       regex: /\/settings\/permissions/,
       requiredPermission: Permission.MANAGE_USERS,
       hidden: currentUser?.id !== 1 && currentUser?.id === user.id,
+    },
+    {
+      text: intl.formatMessage(messages.menuAppearance),
+      route: '/settings/appearance',
+      regex: /\/settings\/appearance/,
     },
   ];
 

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -153,7 +153,7 @@ const UserProfile = () => {
           )) && (
           <div className="relative z-40">
             <dl className="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-3">
-              <div className="overflow-hidden rounded-lg bg-gray-800/50 px-4 py-5 shadow ring-1 ring-gray-700 sm:p-6">
+              <div className={`overflow-hidden px-4 py-5 sm:p-6 rounded-lg bg-surface shadow ring-1 ring-gray-700`}>
                 <dt className="truncate text-sm font-bold text-gray-300">
                   {intl.formatMessage(messages.totalrequests)}
                 </dt>
@@ -173,11 +173,7 @@ const UserProfile = () => {
                 </dd>
               </div>
               <div
-                className={`overflow-hidden rounded-lg bg-gray-800/50 px-4 py-5 shadow ring-1 ${
-                  quota.movie.restricted
-                    ? 'bg-gradient-to-t from-red-900 to-transparent ring-red-500'
-                    : 'ring-gray-700'
-                } sm:p-6`}
+                className={`overflow-hidden px-4 py-5 sm:p-6 rounded-lg bg-surface shadow ring-1 ${quota.movie.restricted ? 'bg-gradient-to-t from-red-900 to-transparent ring-red-500' : 'ring-gray-700'}`}
               >
                 <dt
                   className={`truncate text-sm font-bold ${
@@ -228,11 +224,7 @@ const UserProfile = () => {
                 </dd>
               </div>
               <div
-                className={`overflow-hidden rounded-lg bg-gray-800/50 px-4 py-5 shadow ring-1 ${
-                  quota.tv.restricted
-                    ? 'bg-gradient-to-t from-red-900 to-transparent ring-red-500'
-                    : 'ring-gray-700'
-                } sm:p-6`}
+                className={`overflow-hidden px-4 py-5 sm:p-6 rounded-lg bg-surface shadow ring-1 ${quota.tv.restricted ? 'bg-gradient-to-t from-red-900 to-transparent ring-red-500' : 'ring-gray-700'}`}
               >
                 <dt
                   className={`truncate text-sm font-bold ${

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,62 @@
+import React, { createContext, useCallback, useEffect, useState } from 'react';
+
+export type ThemeId = 'default' | 'amoled-strix';
+
+export interface ThemeDefinition {
+  id: ThemeId;
+  name: string;
+  description: string;
+  /** Preview swatch colors [bg, surface, accent] */
+  swatches: [string, string, string];
+}
+
+export const THEMES: ThemeDefinition[] = [
+  {
+    id: 'default',
+    name: 'Default',
+    description: 'Classic dark theme',
+    swatches: ['#111827', '#1f2937', '#6366f1'],
+  },
+  {
+    id: 'amoled-strix',
+    name: 'AMOLED Strix',
+    description: 'Pure black with violet accents, optimized for OLED displays',
+    swatches: ['#000000', '#080808', '#8b5cf6'],
+  },
+];
+
+const STORAGE_KEY = 'seerr-theme';
+const DEFAULT_THEME: ThemeId = 'default';
+
+export interface ThemeContextProps {
+  theme: ThemeId;
+  setTheme: (theme: ThemeId) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextProps>({
+  theme: DEFAULT_THEME,
+  setTheme: () => void 0,
+});
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [theme, setThemeState] = useState<ThemeId>(DEFAULT_THEME);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as ThemeId | null;
+    const resolved = stored && THEMES.find((t) => t.id === stored) ? stored : DEFAULT_THEME;
+    setThemeState(resolved);
+    document.documentElement.setAttribute('data-theme', resolved);
+  }, []);
+
+  const setTheme = useCallback((next: ThemeId) => {
+    setThemeState(next);
+    localStorage.setItem(STORAGE_KEY, next);
+    document.documentElement.setAttribute('data-theme', next);
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,11 +1,9 @@
-import React, { createContext, useCallback, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useState } from 'react';
 
 export type ThemeId = 'default' | 'amoled-strix';
 
 export interface ThemeDefinition {
   id: ThemeId;
-  name: string;
-  description: string;
   /** Preview swatch colors [bg, surface, accent] */
   swatches: [string, string, string];
 }
@@ -13,20 +11,33 @@ export interface ThemeDefinition {
 export const THEMES: ThemeDefinition[] = [
   {
     id: 'default',
-    name: 'Default',
-    description: 'Classic dark theme',
     swatches: ['#111827', '#1f2937', '#6366f1'],
   },
   {
     id: 'amoled-strix',
-    name: 'AMOLED Strix',
-    description: 'Pure black with violet accents, optimized for OLED displays',
     swatches: ['#000000', '#080808', '#8b5cf6'],
   },
 ];
 
 const STORAGE_KEY = 'seerr-theme';
 const DEFAULT_THEME: ThemeId = 'default';
+
+// Resolve persisted theme synchronously before first render to avoid flash
+function resolveInitialTheme(): ThemeId {
+  if (typeof window === 'undefined') return DEFAULT_THEME;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY) as ThemeId | null;
+    if (stored && THEMES.find((t) => t.id === stored)) {
+      document.documentElement.setAttribute('data-theme', stored);
+      return stored;
+    }
+  } catch {
+    // localStorage unavailable
+  }
+  return DEFAULT_THEME;
+}
+
+const initialTheme = resolveInitialTheme();
 
 export interface ThemeContextProps {
   theme: ThemeId;
@@ -39,14 +50,7 @@ export const ThemeContext = createContext<ThemeContextProps>({
 });
 
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
-  const [theme, setThemeState] = useState<ThemeId>(DEFAULT_THEME);
-
-  useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as ThemeId | null;
-    const resolved = stored && THEMES.find((t) => t.id === stored) ? stored : DEFAULT_THEME;
-    setThemeState(resolved);
-    document.documentElement.setAttribute('data-theme', resolved);
-  }, []);
+  const [theme, setThemeState] = useState<ThemeId>(initialTheme);
 
   const setTheme = useCallback((next: ThemeId) => {
     setThemeState(next);

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,6 @@
+import { ThemeContext } from '@app/context/ThemeContext';
+import { useContext } from 'react';
+
+const useTheme = () => useContext(ThemeContext);
+
+export default useTheme;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import ToastContainer from '@app/components/ToastContainer';
 import { InteractionProvider } from '@app/context/InteractionContext';
 import { LanguageContext } from '@app/context/LanguageContext';
 import { SettingsProvider } from '@app/context/SettingsContext';
+import { ThemeProvider } from '@app/context/ThemeContext';
 import { UserContext } from '@app/context/UserContext';
 import type { User } from '@app/hooks/useUser';
 import { Permission, useUser } from '@app/hooks/useUser';
@@ -203,6 +204,7 @@ const CoreApp: Omit<NextAppComponentType, 'origGetInitialProps'> = ({
           messages={loadedMessages}
         >
           <LoadingBar />
+          <ThemeProvider>
           <SettingsProvider currentSettings={currentSettings}>
             <InteractionProvider>
               <ToastProvider components={{ Toast, ToastContainer }}>
@@ -222,6 +224,7 @@ const CoreApp: Omit<NextAppComponentType, 'origGetInitialProps'> = ({
               </ToastProvider>
             </InteractionProvider>
           </SettingsProvider>
+          </ThemeProvider>
         </IntlProvider>
       </LanguageContext.Provider>
     </SWRConfig>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -15,6 +15,11 @@ class MyDocument extends Document {
       <Html>
         <Head />
         <body>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `(function(){try{var t=localStorage.getItem('seerr-theme');if(t==='amoled-strix')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();`,
+            }}
+          />
           <Main />
           <NextScript />
         </body>

--- a/src/pages/profile/settings/appearance.tsx
+++ b/src/pages/profile/settings/appearance.tsx
@@ -1,0 +1,13 @@
+import UserSettings from '@app/components/UserProfile/UserSettings';
+import UserAppearanceSettings from '@app/components/UserProfile/UserSettings/UserAppearanceSettings';
+import type { NextPage } from 'next';
+
+const UserAppearanceSettingsPage: NextPage = () => {
+  return (
+    <UserSettings>
+      <UserAppearanceSettings />
+    </UserSettings>
+  );
+};
+
+export default UserAppearanceSettingsPage;

--- a/src/pages/users/[userId]/settings/appearance.tsx
+++ b/src/pages/users/[userId]/settings/appearance.tsx
@@ -1,0 +1,16 @@
+import UserSettings from '@app/components/UserProfile/UserSettings';
+import UserAppearanceSettings from '@app/components/UserProfile/UserSettings/UserAppearanceSettings';
+import useRouteGuard from '@app/hooks/useRouteGuard';
+import { Permission } from '@app/hooks/useUser';
+import type { NextPage } from 'next';
+
+const UserAppearanceSettingsPage: NextPage = () => {
+  useRouteGuard(Permission.MANAGE_USERS);
+  return (
+    <UserSettings>
+      <UserAppearanceSettings />
+    </UserSettings>
+  );
+};
+
+export default UserAppearanceSettingsPage;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -708,6 +708,7 @@
 }
 [data-theme='amoled-strix'] .discover-movies-amoled-heading {
   display: block;
+  margin-top: 72px;
 }
 [data-theme='amoled-strix'] .discover-movies-standard-heading {
   display: none;
@@ -729,6 +730,7 @@
 }
 [data-theme='amoled-strix'] .discover-tv-amoled-heading {
   display: block;
+  margin-top: 72px;
 }
 [data-theme='amoled-strix'] .discover-tv-standard-heading {
   display: none;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -734,15 +734,12 @@
   display: none;
 }
 
-/* PersonDetails: show correct fader variant */
-.person-fader-amoled {
+/* PersonDetails: AMOLED gradient overlay — hidden by default, shown in AMOLED mode */
+.person-fader-amoled-overlay {
   display: none;
 }
-[data-theme='amoled-strix'] .person-fader-amoled {
+[data-theme='amoled-strix'] .person-fader-amoled-overlay {
   display: block;
-}
-[data-theme='amoled-strix'] .person-fader-standard {
-  display: none;
 }
 
 /* PersonDetails: profile photo shape in AMOLED (square rounded-xl vs circle) */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -654,6 +654,7 @@
 [data-theme='amoled-strix'] .issue-backdrop-overlay {
   --tw-gradient-from: rgba(0, 0, 0, 0.6);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.6), rgb(17, 24, 39));
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,16 +3,76 @@
 @tailwind utilities;
 
 @layer base {
+  /* ── Default theme (exact Tailwind v3 gray + indigo defaults) ── */
+  :root,
+  [data-theme='default'] {
+    --gray-100: 243 244 246;
+    --gray-200: 229 231 235;
+    --gray-300: 209 213 219;
+    --gray-400: 156 163 175;
+    --gray-500: 107 114 128;
+    --gray-600: 75 85 99;
+    --gray-700: 55 65 81;
+    --gray-800: 31 41 55;
+    --gray-900: 17 24 39;
+    --indigo-400: 129 140 248;
+    --indigo-500: 99 102 241;
+    --indigo-600: 79 70 229;
+    --scrollbar-track: #1f2937;
+    --scrollbar-thumb: #4b5563;
+    --scrollbar-thumb-hover: #6b7280;
+    --sidebar-bg-from: rgba(31, 41, 55, 1);
+    --sidebar-bg-to: #131928;
+    /* Semantic surface tokens - bare RGB triplets to support Tailwind opacity modifiers */
+    --color-bg: 17 24 39;
+    --color-surface: 31 41 55;
+    --color-surface-raised: 55 65 81;
+    --color-input: 31 41 55; /* intentionally same as surface in default; diverges in amoled */
+    --color-border: 55 65 81;
+    --color-border-muted: 75 85 99;
+    --color-ring: 55 65 81;
+  }
+
+  /* ── AMOLED Strix theme — pure black + neon violet ── */
+  [data-theme='amoled-strix'] {
+    --gray-100: 240 240 240;
+    --gray-200: 200 200 200;
+    --gray-300: 170 170 170;
+    --gray-400: 120 120 120;
+    --gray-500: 60 60 60;
+    --gray-600: 28 28 28;
+    --gray-700: 18 18 18;
+    --gray-800: 8 8 8;
+    --gray-900: 0 0 0;
+    --indigo-400: 167 139 250;
+    --indigo-500: 139 92 246;
+    --indigo-600: 124 58 237;
+    --scrollbar-track: #000000;
+    --scrollbar-thumb: #2a1a4a;
+    --scrollbar-thumb-hover: #7c3aed;
+    --sidebar-bg-from: rgba(0, 0, 0, 1);
+    --sidebar-bg-to: #050008;
+    /* Semantic surface tokens - AMOLED values */
+    --color-bg: 0 0 0;
+    --color-surface: 14 14 14;
+    --color-surface-raised: 24 24 24;
+    --color-input: 10 10 10;
+    --color-border: 36 36 36;
+    --color-border-muted: 52 52 52;
+    --color-ring: 255 255 255;
+  }
+
   html {
     min-height: calc(100% + env(safe-area-inset-top));
     padding: env(safe-area-inset-top) env(safe-area-inset-right)
       calc(4rem + env(safe-area-inset-bottom)) env(safe-area-inset-left);
+    scrollbar-gutter: stable;
     scrollbar-width: thin;
-    scrollbar-color: #4b5563 #1f2937;
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
   }
 
   html:hover {
-    scrollbar-color: #6b7280 #1f2937;
+    scrollbar-color: var(--scrollbar-thumb-hover) var(--scrollbar-track);
   }
 
   /* WebKit scrollbar styles */
@@ -21,15 +81,15 @@
   }
 
   html::-webkit-scrollbar-track {
-    background: #1f2937;
+    background: var(--scrollbar-track);
   }
 
   html::-webkit-scrollbar-thumb {
-    background-color: #4b5563;
+    background-color: var(--scrollbar-thumb);
   }
 
   html:hover::-webkit-scrollbar-thumb {
-    background-color: #6b7280;
+    background-color: var(--scrollbar-thumb-hover);
   }
 
   @media (min-width: 640px) {
@@ -62,7 +122,7 @@
     @apply border-r border-gray-700;
     padding-top: env(safe-area-inset-top);
     padding-left: env(safe-area-inset-left);
-    background: linear-gradient(180deg, rgba(31, 41, 55, 1) 0%, #131928 100%);
+    background: linear-gradient(180deg, var(--sidebar-bg-from) 0%, var(--sidebar-bg-to) 100%);
   }
 
   .slideover {
@@ -585,4 +645,192 @@
 
 .ptr--box {
   margin-bottom: -13px !important;
+}
+
+/* ── Structural AMOLED overrides ── */
+
+/* CollectionDetails / IssueDetails: darker gradient overlay */
+[data-theme='amoled-strix'] .collection-backdrop-overlay,
+[data-theme='amoled-strix'] .issue-backdrop-overlay {
+  --tw-gradient-from: rgba(0, 0, 0, 0.6);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.6), rgb(17, 24, 39));
+}
+
+/* Slider: hide nav arrows in AMOLED */
+[data-theme='amoled-strix'] .slider-nav-arrows {
+  display: none;
+}
+
+/* Layout: show AmoledNavbar, hide standard navbar; adjust main offset */
+.layout-amoled-navbar {
+  display: none;
+}
+[data-theme='amoled-strix'] .layout-amoled-navbar {
+  display: block;
+}
+[data-theme='amoled-strix'] .layout-standard-navbar {
+  display: none;
+}
+[data-theme='amoled-strix'] .layout-main {
+  top: 0;
+}
+/* Hero slider: in AMOLED mode, layout-main starts at top:0 so no negative margin needed */
+[data-theme='amoled-strix'] .hero-slider-root {
+  margin-top: 0;
+}
+
+/* MediaSlider: show AMOLED header, hide standard header */
+.media-slider-amoled-header {
+  display: none;
+}
+[data-theme='amoled-strix'] .media-slider-amoled-header {
+  display: flex;
+}
+[data-theme='amoled-strix'] .media-slider-standard-header {
+  display: none;
+}
+
+/* DiscoverMovies: show backdrop + relative wrapper + AMOLED heading */
+.discover-movies-amoled-backdrop {
+  display: none;
+}
+[data-theme='amoled-strix'] .discover-movies-amoled-backdrop {
+  display: block;
+}
+[data-theme='amoled-strix'] .discover-movies-content-wrapper {
+  position: relative;
+  z-index: 10;
+}
+.discover-movies-amoled-heading {
+  display: none;
+}
+[data-theme='amoled-strix'] .discover-movies-amoled-heading {
+  display: block;
+}
+[data-theme='amoled-strix'] .discover-movies-standard-heading {
+  display: none;
+}
+
+/* DiscoverTv: show backdrop + relative wrapper + AMOLED heading */
+.discover-tv-amoled-backdrop {
+  display: none;
+}
+[data-theme='amoled-strix'] .discover-tv-amoled-backdrop {
+  display: block;
+}
+[data-theme='amoled-strix'] .discover-tv-content-wrapper {
+  position: relative;
+  z-index: 10;
+}
+.discover-tv-amoled-heading {
+  display: none;
+}
+[data-theme='amoled-strix'] .discover-tv-amoled-heading {
+  display: block;
+}
+[data-theme='amoled-strix'] .discover-tv-standard-heading {
+  display: none;
+}
+
+/* PersonDetails: show correct fader variant */
+.person-fader-amoled {
+  display: none;
+}
+[data-theme='amoled-strix'] .person-fader-amoled {
+  display: block;
+}
+[data-theme='amoled-strix'] .person-fader-standard {
+  display: none;
+}
+
+/* PersonDetails: profile photo shape in AMOLED (square rounded-xl vs circle) */
+[data-theme='amoled-strix'] .person-profile-photo {
+  height: 10rem;
+  width: 10rem;
+  border-radius: 0.75rem;
+  --tw-ring-color: rgba(255, 255, 255, 0.1);
+}
+@media (min-width: 1024px) {
+  [data-theme='amoled-strix'] .person-profile-photo {
+    height: 13rem;
+    width: 13rem;
+  }
+}
+
+/* MovieDetails / TvDetails: hide backdrop hero section in AMOLED */
+[data-theme='amoled-strix'] .movie-details-backdrop-section,
+[data-theme='amoled-strix'] .tv-details-backdrop-section {
+  display: none;
+}
+
+/* TitleCard: rounded corners, ring and shadow */
+[data-theme='amoled-strix'] .title-card-inner {
+  border-radius: 0.5rem;
+  --tw-ring-color: rgba(255, 255, 255, 0.06);
+  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+}
+[data-theme='amoled-strix'] .title-card-inner:is(.scale-105) {
+  --tw-shadow: 0 25px 50px -12px rgba(30, 27, 75, 0.6);
+  --tw-ring-color: rgba(99, 102, 241, 0.5);
+}
+
+/* TitleCard: AMOLED circle badge visible, standard badge hidden */
+.title-card-amoled-badge {
+  display: none;
+}
+[data-theme='amoled-strix'] .title-card-amoled-badge {
+  display: flex;
+}
+[data-theme='amoled-strix'] .title-card-media-type-badge {
+  display: none;
+}
+
+/* TitleCard: icon buttons */
+.title-card-amoled-icon-btn {
+  display: none;
+}
+[data-theme='amoled-strix'] .title-card-amoled-icon-btn {
+  display: flex;
+}
+[data-theme='amoled-strix'] .title-card-standard-icon-btn {
+  display: none;
+}
+
+/* TitleCard: loading overlay and detail overlay radius */
+[data-theme='amoled-strix'] .title-card-loading-overlay,
+[data-theme='amoled-strix'] .title-card-detail-overlay {
+  border-radius: 0.5rem;
+}
+
+/* TitleCard: detail link gradient */
+[data-theme='amoled-strix'] .title-card-detail-link {
+  background: linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.5) 45%, rgba(0,0,0,0.96) 100%) !important;
+}
+
+/* TitleCard: content padding-bottom when request button shown */
+[data-theme='amoled-strix'] .title-card-content-pb {
+  padding-bottom: 3rem;
+}
+
+/* TitleCard: AMOLED compact title block vs standard title block */
+.title-card-amoled-title-block {
+  display: none;
+}
+[data-theme='amoled-strix'] .title-card-amoled-title-block {
+  display: block;
+}
+[data-theme='amoled-strix'] .title-card-standard-title-block {
+  display: none;
+}
+
+/* TitleCard: request button variants */
+.title-card-amoled-request-btn {
+  display: none;
+}
+[data-theme='amoled-strix'] .title-card-amoled-request-btn {
+  display: flex;
+}
+[data-theme='amoled-strix'] .title-card-standard-request-btn {
+  display: none;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,37 @@ module.exports = {
       fontFamily: {
         sans: ['Inter Variable', ...defaultTheme.fontFamily.sans],
       },
+      colors: {
+        gray: {
+          100: 'rgb(var(--gray-100) / <alpha-value>)',
+          200: 'rgb(var(--gray-200) / <alpha-value>)',
+          300: 'rgb(var(--gray-300) / <alpha-value>)',
+          400: 'rgb(var(--gray-400) / <alpha-value>)',
+          500: 'rgb(var(--gray-500) / <alpha-value>)',
+          600: 'rgb(var(--gray-600) / <alpha-value>)',
+          700: 'rgb(var(--gray-700) / <alpha-value>)',
+          800: 'rgb(var(--gray-800) / <alpha-value>)',
+          900: 'rgb(var(--gray-900) / <alpha-value>)',
+        },
+        indigo: {
+          400: 'rgb(var(--indigo-400) / <alpha-value>)',
+          500: 'rgb(var(--indigo-500) / <alpha-value>)',
+          600: 'rgb(var(--indigo-600) / <alpha-value>)',
+        },
+        app: {
+          DEFAULT: 'rgb(var(--color-bg) / <alpha-value>)',
+        },
+        surface: {
+          DEFAULT: 'rgb(var(--color-surface) / <alpha-value>)',
+          raised: 'rgb(var(--color-surface-raised) / <alpha-value>)',
+        },
+        input: {
+          DEFAULT: 'rgb(var(--color-input) / <alpha-value>)',
+        },
+        'border-default': 'rgb(var(--color-border) / <alpha-value>)',
+        'border-muted': 'rgb(var(--color-border-muted) / <alpha-value>)',
+        'ring-app': 'rgb(var(--color-ring) / <alpha-value>)',
+      },
       typography: (theme) => ({
         DEFAULT: {
           css: {


### PR DESCRIPTION
## AI Assistance Disclosure

This PR was developed with Claude Code (Anthropic) as a coding assistant. All code was reviewed by me and tested against a live Seerr instance running both the default and AMOLED-Strix themes. I understand the implementation and can answer questions about it.

---

## Summary

This PR introduces an **AMOLED-Strix** theme variant and a **semantic CSS token system** that makes all theme-aware components fully declarative — no per-component theme logic required.

### What's included

**1. Theme system foundation** (`src/styles/globals.css`, `tailwind.config.js`)**

A new `[data-theme='amoled-strix']` attribute on `<html>` remaps 7 semantic color tokens:

| Token | Default (gray) | AMOLED-Strix |
|---|---|---|
| `--color-bg` | `17 24 39` | `0 0 0` |
| `--color-surface` | `31 41 55` | `14 14 14` |
| `--color-surface-raised` | `55 65 81` | `24 24 24` |
| `--color-input` | `31 41 55` | `10 10 10` |
| `--color-border` | `55 65 81` | `36 36 36` |
| `--color-border-muted` | `52 52 52` | `52 52 52` |
| `--color-ring` | `55 65 81` | `255 255 255` |

Tokens use bare RGB triplets (not `var()` references) so Tailwind opacity modifiers like `bg-surface/80` work correctly.

These wire into Tailwind as: `bg-app`, `bg-surface`, `bg-surface-raised`, `bg-input`, `border-border-default`, `border-border-muted`, `ring-ring-app`.

**2. Appearance settings UI**

A new "Appearance" settings page lets users switch between Default and AMOLED-Strix themes. The selection is persisted via a `data-theme` attribute on `<html>` and stored in user preferences.

**3. AMOLED-Strix visual design**

The AMOLED-Strix theme includes:
- Pure black page background with near-black (`14,14,14`) card surfaces — cards are visible but don't wash into the background
- Cinematic full-bleed hero on movie/TV detail pages
- Redesigned title cards with glass badge, stronger gradient, and glass request button
- Always-expanded search box on desktop (collapsible on mobile)
- Custom AMOLED navbar (transparent, floating)
- Hero slider on the Discover page
- Redesigned slider section headers and chevron buttons
- Blurred backdrop image on Discover pages

**4. Semantic token migration**

All `isAmoled` component-level conditionals are replaced with semantic classes. Two approaches are used:

- **Color swaps** (`isAmoled ? 'bg-black' : 'bg-gray-800'` → `bg-surface`): handled via Tailwind semantic classes backed by CSS custom properties
- **Structural changes** (conditional JSX, border-radius, layout offsets): moved to `[data-theme='amoled-strix'] .stable-class { ... }` rules in `globals.css`

After migration:
- `isAmoled` exists in exactly **one** file: `ImageFader/index.tsx` — a planned exception where the value is used to compute a CSS gradient string passed as an inline style (cannot be expressed as a class)
- `useTheme` is retained only in `ImageFader` and the theme switcher UI (`UserAppearanceSettings`)

## Test plan

- [x] Default theme: cards have dark gray background, inputs slightly lighter, dropdowns elevated above cards, table headers distinct from rows
- [x] AMOLED-Strix: page is pure black, cards visible with subtle white ring, inputs slightly darker, no elements invisible against background
- [x] Switching themes in Appearance settings takes effect immediately without page reload
- [x] Movie/TV detail pages: cinematic hero displays correctly in both themes
- [x] Discover page: hero slider appears in AMOLED-Strix, standard layout in default
- [x] Production build passes with no TypeScript or lint errors

## Files changed

- `src/styles/globals.css` — semantic token definitions + structural AMOLED CSS selectors
- `tailwind.config.js` — semantic color entries
- `src/components/UserProfile/UserSettings/UserAppearanceSettings/` — new appearance settings page
- `src/components/Layout/AmoledNavbar/` — new AMOLED navbar
- `src/components/Discover/HeroSlider/` — new hero slider component
- ~55 existing components — `isAmoled` conditionals replaced with semantic tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme customization with Default and AMOLED themes, global theme support, Appearance settings pages (user & admin).
  * AMOLED UX additions: new AMOLED navbar, AMOLED full‑bleed layouts for Movie/TV, and an auto‑advancing Hero carousel on Discover.
  * Title cards: optional user score display and updated request/watch controls.

* **Style**
  * Broad visual refresh: surface tokens, new gradients/overlays, blur/vignette, AMOLED-specific styling and scrollbar theming.
  * New "glass" button/dropdown variant; tightened no-wrap text for buttons and dropdowns.
* **Accessibility**
  * Improved slider navigation with aria labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->