### PR TITLE
fix(watchlist-sync): handle empty watchlists on PostgreSQL

### DIFF
--- a/server/job/schedule.ts
+++ b/server/job/schedule.ts
@@ -97,7 +97,12 @@ export const startJobs = (): void => {
         logger.info('Starting scheduled job: Plex Watchlist Sync', {
           label: 'Jobs',
         });
-        watchlistSync.syncWatchlist();
+        watchlistSync.syncWatchlist().catch((e) => {
+          logger.error('Failed to sync watchlists', {
+            label: 'Plex Watchlist Sync',
+            errorMessage: e.message,
+          });
+        });
       }),
     });
   } else if (

--- a/server/lib/watchlistsync.ts
+++ b/server/lib/watchlistsync.ts
@@ -76,13 +76,18 @@ class WatchlistSync {
     const watchlistTmdbIds = response.items.map((i) => i.tmdbId);
 
     const requestRepository = getRepository(MediaRequest);
-    const existingAutoRequests = await requestRepository
-      .createQueryBuilder('request')
-      .leftJoinAndSelect('request.media', 'media')
-      .where('request.requestedBy = :userId', { userId: user.id })
-      .andWhere('request.isAutoRequest = true')
-      .andWhere('media.tmdbId IN (:...tmdbIds)', { tmdbIds: watchlistTmdbIds })
-      .getMany();
+    const existingAutoRequests: MediaRequest[] =
+      watchlistTmdbIds.length > 0
+        ? await requestRepository
+            .createQueryBuilder('request')
+            .leftJoinAndSelect('request.media', 'media')
+            .where('request.requestedBy = :userId', { userId: user.id })
+            .andWhere('request.isAutoRequest = true')
+            .andWhere('media.tmdbId IN (:...tmdbIds)', {
+              tmdbIds: watchlistTmdbIds,
+            })
+            .getMany()
+        : [];
 
     const autoRequestedTmdbIds = new Set(
       existingAutoRequests


### PR DESCRIPTION
## Description

Fixes watchlist sync silently failing on PostgreSQL when a user has an empty watchlist.

Two issues:

1. When a user has `watchlistSyncMovies` or `watchlistSyncTv` enabled but their Plex watchlist contains 0 items, the `existingAutoRequests` query passes an empty array to TypeORM's `IN (:...tmdbIds)`, generating `IN ()` — valid in SQLite but a syntax error in PostgreSQL.

2. The scheduler calls `syncWatchlist()` without `.catch()`, so the resulting `QueryFailedError` is an unhandled promise rejection that silently kills the sync loop for **all** users, not just the one with the empty watchlist.

**Changes:**
- **`server/lib/watchlistsync.ts`**: Short-circuit `existingAutoRequests` to `[]` when `watchlistTmdbIds` is empty, skipping the query entirely.
- **`server/job/schedule.ts`**: Add `.catch()` to the `syncWatchlist()` call so errors are logged instead of silently dropped.

## How Has This Been Tested?

Reproduced on a PostgreSQL-backed Seerr 3.1.0 instance with 13 users. User with 0 watchlist items caused `QueryFailedError: syntax error at or near ")"` on every sync cycle, preventing all other users' watchlists from syncing. After this fix, the sync completes successfully for all users.

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice)): AI (Claude) was used to generate the fix.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
