### PR TITLE
docs: fix PM2 start command syntax

### DIFF
--- a/docs/getting-started/buildfromsource.mdx
+++ b/docs/getting-started/buildfromsource.mdx
@@ -157,7 +157,7 @@ npm install -g pm2
 ```
 2. Start seerr with PM2:
 ```bash
-pm2 start dist/index.js --name seerr --node-args="--NODE_ENV=production"
+NODE_ENV=production pm2 start dist/index.js --name seerr
 ```
 3. Save the process list:
 ```bash

--- a/docs/getting-started/buildfromsource.mdx
+++ b/docs/getting-started/buildfromsource.mdx
@@ -275,7 +275,7 @@ npm install -g pm2
 ```
 2. Start seerr with PM2:
 ```powershell
-pm2 start dist/index.js --name seerr  --node-args="--NODE_ENV=production"
+set NODE_ENV=production && pm2 start dist/index.js --name seerr
 ```
 3. Save the process list:
 ```powershell

--- a/docs/getting-started/buildfromsource.mdx
+++ b/docs/getting-started/buildfromsource.mdx
@@ -206,7 +206,7 @@ git checkout main
 3. Install the dependencies:
 ```powershell
 npm install -g win-node-env
-set CYPRESS_INSTALL_BINARY=0 && pnpm install --frozen-lockfile
+$env:CYPRESS_INSTALL_BINARY = 0; pnpm install --frozen-lockfile
 ```
 4. Build the project:
 ```powershell
@@ -275,7 +275,7 @@ npm install -g pm2
 ```
 2. Start seerr with PM2:
 ```powershell
-set NODE_ENV=production && pm2 start dist/index.js --name seerr
+$env:NODE_ENV = "production"; pm2 start dist/index.js --name seerr
 ```
 3. Save the process list:
 ```powershell


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- The use of the "--node-args" causes pm2 can't start the application (`node: bad option: --NODE_ENV=production`), see screenshots. This pull request is made to the docs to pass the environment variable to pm2 rather than passing the environment variable via "--node-args"

## How Has This Been Tested?

- The application successfully started on pm2 v6.0.14 with node v22.22.1 using ubuntu Server 24.04.1 LTS Operating system
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

Using --node-args:

<img width="672" height="392" alt="image" src="https://github.com/user-attachments/assets/23715f0f-162f-4b73-8d7a-a3a519158f66" />
<img width="779" height="598" alt="image" src="https://github.com/user-attachments/assets/9099ecdd-a46b-49df-9a7f-0be6e7b83328" />

Passing ENV to the command:

<img width="1119" height="193" alt="image" src="https://github.com/user-attachments/assets/b548487c-dd77-40e1-b060-0af471ec53ef" />
<img width="828" height="600" alt="image" src="https://github.com/user-attachments/assets/f9ed95e5-f736-432f-bcb0-97bcad5e610f" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified PM2 startup examples to set NODE_ENV as an environment variable prior to invoking PM2 on Unix and Windows, simplifying startup commands.
  * Fixed Windows dependency-install example to use PowerShell-style environment assignment for the Cypress install-variable, improving Windows setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->