### PR TITLE
fix(subscriber): await season status saves when approving TV requests

### DIFF
--- a/server/subscriber/MediaRequestSubscriber.test.ts
+++ b/server/subscriber/MediaRequestSubscriber.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
+import { MediaRequest } from '@server/entity/MediaRequest';
+import SeasonRequest from '@server/entity/SeasonRequest';
+import { User } from '@server/entity/User';
+import { setupTestDb } from '@server/test/db';
+
+import { MediaRequestSubscriber } from './MediaRequestSubscriber';
+
+setupTestDb();
+
+/** Creates a TV request with the given season numbers, owned by the given user. */
+async function createTvRequest(
+  requestedBy: User,
+  seasonNumbers: number[],
+  status = MediaRequestStatus.PENDING
+): Promise<MediaRequest> {
+  const mediaRepo = getRepository(Media);
+  const requestRepo = getRepository(MediaRequest);
+
+  let media = await mediaRepo.findOne({ where: { tmdbId: 77777 } });
+  if (!media) {
+    media = new Media();
+    media.tmdbId = 77777;
+    media.mediaType = MediaType.TV;
+    media.status = MediaStatus.PENDING;
+    await mediaRepo.save(media);
+  }
+
+  const mediaRequest = new MediaRequest({
+    media,
+    requestedBy,
+    status,
+    type: MediaType.TV,
+    is4k: false,
+    seasons: seasonNumbers.map(
+      (sn) => new SeasonRequest({ seasonNumber: sn, status })
+    ),
+  });
+
+  const saved = await requestRepo.save(mediaRequest);
+  // Reload so eager relations (seasons) include their DB-assigned IDs.
+  return requestRepo.findOneOrFail({ where: { id: saved.id } });
+}
+
+describe('MediaRequestSubscriber.updateParentStatus', () => {
+  it('persists APPROVED status to all child SeasonRequests in the database', async () => {
+    const userRepo = getRepository(User);
+    const requestRepo = getRepository(MediaRequest);
+
+    const user = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+    const mediaRequest = await createTvRequest(user, [1, 2, 3]);
+
+    mediaRequest.status = MediaRequestStatus.APPROVED;
+
+    const subscriber = new MediaRequestSubscriber();
+    await subscriber.updateParentStatus(mediaRequest);
+
+    // Re-fetch from DB to confirm the saves were awaited
+    const reloaded = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+
+    assert.strictEqual(reloaded.seasons.length, 3);
+    for (const season of reloaded.seasons) {
+      assert.strictEqual(
+        season.status,
+        MediaRequestStatus.APPROVED,
+        `Season ${season.seasonNumber} should be APPROVED`
+      );
+    }
+  });
+
+  it('persists DECLINED status to all child SeasonRequests in the database', async () => {
+    const userRepo = getRepository(User);
+    const requestRepo = getRepository(MediaRequest);
+
+    const user = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+    const mediaRequest = await createTvRequest(user, [1, 2]);
+
+    mediaRequest.status = MediaRequestStatus.DECLINED;
+
+    const subscriber = new MediaRequestSubscriber();
+    await subscriber.updateParentStatus(mediaRequest);
+
+    const reloaded = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+
+    assert.strictEqual(reloaded.seasons.length, 2);
+    for (const season of reloaded.seasons) {
+      assert.strictEqual(
+        season.status,
+        MediaRequestStatus.DECLINED,
+        `Season ${season.seasonNumber} should be DECLINED`
+      );
+    }
+  });
+});

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -936,10 +936,10 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       media.mediaType === MediaType.TV &&
       entity.status === MediaRequestStatus.APPROVED
     ) {
-      entity.seasons.forEach((season) => {
+      for (const season of entity.seasons) {
         season.status = MediaRequestStatus.APPROVED;
-        seasonRequestRepository.save(season);
-      });
+        await seasonRequestRepository.save(season);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

When a TV `MediaRequest` is approved, `updateParentStatus` iterates its `SeasonRequest` children and marks each one `APPROVED`. The saves were issued via `forEach` without `await`, making them fire-and-forget. Anything reading season statuses immediately after approval -- notification logic, media status checks -- could observe stale `PENDING` values.

The **declined path in the same function already does this correctly** using `for...of` with `await`. The approved path was inconsistent with it.

**Before:**
```ts
entity.seasons.forEach((season) => {
  season.status = MediaRequestStatus.APPROVED;
  seasonRequestRepository.save(season); // unawaited
});
```

**After (matching the pattern used in the declined branch):**
```ts
for (const season of entity.seasons) {
  season.status = MediaRequestStatus.APPROVED;
  await seasonRequestRepository.save(season);
}
```

**AI Disclosure:** I used Claude Code to help write the tests. I reviewed and understood all generated code before submitting.

## How Has This Been Tested?

Integration tests at `server/subscriber/MediaRequestSubscriber.test.ts` using the real SQLite test database via `setupTestDb()`.

Tests:
- `updateParentStatus` -- persists `APPROVED` status to all child `SeasonRequest` rows in the database (regression guard for the unawaited save)
- `updateParentStatus` -- persists `DECLINED` status to all child `SeasonRequest` rows (regression guard for the already-correct declined path)

**To reproduce the bug manually:**
1. Create a TV show request spanning multiple seasons.
2. Approve the request via the admin panel or `PUT /api/v1/request/:id/approve`.
3. Immediately fetch the request and inspect `seasons[].status`.
4. Before this fix: season statuses may still read `PENDING` due to unawaited saves racing with the response.
5. After this fix: all season requests reliably reflect `APPROVED`.

## Screenshots / Logs (if applicable)

N/A -- backend-only change with no UI impact.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. (no documentation changes required for this fix)
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` (no new UI strings added)
- [x] Database migration (if required) (no schema changes)
