### PR TITLE
docs(docker): Fix path in migration guide to update permissions

### DIFF
--- a/docs/migration-guide.mdx
+++ b/docs/migration-guide.mdx
@@ -55,7 +55,7 @@ Since the container now runs as the `node` user (UID 1000), you must ensure your
 If you're migrating from a previous installation, you may need to update the ownership of your config folder:
 
 ```bash
-docker run --rm -v /path/to/appdata/config:/data alpine chown -R 1000:1000 /data
+docker run --rm -v /path/to/appdata/config:/app/config alpine chown -R 1000:1000 /app/config
 ```
 
 This ensures the `node` user (UID 1000) owns the config directory and can read and write to it.


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The suggested command was pointing to `/data` instead of `/app/config`. 

While the user should check the command anyway to replace `/path/to/appdata/config`, leaving `/data` as the destination is confusing.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker CLI example in the migration guide with corrected configuration directory paths and ownership settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->