### PR TITLE
fix(creditHelpers): use indexOf instead of findIndex in sortCrewPriority

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -8,7 +8,8 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@server/*": ["*"]
+      "@server/*": ["*"],
+      "@app/*": ["../src/*"]
     }
   },
   "include": ["**/*.ts"]

--- a/server/utils/creditHelpers.test.ts
+++ b/server/utils/creditHelpers.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { Crew } from '@server/models/common';
+
+import { sortCrewPriority } from '@app/utils/creditHelpers';
+
+const makeCrew = (job: string, name = job): Crew => ({
+  id: 0,
+  creditId: '',
+  department: '',
+  job,
+  name,
+});
+
+describe('sortCrewPriority', () => {
+  it('filters out jobs not in the priority list', () => {
+    const crew = [
+      makeCrew('Director'),
+      makeCrew('Gaffer'),
+      makeCrew('Producer'),
+    ];
+    const result = sortCrewPriority(crew);
+    assert.deepEqual(
+      result.map((c) => c.job),
+      ['Director', 'Producer']
+    );
+  });
+
+  it('returns an empty array when no crew match priority jobs', () => {
+    assert.deepEqual(
+      sortCrewPriority([makeCrew('Gaffer'), makeCrew('Grip')]),
+      []
+    );
+  });
+
+  it('returns an empty array for empty input', () => {
+    assert.deepEqual(sortCrewPriority([]), []);
+  });
+
+  it('sorts crew by priority order', () => {
+    const crew = [
+      makeCrew('Executive Producer'),
+      makeCrew('Writer'),
+      makeCrew('Director'),
+      makeCrew('Producer'),
+      makeCrew('Composer'),
+    ];
+    const result = sortCrewPriority(crew);
+    assert.deepEqual(
+      result.map((c) => c.job),
+      ['Director', 'Writer', 'Composer', 'Producer', 'Executive Producer']
+    );
+  });
+
+  it('handles multiple crew members sharing the same job', () => {
+    const crew = [
+      makeCrew('Producer', 'Producer B'),
+      makeCrew('Director', 'Director A'),
+      makeCrew('Producer', 'Producer A'),
+    ];
+    const result = sortCrewPriority(crew);
+    assert.equal(result[0].job, 'Director');
+    assert.ok(result.slice(1).every((c) => c.job === 'Producer'));
+  });
+
+  it('correctly ranks Producer, Co-Producer, and Executive Producer independently', () => {
+    const crew = [
+      makeCrew('Executive Producer'),
+      makeCrew('Co-Producer'),
+      makeCrew('Producer'),
+    ];
+    const result = sortCrewPriority(crew);
+    assert.deepEqual(
+      result.map((c) => c.job),
+      ['Producer', 'Co-Producer', 'Executive Producer']
+    );
+  });
+});

--- a/server/utils/creditHelpers.test.ts
+++ b/server/utils/creditHelpers.test.ts
@@ -60,8 +60,16 @@ describe('sortCrewPriority', () => {
       makeCrew('Producer', 'Producer A'),
     ];
     const result = sortCrewPriority(crew);
+    assert.equal(result.length, 3);
     assert.equal(result[0].job, 'Director');
     assert.ok(result.slice(1).every((c) => c.job === 'Producer'));
+    assert.deepEqual(
+      result
+        .slice(1)
+        .map((c) => c.name)
+        .sort(),
+      ['Producer A', 'Producer B']
+    );
   });
 
   it('correctly ranks Producer, Co-Producer, and Executive Producer independently', () => {

--- a/src/utils/creditHelpers.ts
+++ b/src/utils/creditHelpers.ts
@@ -16,8 +16,8 @@ export const sortCrewPriority = (crew: Crew[]): Crew[] => {
   return crew
     .filter((person) => priorityJobs.includes(person.job))
     .sort((a, b) => {
-      const aScore = priorityJobs.findIndex((job) => job.includes(a.job));
-      const bScore = priorityJobs.findIndex((job) => job.includes(b.job));
+      const aScore = priorityJobs.indexOf(a.job);
+      const bScore = priorityJobs.indexOf(b.job);
 
       return aScore - bScore;
     });


### PR DESCRIPTION
## Description

The sort comparator in `sortCrewPriority` used `findIndex` with a substring predicate (`job.includes(a.job)`) to locate each job's priority rank. Since the preceding `.filter()` already guarantees every crew member's job is an exact member of `priorityJobs`, `indexOf` is correct and simpler.

The substring approach is fragile: if a shorter title were ever added earlier in the list (e.g. `'Pro'` before `'Producer'`), the substring match would silently return the wrong index and mis-rank those crew members.

Also adds `@app/*` to the server tsconfig paths so server-side tests can import `src/` utilities without relative paths.

**AI Disclosure:** I used Claude Code to help write the tests. I reviewed and understood all generated code before submitting.

## How Has This Been Tested?

New `node:test` suite at `server/utils/creditHelpers.test.ts` covering:
- Filters out jobs not in the priority list
- Returns an empty array when no crew match priority jobs
- Returns an empty array for empty input
- Sorts crew by priority order
- Handles multiple crew members sharing the same job (asserts both entries are retained and correctly ranked)
- Correctly ranks Producer, Co-Producer, and Executive Producer independently

All 6 tests pass.

## Screenshots / Logs (if applicable)

```
▶ sortCrewPriority
  ✔ filters out jobs not in the priority list (0.594083ms)
  ✔ returns an empty array when no crew match priority jobs (0.049083ms)
  ✔ returns an empty array for empty input (0.09075ms)
  ✔ sorts crew by priority order (0.052667ms)
  ✔ handles multiple crew members sharing the same job (0.073708ms)
  ✔ correctly ranks Producer, Co-Producer, and Executive Producer independently (0.043792ms)
✔ sortCrewPriority (1.3715ms)
ℹ tests 6
ℹ pass 6
ℹ fail 0
```

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. (no documentation changes required for this fix)
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` (no new UI strings added)
- [x] Database migration (if required) (no schema changes)
