### PR TITLE
fix(helm): configure liveness and readiness probes to match Docker defaults

### DIFF
--- a/charts/seerr-chart/Chart.yaml
+++ b/charts/seerr-chart/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: '>=1.23.0-0'
 name: seerr-chart
 description: Seerr helm chart for Kubernetes
 type: application
-version: 3.3.0
+version: 3.3.1
 # renovate: image=ghcr.io/seerr-team/seerr
 appVersion: 'v3.1.0'
 maintainers:

--- a/charts/seerr-chart/README.md
+++ b/charts/seerr-chart/README.md
@@ -1,6 +1,6 @@
 # seerr-chart
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.1.0](https://img.shields.io/badge/AppVersion-v3.1.0-informational?style=flat-square)
+![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.1.0](https://img.shields.io/badge/AppVersion-v3.1.0-informational?style=flat-square)
 
 Seerr helm chart for Kubernetes
 
@@ -73,8 +73,8 @@ If `replicaCount` value was used - remove it. Helm update should work fine after
 | podLabels | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` |  |
-| probes.livenessProbe | object | `{}` | Configure liveness probe |
-| probes.readinessProbe | object | `{}` | Configure readiness probe |
+| probes.livenessProbe | object | `{"initialDelaySeconds":20,"periodSeconds":15,"timeoutSeconds":3}` | Configure liveness probe |
+| probes.readinessProbe | object | `{"initialDelaySeconds":60,"periodSeconds":15,"timeoutSeconds":3}` | Configure readiness probe |
 | probes.startupProbe | string | `nil` | Configure startup probe |
 | resources | object | `{}` |  |
 | route.main.additionalRules | list | `[]` |  |

--- a/charts/seerr-chart/templates/statefulset.yaml
+++ b/charts/seerr-chart/templates/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/v1/status
               port: http
             {{- if .Values.probes.livenessProbe.initialDelaySeconds }}
             initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
@@ -63,7 +63,7 @@ spec:
             {{- end }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/v1/status
               port: http
             {{- if .Values.probes.readinessProbe.initialDelaySeconds }}
             initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}

--- a/charts/seerr-chart/values.yaml
+++ b/charts/seerr-chart/values.yaml
@@ -13,19 +13,19 @@ fullnameOverride: ''
 # Liveness / Readiness / Startup Probes
 probes:
   # -- Configure liveness probe
-  livenessProbe: {}
-  # initialDelaySeconds: 60
-  # periodSeconds: 30
-  # timeoutSeconds: 5
-  # successThreshold: 1
-  # failureThreshold: 5
+  livenessProbe:
+    initialDelaySeconds: 20
+    periodSeconds: 15
+    timeoutSeconds: 3
+    # successThreshold: 1
+    # failureThreshold: 3
   # -- Configure readiness probe
-  readinessProbe: {}
-  # initialDelaySeconds: 60
-  # periodSeconds: 30
-  # timeoutSeconds: 5
-  # successThreshold: 1
-  # failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 15
+    timeoutSeconds: 3
+    # successThreshold: 1
+    # failureThreshold: 3
   # -- Configure startup probe
   startupProbe: null
   #  tcpSocket:


### PR DESCRIPTION
## Description

Switches liveness and readiness endpoint to `/api/v1/status` to avoid unnecessary redirect chains and reduce load/noise, matching the documented docker healthcheck.

Set sensible default probe values in values.yaml to match the docker documentation defaults:
livenessProbe: initialDelaySeconds=20, periodSeconds=15, timeoutSeconds=3
readinessProbe: initialDelaySeconds=60, periodSeconds=15, timeoutSeconds=3

- Fixes #2754

## How Has This Been Tested?

Rolled out the chart in my k8s cluster.

## Screenshots / Logs (if applicable)

<img width="1973" height="1147" alt="image" src="https://github.com/user-attachments/assets/ded19140-249e-46bd-badc-084681978de8" />

Rollout around 21:45.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart to version 3.3.1 with improved health probe configuration.
  * Configured explicit timing parameters for liveness and readiness probes to enhance deployment reliability.
  * Updated probe endpoints for more accurate health status monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->