### PR TITLE
fix(subscriber): await async calls in MediaSubscriber lifecycle hooks

### DIFF
--- a/server/subscriber/MediaSubscriber.test.ts
+++ b/server/subscriber/MediaSubscriber.test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
+import { MediaRequest } from '@server/entity/MediaRequest';
+import { User } from '@server/entity/User';
+import { setupTestDb } from '@server/test/db';
+
+setupTestDb();
+
+async function createMedia(
+  status: MediaStatus,
+  mediaType = MediaType.MOVIE
+): Promise<Media> {
+  const mediaRepo = getRepository(Media);
+  const media = new Media();
+  media.tmdbId = Math.floor(Math.random() * 900000) + 100000;
+  media.mediaType = mediaType;
+  media.status = status;
+  return mediaRepo.save(media);
+}
+
+async function createMovieRequest(
+  requestedBy: User,
+  media: Media,
+  status: MediaRequestStatus
+): Promise<MediaRequest> {
+  const requestRepo = getRepository(MediaRequest);
+  const req = new MediaRequest({
+    media,
+    requestedBy,
+    status,
+    type: MediaType.MOVIE,
+    is4k: false,
+  });
+  return requestRepo.save(req);
+}
+
+describe('MediaSubscriber', () => {
+  /**
+   * Tests the beforeUpdate path: when media transitions PENDING → AVAILABLE,
+   * updateChildRequestStatus must be awaited so that PENDING requests are
+   * promoted to APPROVED before the save completes. afterUpdate then sees
+   * those APPROVED requests and marks them COMPLETED.
+   *
+   * Without await on updateChildRequestStatus, afterUpdate may read the
+   * request before the status change is committed and leave it PENDING.
+   */
+  it('processes a PENDING request to COMPLETED when media transitions PENDING -> AVAILABLE', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const user = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    // Create media in PENDING state with a matching PENDING request
+    const media = await createMedia(MediaStatus.PENDING);
+    const mediaRequest = await createMovieRequest(
+      user,
+      media,
+      MediaRequestStatus.PENDING
+    );
+
+    // Transition PENDING → AVAILABLE.
+    // beforeUpdate auto-approves the PENDING request (updateChildRequestStatus).
+    // afterUpdate then marks the APPROVED request COMPLETED (updateRelatedMediaRequest).
+    // Both calls must be awaited for the final COMPLETED state to be visible.
+    media.status = MediaStatus.AVAILABLE;
+    await mediaRepo.save(media);
+
+    const reloaded = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.strictEqual(reloaded.status, MediaRequestStatus.COMPLETED);
+  });
+
+  /**
+   * Tests the afterUpdate path: when media transitions PROCESSING → AVAILABLE,
+   * updateRelatedMediaRequest must be awaited so that APPROVED requests are
+   * marked COMPLETED before the save returns.
+   */
+  it('marks an APPROVED request COMPLETED when media transitions PROCESSING -> AVAILABLE', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const user = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    // PROCESSING means beforeUpdate does not fire (was not PENDING)
+    const media = await createMedia(MediaStatus.PROCESSING);
+    const mediaRequest = await createMovieRequest(
+      user,
+      media,
+      MediaRequestStatus.APPROVED
+    );
+
+    media.status = MediaStatus.AVAILABLE;
+    await mediaRepo.save(media);
+
+    const reloaded = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.strictEqual(reloaded.status, MediaRequestStatus.COMPLETED);
+  });
+
+  it('marks a FAILED request COMPLETED when media transitions PROCESSING -> AVAILABLE', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const user = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    const media = await createMedia(MediaStatus.PROCESSING);
+    const mediaRequest = await createMovieRequest(
+      user,
+      media,
+      MediaRequestStatus.FAILED
+    );
+
+    media.status = MediaStatus.AVAILABLE;
+    await mediaRepo.save(media);
+
+    const reloaded = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.strictEqual(reloaded.status, MediaRequestStatus.COMPLETED);
+  });
+});

