### PR TITLE
fix(request): correct delete permission check and await movie save

### DIFF
--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -31,6 +31,8 @@ function createApp() {
       secret: 'test-secret',
       resave: false,
       saveUninitialized: false,
+      // secure: false is intentional -- supertest uses HTTP, not HTTPS
+      cookie: { secure: false },
     })
   );
   app.use(checkUser);
@@ -61,10 +63,17 @@ before(async () => {
 setupTestDb();
 
 async function authenticatedAgent(email: string, password: string) {
-  const agent = request.agent(app);
-  const res = await agent.post('/auth/local').send({ email, password });
-  assert.strictEqual(res.status, 200);
-  return agent;
+  const settings = getSettings();
+  const priorLocalLogin = settings.main.localLogin;
+  settings.main.localLogin = true;
+  try {
+    const agent = request.agent(app);
+    const res = await agent.post('/auth/local').send({ email, password });
+    assert.strictEqual(res.status, 200);
+    return agent;
+  } finally {
+    settings.main.localLogin = priorLocalLogin;
+  }
 }
 
 /** Creates a minimal movie request owned by the given user. */

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
+import { MediaRequest } from '@server/entity/MediaRequest';
+import { User } from '@server/entity/User';
+import { getSettings } from '@server/lib/settings';
+import { checkUser } from '@server/middleware/auth';
+import { setupTestDb } from '@server/test/db';
+import type { Express } from 'express';
+import express from 'express';
+import session from 'express-session';
+import request from 'supertest';
+
+import authRoutes from './auth';
+import requestRoutes from './request';
+
+let app: Express;
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+  app.use(checkUser);
+  app.use('/auth', authRoutes);
+  app.use('/request', requestRoutes);
+  app.use(
+    (
+      err: { status?: number; message?: string },
+      _req: express.Request,
+      res: express.Response,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      _next: express.NextFunction
+    ) => {
+      res
+        .status(err.status ?? 500)
+        .json({ status: err.status ?? 500, message: err.message });
+    }
+  );
+  return app;
+}
+
+before(async () => {
+  app = createApp();
+  const settings = getSettings();
+  settings.main.localLogin = true;
+});
+
+setupTestDb();
+
+async function authenticatedAgent(email: string, password: string) {
+  const agent = request.agent(app);
+  const res = await agent.post('/auth/local').send({ email, password });
+  assert.strictEqual(res.status, 200);
+  return agent;
+}
+
+/** Creates a minimal movie request owned by the given user. */
+async function createMovieRequest(
+  requestedBy: User,
+  status = MediaRequestStatus.PENDING
+): Promise<MediaRequest> {
+  const mediaRepo = getRepository(Media);
+  const requestRepo = getRepository(MediaRequest);
+
+  let media = await mediaRepo.findOne({ where: { tmdbId: 99999 } });
+  if (!media) {
+    media = new Media();
+    media.tmdbId = 99999;
+    media.mediaType = MediaType.MOVIE;
+    media.status = MediaStatus.UNKNOWN;
+    await mediaRepo.save(media);
+  }
+
+  const mediaRequest = new MediaRequest({
+    media,
+    requestedBy,
+    status,
+    type: MediaType.MOVIE,
+    is4k: false,
+  });
+  return requestRepo.save(mediaRequest);
+}
+
+describe('DELETE /request/:requestId', () => {
+  it('allows the owner to delete their own pending request', async () => {
+    const userRepo = getRepository(User);
+    const owner = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+    const mediaRequest = await createMovieRequest(owner);
+
+    const agent = await authenticatedAgent('friend@seerr.dev', 'test1234');
+    const res = await agent.delete(`/request/${mediaRequest.id}`);
+
+    assert.strictEqual(res.status, 204);
+  });
+
+  it('allows an admin to delete any pending request', async () => {
+    const userRepo = getRepository(User);
+    const owner = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+    const mediaRequest = await createMovieRequest(owner);
+
+    const agent = await authenticatedAgent('admin@seerr.dev', 'test1234');
+    const res = await agent.delete(`/request/${mediaRequest.id}`);
+
+    assert.strictEqual(res.status, 204);
+  });
+
+  it('prevents a non-owner non-admin from deleting a pending request', async () => {
+    const userRepo = getRepository(User);
+    // admin creates the request; friend tries to delete it
+    const owner = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+    const mediaRequest = await createMovieRequest(owner);
+
+    const agent = await authenticatedAgent('friend@seerr.dev', 'test1234');
+    const res = await agent.delete(`/request/${mediaRequest.id}`);
+
+    assert.strictEqual(res.status, 401);
+  });
+
+  it('prevents the owner from deleting an approved request', async () => {
+    const userRepo = getRepository(User);
+    const owner = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+    const mediaRequest = await createMovieRequest(
+      owner,
+      MediaRequestStatus.APPROVED
+    );
+
+    const agent = await authenticatedAgent('friend@seerr.dev', 'test1234');
+    const res = await agent.delete(`/request/${mediaRequest.id}`);
+
+    assert.strictEqual(res.status, 401);
+  });
+
+  it('returns 404 for a non-existent request', async () => {
+    const agent = await authenticatedAgent('admin@seerr.dev', 'test1234');
+    const res = await agent.delete('/request/99999999');
+
+    assert.strictEqual(res.status, 404);
+  });
+});
+
+describe('PUT /request/:requestId (movie)', () => {
+  it('persists server and root folder changes to the database', async () => {
+    const userRepo = getRepository(User);
+    const requestRepo = getRepository(MediaRequest);
+    const owner = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+    const mediaRequest = await createMovieRequest(owner);
+
+    const agent = await authenticatedAgent('admin@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.MOVIE,
+      serverId: 3,
+      profileId: 7,
+      rootFolder: '/updated/movies',
+      tags: [1, 2],
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.strictEqual(saved.serverId, 3);
+    assert.strictEqual(saved.profileId, 7);
+    assert.strictEqual(saved.rootFolder, '/updated/movies');
+  });
+});

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it } from 'node:test';
+import { before, beforeEach, describe, it, mock } from 'node:test';
 
 import {
   MediaRequestStatus,
@@ -17,9 +17,14 @@ import type { Express } from 'express';
 import express from 'express';
 import session from 'express-session';
 import request from 'supertest';
-
 import authRoutes from './auth';
 import requestRoutes from './request';
+
+const sendNotificationMock = mock.method(
+  MediaRequest,
+  'sendNotification',
+  async () => undefined
+).mock;
 
 let app: Express;
 
@@ -31,8 +36,6 @@ function createApp() {
       secret: 'test-secret',
       resave: false,
       saveUninitialized: false,
-      // secure: false is intentional -- supertest uses HTTP, not HTTPS
-      cookie: { secure: false },
     })
   );
   app.use(checkUser);
