### PR TITLE
feat(discord): add thread support for Discord notifications #2719

### DIFF
--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -299,7 +299,15 @@ class DiscordAgent
         userMentions.push(`<@&${settings.options.webhookRoleId}>`);
       }
 
-      await axios.post(settings.options.webhookUrl, {
+      const notificationType = Notification[type];
+      const threadId = settings.options.threadMappings?.[notificationType];
+      
+      // Append thread_id to webhook URL if configured
+      const webhookUrl = threadId 
+        ? `${settings.options.webhookUrl}?thread_id=${threadId}`
+        : settings.options.webhookUrl;
+
+      await axios.post(webhookUrl, {
         username: settings.options.botUsername
           ? settings.options.botUsername
           : getSettings().main.applicationTitle,

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -226,6 +226,7 @@ export interface NotificationAgentDiscord extends NotificationAgentConfig {
     webhookUrl: string;
     webhookRoleId?: string;
     enableMentions: boolean;
+    threadMappings?: Record<string, string>;
   };
 }
 
@@ -469,6 +470,7 @@ class Settings {
               webhookUrl: '',
               webhookRoleId: '',
               enableMentions: true,
+              threadMappings: {},
             },
           },
           slack: {

--- a/src/components/Settings/Notifications/NotificationsDiscord.tsx
+++ b/src/components/Settings/Notifications/NotificationsDiscord.tsx
@@ -33,6 +33,11 @@ const messages = defineMessages('components.Settings.Notifications', {
   validationWebhookRoleId: 'You must provide a valid Discord Role ID',
   validationTypes: 'You must select at least one notification type',
   enableMentions: 'Enable Mentions',
+  threadSettings: 'Thread Settings',
+  treadSettingsTip: 'Configure Discord threads for different notification types (optional)',
+  threadId: 'Thread ID',
+  threadIdTip:
+    'Leave empty to send to main channel. Get ID by enabling Developer Mode in Discord',
 });
 
 const NotificationsDiscord = () => {
@@ -82,6 +87,7 @@ const NotificationsDiscord = () => {
         webhookUrl: data.options.webhookUrl,
         webhookRoleId: data?.options.webhookRoleId,
         enableMentions: data?.options.enableMentions,
+        threadMappings: data?.options.threadMappings || {},
       }}
       validationSchema={NotificationsDiscordSchema}
       onSubmit={async (values) => {
@@ -96,6 +102,7 @@ const NotificationsDiscord = () => {
               webhookUrl: values.webhookUrl,
               webhookRoleId: values.webhookRoleId,
               enableMentions: values.enableMentions,
+              threadMappings: values.threadMappings,
             },
           });
 
@@ -146,6 +153,7 @@ const NotificationsDiscord = () => {
                 webhookUrl: values.webhookUrl,
                 webhookRoleId: values.webhookRoleId,
                 enableMentions: values.enableMentions,
+                threadMappings: values.threadMappings,
               },
             });
 


### PR DESCRIPTION
## Description

Adds support for sending Discord notifications to specific threads based on notification type, allowing better organization of notifications within Discord servers.

**Fixes #2719**

##Changes Made:
- Added `threadMappings` configuration to store thread IDs per notification type
- Updated Discord agent to append `thread_id` query parameter to webhook URL when configured
- Added threadMappings to React component form (Formik state management)
- Included threadMappings in API requests (settings save and test endpoints)
- Set default to empty thread mappings for backward compatibility

### How It Works:
Users can now configure which Discord thread each notification type should be sent to:
- `REQUEST_ADDED` → Thread ID for new requests
- `REQUEST_APPROVED` → Thread ID for approved requests
- `REQUEST_DECLINED` → Thread ID for declined requests
- `MEDIA_AVAILABLE` → Thread ID for available media
- etc...

If no thread is configured for a notification type, it falls back to the main channel (existing behavior).

## How Has This Been Tested?

- [x] Tested locally with Discord webhook
- [x] Verified thread parameter appends correctly to webhook URL
- [x] Tested fallback to main channel when no thread configured
- [x] Verified settings persist correctly (threadMappings saved/loaded)
- [x] Tested with both empty and populated thread mappings
- [x] Verified no breaking changes to existing Discord notifications

## Screenshots / Logs (if applicable)

**Before:**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added Discord thread support for notifications. You can now map notification types to specific Discord threads in your server. Notifications post to designated threads when configured, or fall back to your main webhook channel if no mapping exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->