### PR TITLE
fix(api): add missing mediaType query parameter to blocklist and watchlist

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -4620,6 +4620,14 @@ paths:
           example: '1'
           schema:
             type: string
+        - in: query
+          name: mediaType
+          required: true
+          schema:
+            type: string
+            enum:
+              - movie
+              - tv
       responses:
         '200':
           description: Blocklist details in JSON
@@ -4635,6 +4643,14 @@ paths:
           example: '1'
           schema:
             type: string
+        - in: query
+          name: mediaType
+          required: true
+          schema:
+            type: string
+            enum:
+              - movie
+              - tv
       responses:
         '204':
           description: Succesfully removed media item
@@ -4737,6 +4753,14 @@ paths:
           example: '1'
           schema:
             type: string
+        - in: query
+          name: mediaType
+          required: true
+          schema:
+            type: string
+            enum:
+              - movie
+              - tv
       responses:
         '200':
           description: Blocklist details in JSON
@@ -4755,6 +4779,14 @@ paths:
           example: '1'
           schema:
             type: string
+        - in: query
+          name: mediaType
+          required: true
+          schema:
+            type: string
+            enum:
+              - movie
+              - tv
       responses:
         '204':
           description: Succesfully removed media item
@@ -4790,6 +4822,14 @@ paths:
           example: '1'
           schema:
             type: string
+        - in: query
+          name: mediaType
+          required: true
+          schema:
+            type: string
+            enum:
+              - movie
+              - tv
       responses:
         '204':
           description: Succesfully removed watchlist item


### PR DESCRIPTION

<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Adds mediaType definition to openapi spec for blocklist and watchlist endpoints, required after #2577

No use of AI

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested the endpoints manually

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