--- a/server/subscriber/MediaSubscriber.test.ts
+++ b/server/subscriber/MediaSubscriber.test.ts
@@ -16,20 +16,23 @@ setupTestDb();
 
 async function createMedia(
   status: MediaStatus,
-  mediaType = MediaType.MOVIE
+  mediaType = MediaType.MOVIE,
+  status4k = MediaStatus.UNKNOWN
 ): Promise<Media> {
   const mediaRepo = getRepository(Media);
   const media = new Media();
   media.tmdbId = Math.floor(Math.random() * 900000) + 100000;
   media.mediaType = mediaType;
   media.status = status;
+  media.status4k = status4k;
   return mediaRepo.save(media);
 }
 
 async function createMovieRequest(
   requestedBy: User,
   media: Media,
-  status: MediaRequestStatus
+  status: MediaRequestStatus,
+  is4k = false
 ): Promise<MediaRequest> {
   const requestRepo = getRepository(MediaRequest);
   const req = new MediaRequest({
@@ -37,7 +40,7 @@ async function createMovieRequest(
     requestedBy,
     status,
     type: MediaType.MOVIE,
-    is4k: false,
+    is4k,
   });
   return requestRepo.save(req);
 }
@@ -61,7 +64,6 @@ describe('MediaSubscriber', () => {
       where: { email: 'admin@seerr.dev' },
     });
 
-    // Create media in PENDING state with a matching PENDING request
     const media = await createMedia(MediaStatus.PENDING);
     const mediaRequest = await createMovieRequest(
       user,
@@ -69,11 +71,39 @@ describe('MediaSubscriber', () => {
       MediaRequestStatus.PENDING
     );
 
-    // Transition PENDING → AVAILABLE.
-    // beforeUpdate auto-approves the PENDING request (updateChildRequestStatus).
-    // afterUpdate then marks the APPROVED request COMPLETED (updateRelatedMediaRequest).
-    // Both calls must be awaited for the final COMPLETED state to be visible.
+    // beforeUpdate auto-approves PENDING request; afterUpdate marks it COMPLETED
     media.status = MediaStatus.AVAILABLE;
+    await mediaRepo.save(media);
+
+    const reloaded = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.strictEqual(reloaded.status, MediaRequestStatus.COMPLETED);
+  });
+
+  it('processes a PENDING 4K request to COMPLETED when media 4K status transitions PENDING -> AVAILABLE', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const user = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    // status stays UNKNOWN; only status4k goes PENDING → AVAILABLE
+    const media = await createMedia(
+      MediaStatus.UNKNOWN,
+      MediaType.MOVIE,
+      MediaStatus.PENDING
+    );
+    const mediaRequest = await createMovieRequest(
+      user,
+      media,
+      MediaRequestStatus.PENDING,
+      true
+    );
+
+    media.status4k = MediaStatus.AVAILABLE;
     await mediaRepo.save(media);
 
     const reloaded = await requestRepo.findOneOrFail({
@@ -105,6 +135,36 @@ describe('MediaSubscriber', () => {
     );
 
     media.status = MediaStatus.AVAILABLE;
+    await mediaRepo.save(media);
+
+    const reloaded = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.strictEqual(reloaded.status, MediaRequestStatus.COMPLETED);
+  });
+
+  it('marks an APPROVED 4K request COMPLETED when media 4K status transitions PROCESSING -> AVAILABLE', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const user = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    const media = await createMedia(
+      MediaStatus.UNKNOWN,
+      MediaType.MOVIE,
+      MediaStatus.PROCESSING
+    );
+    const mediaRequest = await createMovieRequest(
+      user,
+      media,
+      MediaRequestStatus.APPROVED,
+      true
+    );
+
+    media.status4k = MediaStatus.AVAILABLE;
     await mediaRepo.save(media);
 
     const reloaded = await requestRepo.findOneOrFail({

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -3,18 +3,25 @@ import {
   MediaStatus,
   MediaType,
 } from '@server/constants/media';
-import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
-import type { EntitySubscriberInterface, UpdateEvent } from 'typeorm';
+import type {
+  EntityManager,
+  EntitySubscriberInterface,
+  UpdateEvent,
+} from 'typeorm';
 import { EventSubscriber, In } from 'typeorm';
 
 @EventSubscriber()
 export class MediaSubscriber implements EntitySubscriberInterface<Media> {
-  private async updateChildRequestStatus(event: Media, is4k: boolean) {
-    const requestRepository = getRepository(MediaRequest);
+  private async updateChildRequestStatus(
+    manager: EntityManager,
+    event: Media,
+    is4k: boolean
+  ) {
+    const requestRepository = manager.getRepository(MediaRequest);
 
     const requests = await requestRepository.find({
       where: { media: { id: event.id } },
@@ -32,12 +39,13 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
   }
 
   private async updateRelatedMediaRequest(
+    manager: EntityManager,
     event: Media,
     databaseEvent: Media,
     is4k: boolean
   ) {
-    const requestRepository = getRepository(MediaRequest);
-    const seasonRequestRepository = getRepository(SeasonRequest);
+    const requestRepository = manager.getRepository(MediaRequest);
+    const seasonRequestRepository = manager.getRepository(SeasonRequest);
 
     const relatedRequests = await requestRepository.find({
       relations: {
@@ -130,14 +138,22 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
       event.entity.status === MediaStatus.AVAILABLE &&
       event.databaseEntity.status === MediaStatus.PENDING
     ) {
-      await this.updateChildRequestStatus(event.entity as Media, false);
+      await this.updateChildRequestStatus(
+        event.manager,
+        event.entity as Media,
+        false
+      );
     }
 
     if (
       event.entity.status4k === MediaStatus.AVAILABLE &&
       event.databaseEntity.status4k === MediaStatus.PENDING
     ) {
-      await this.updateChildRequestStatus(event.entity as Media, true);
+      await this.updateChildRequestStatus(
+        event.manager,
+        event.entity as Media,
+        true
+      );
     }
 
     // Manually load related seasons into databaseEntity
@@ -181,6 +197,7 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
       validStatuses.includes(event.entity.status)
     ) {
       await this.updateRelatedMediaRequest(
+        event.manager,
         event.entity as Media,
         event.databaseEntity as Media,
         false
@@ -193,6 +210,7 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
       validStatuses.includes(event.entity.status4k)
     ) {
       await this.updateRelatedMediaRequest(
+        event.manager,
         event.entity as Media,
         event.databaseEntity as Media,
         true

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -130,14 +130,14 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
       event.entity.status === MediaStatus.AVAILABLE &&
       event.databaseEntity.status === MediaStatus.PENDING
     ) {
-      this.updateChildRequestStatus(event.entity as Media, false);
+      await this.updateChildRequestStatus(event.entity as Media, false);
     }
 
     if (
       event.entity.status4k === MediaStatus.AVAILABLE &&
       event.databaseEntity.status4k === MediaStatus.PENDING
     ) {
-      this.updateChildRequestStatus(event.entity as Media, true);
+      await this.updateChildRequestStatus(event.entity as Media, true);
     }
 
     // Manually load related seasons into databaseEntity
@@ -180,7 +180,7 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
           seasonStatusCheck(false))) &&
       validStatuses.includes(event.entity.status)
     ) {
-      this.updateRelatedMediaRequest(
+      await this.updateRelatedMediaRequest(
         event.entity as Media,
         event.databaseEntity as Media,
         false
@@ -192,7 +192,7 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
         (event.entity.mediaType === MediaType.TV && seasonStatusCheck(true))) &&
       validStatuses.includes(event.entity.status4k)
     ) {
-      this.updateRelatedMediaRequest(
+      await this.updateRelatedMediaRequest(
         event.entity as Media,
         event.databaseEntity as Media,
         true

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -18,14 +18,16 @@ import { EventSubscriber, In } from 'typeorm';
 export class MediaSubscriber implements EntitySubscriberInterface<Media> {
   private async updateChildRequestStatus(
     manager: EntityManager,
-    event: Media,
+    media: Media,
     is4k: boolean
   ) {
     const requestRepository = manager.getRepository(MediaRequest);
 
     const requests = await requestRepository.find({
-      where: { media: { id: event.id } },
+      where: { media: { id: media.id } },
     });
+
+    const toSave: MediaRequest[] = [];
 
     for (const request of requests) {
       if (
@@ -33,8 +35,12 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
         request.status === MediaRequestStatus.PENDING
       ) {
         request.status = MediaRequestStatus.APPROVED;
-        await requestRepository.save(request);
+        toSave.push(request);
       }
+    }
+
+    if (toSave.length > 0) {
+      await requestRepository.save(toSave);
     }
   }
 


### PR DESCRIPTION
## Description

`MediaSubscriber.beforeUpdate` called `updateChildRequestStatus` without `await`, and `afterUpdate` called `updateRelatedMediaRequest` without `await`. This created a race condition where the subscriber lifecycle could return before the related `MediaRequest` status changes were committed to the database -- leaving requests stuck in `PENDING` or `APPROVED` instead of being promoted to `COMPLETED` when media became available.

A second, related issue: both helpers resolved their repositories via the global `getRepository()` from `@server/datasource` rather than the transaction-scoped `event.manager`. This meant their writes executed outside the event's unit of work. If the outer `Media` save failed after those writes committed, `MediaRequest` and `SeasonRequest` rows could diverge from their parent media state.

**Fix:**
- Added `await` to both `updateChildRequestStatus` and `updateRelatedMediaRequest` call sites in `beforeUpdate` and `afterUpdate`
- Changed both helper signatures to accept `EntityManager` as their first parameter, passing `event.manager` from the subscriber
- Removed the now-unused `getRepository` import from `@server/datasource`
- Renamed the `event` parameter to `media` in `updateChildRequestStatus` for clarity
- Batch-save changed `MediaRequest` rows in `updateChildRequestStatus` instead of one save per loop iteration

**AI Disclosure:** I used Claude Code to help write the tests and validate the approach. I reviewed and understood all generated code before submitting.

## How Has This Been Tested?

Integration tests at `server/subscriber/MediaSubscriber.test.ts` using the real SQLite test database via `setupTestDb()`, covering both standard and 4K request paths.

Tests:
- `PENDING` request is promoted to `COMPLETED` when media transitions `PENDING -> AVAILABLE`
- `PENDING` 4K request is promoted to `COMPLETED` when media 4K status transitions `PENDING -> AVAILABLE`
- `APPROVED` request is marked `COMPLETED` when media transitions `PROCESSING -> AVAILABLE`
- `APPROVED` 4K request is marked `COMPLETED` when media 4K status transitions `PROCESSING -> AVAILABLE`
- `FAILED` request is marked `COMPLETED` when media transitions `PROCESSING -> AVAILABLE`

## Screenshots / Logs (if applicable)

N/A -- backend-only change with no UI impact.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. (no documentation changes required for this fix)
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` (no new UI strings added)
- [x] Database migration (if required) (no schema changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for media request status updates across availability transitions.

* **Refactor**
  * Improved internal database transaction handling for media status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->