@@ -56,16 +59,19 @@ function createApp() {
 
 before(async () => {
   app = createApp();
-  const settings = getSettings();
-  settings.main.localLogin = true;
+});
+
+beforeEach(() => {
+  sendNotificationMock.resetCalls();
 });
 
 setupTestDb();
 
-async function authenticatedAgent(email: string, password: string) {
+async function loginAs(email: string, password: string) {
   const settings = getSettings();
   const priorLocalLogin = settings.main.localLogin;
   settings.main.localLogin = true;
+
   try {
     const agent = request.agent(app);
     const res = await agent.post('/auth/local').send({ email, password });
@@ -76,55 +82,55 @@ async function authenticatedAgent(email: string, password: string) {
   }
 }
 
-/** Creates a minimal movie request owned by the given user. */
-async function createMovieRequest(
-  requestedBy: User,
-  status = MediaRequestStatus.PENDING
-): Promise<MediaRequest> {
+async function seedRequest(status = MediaRequestStatus.PENDING) {
+  const userRepo = getRepository(User);
   const mediaRepo = getRepository(Media);
   const requestRepo = getRepository(MediaRequest);
 
-  let media = await mediaRepo.findOne({ where: { tmdbId: 99999 } });
-  if (!media) {
-    media = new Media();
-    media.tmdbId = 99999;
-    media.mediaType = MediaType.MOVIE;
-    media.status = MediaStatus.UNKNOWN;
-    await mediaRepo.save(media);
-  }
-
-  const mediaRequest = new MediaRequest({
-    media,
-    requestedBy,
-    status,
-    type: MediaType.MOVIE,
-    is4k: false,
+  const requestedBy = await userRepo.findOneOrFail({
+    where: { email: 'friend@seerr.dev' },
   });
-  return requestRepo.save(mediaRequest);
+
+  const media = await mediaRepo.save(
+    new Media({
+      mediaType: MediaType.MOVIE,
+      tmdbId: 12345,
+      status: MediaStatus.UNKNOWN,
+      status4k: MediaStatus.UNKNOWN,
+    })
+  );
+
+  const created = await requestRepo.save(
+    new MediaRequest({
+      type: MediaType.MOVIE,
+      status,
+      media,
+      requestedBy,
+      is4k: false,
+      updatedAt: new Date('2025-03-01T00:00:00.000Z'),
+    })
+  );
+
+  return requestRepo.findOneOrFail({
+    where: { id: created.id },
+    relations: { requestedBy: true, modifiedBy: true },
+  });
 }
 
 describe('DELETE /request/:requestId', () => {
   it('allows the owner to delete their own pending request', async () => {
-    const userRepo = getRepository(User);
-    const owner = await userRepo.findOneOrFail({
-      where: { email: 'friend@seerr.dev' },
-    });
-    const mediaRequest = await createMovieRequest(owner);
+    const mediaRequest = await seedRequest();
 
-    const agent = await authenticatedAgent('friend@seerr.dev', 'test1234');
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
     const res = await agent.delete(`/request/${mediaRequest.id}`);
 
     assert.strictEqual(res.status, 204);
   });
 
   it('allows an admin to delete any pending request', async () => {
-    const userRepo = getRepository(User);
-    const owner = await userRepo.findOneOrFail({
-      where: { email: 'friend@seerr.dev' },
-    });
-    const mediaRequest = await createMovieRequest(owner);
+    const mediaRequest = await seedRequest();
 
-    const agent = await authenticatedAgent('admin@seerr.dev', 'test1234');
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
     const res = await agent.delete(`/request/${mediaRequest.id}`);
 
     assert.strictEqual(res.status, 204);
@@ -132,36 +138,50 @@ describe('DELETE /request/:requestId', () => {
 
   it('prevents a non-owner non-admin from deleting a pending request', async () => {
     const userRepo = getRepository(User);
-    // admin creates the request; friend tries to delete it
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    // Create a request owned by admin, then try to delete as friend
     const owner = await userRepo.findOneOrFail({
       where: { email: 'admin@seerr.dev' },
     });
-    const mediaRequest = await createMovieRequest(owner);
 
-    const agent = await authenticatedAgent('friend@seerr.dev', 'test1234');
+    const media = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.MOVIE,
+        tmdbId: 54321,
+        status: MediaStatus.UNKNOWN,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+
+    const mediaRequest = await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.PENDING,
+        media,
+        requestedBy: owner,
+        is4k: false,
+      })
+    );
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
     const res = await agent.delete(`/request/${mediaRequest.id}`);
 
     assert.strictEqual(res.status, 401);
   });
 
   it('prevents the owner from deleting an approved request', async () => {
-    const userRepo = getRepository(User);
-    const owner = await userRepo.findOneOrFail({
-      where: { email: 'friend@seerr.dev' },
-    });
-    const mediaRequest = await createMovieRequest(
-      owner,
-      MediaRequestStatus.APPROVED
-    );
+    const mediaRequest = await seedRequest(MediaRequestStatus.APPROVED);
 
-    const agent = await authenticatedAgent('friend@seerr.dev', 'test1234');
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
     const res = await agent.delete(`/request/${mediaRequest.id}`);
 
     assert.strictEqual(res.status, 401);
   });
 
   it('returns 404 for a non-existent request', async () => {
-    const agent = await authenticatedAgent('admin@seerr.dev', 'test1234');
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
     const res = await agent.delete('/request/99999999');
 
     assert.strictEqual(res.status, 404);
@@ -170,14 +190,10 @@ describe('DELETE /request/:requestId', () => {
 
 describe('PUT /request/:requestId (movie)', () => {
   it('persists server and root folder changes to the database', async () => {
-    const userRepo = getRepository(User);
     const requestRepo = getRepository(MediaRequest);
-    const owner = await userRepo.findOneOrFail({
-      where: { email: 'admin@seerr.dev' },
-    });
-    const mediaRequest = await createMovieRequest(owner);
+    const mediaRequest = await seedRequest();
 
-    const agent = await authenticatedAgent('admin@seerr.dev', 'test1234');
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
     const res = await agent.put(`/request/${mediaRequest.id}`).send({
       mediaType: MediaType.MOVIE,
       serverId: 3,

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -512,7 +512,7 @@ requestRoutes.put<{ requestId: string }>(
         request.tags = req.body.tags;
         request.requestedBy = requestUser as User;
 
-        requestRepository.save(request);
+        await requestRepository.save(request);
       } else if (req.body.mediaType === MediaType.TV) {
         const mediaRepository = getRepository(Media);
         request.serverId = req.body.serverId;
@@ -609,8 +609,8 @@ requestRoutes.delete('/:requestId', async (req, res, next) => {
 
     if (
       !req.user?.hasPermission(Permission.MANAGE_REQUESTS) &&
-      request.requestedBy.id !== req.user?.id &&
-      request.status !== 1
+      (request.requestedBy.id !== req.user?.id ||
+        request.status !== MediaRequestStatus.PENDING)
     ) {
       return next({
         status: 401,


### PR DESCRIPTION
## Description

Two bugs in `server/routes/request.ts`:

**1. Anyone can delete any pending request**

The `DELETE /request/:id` handler used three top-level `&&` conditions to gate deletion:

```ts
// Before
if (
  !req.user?.hasPermission(Permission.MANAGE_REQUESTS) &&
  request.requestedBy.id !== req.user?.id &&
  request.status !== 1
) {
```

Because all three must be true to deny, the third condition short-circuits the check whenever a request is `PENDING` -- meaning any authenticated user can delete any pending request they did not create. The intended behaviour is that non-admins may only retract their own requests while they are still pending.

```ts
// After
if (
  !req.user?.hasPermission(Permission.MANAGE_REQUESTS) &&
  (request.requestedBy.id !== req.user?.id ||
    request.status !== MediaRequestStatus.PENDING)
) {
```

Also replaces the magic number `1` with `MediaRequestStatus.PENDING`.

**2. Movie request update is not awaited**

The movie branch of `PUT /request/:id` called `requestRepository.save()` without `await`, returning the `200` response before the write completed. The TV branch in the same handler correctly awaits the save.

**AI Disclosure:** I used Claude Code to help write the tests. I reviewed and understood all generated code before submitting.

## How Has This Been Tested?

New suite at `server/routes/request.test.ts` using the real SQLite test database via `setupTestDb()`:

- `allows the owner to delete their own pending request`
- `allows an admin to delete any pending request`
- `prevents a non-owner non-admin from deleting a pending request` -- directly tests the authorization bug
- `prevents the owner from deleting an approved request` -- asserts the status check is enforced
- `returns 404 for a non-existent request`
- `persists server and root folder changes to the database` -- regression guard for the unawaited movie save

**To reproduce bug 1 manually:**
1. Log in as a non-admin user (User A) and submit a request.
2. Log in as a different non-admin user (User B) who did not create the request.
3. Send `DELETE /api/v1/request/:id` as User B.
4. Before this fix: the request is deleted. After this fix: 403 Forbidden.

*This was independently confirmed by @fallenbagel via API before review.*

## Screenshots / Logs (if applicable)

N/A -- backend-only change with no UI impact.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. (no documentation changes required for this fix)
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` (no new UI strings added)
- [x] Database migration (if required) (no schema changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened deletion authorization so requests can only be removed when allowed by status and ownership.
  * Ensured updates to movie requests are reliably persisted.

* **Tests**
  * Added end-to-end tests covering request deletion and update endpoints, including authorization and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->