### PR TITLE
fix: await missing repository saves

### DIFF
--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -512,7 +512,7 @@ requestRoutes.put<{ requestId: string }>(
         request.tags = req.body.tags;
         request.requestedBy = requestUser as User;
 
-        requestRepository.save(request);
+        await requestRepository.save(request);
       } else if (req.body.mediaType === MediaType.TV) {
         const mediaRepository = getRepository(Media);
         request.serverId = req.body.serverId;

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -617,7 +617,7 @@ userSettingsRoutes.post<{ id: string }, UserSettingsNotificationsResponse>(
         );
       }
 
-      userRepository.save(user);
+      await userRepository.save(user);
 
       return res.status(200).json({
         pgpKey: user.settings.pgpKey,

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -936,10 +936,10 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       media.mediaType === MediaType.TV &&
       entity.status === MediaRequestStatus.APPROVED
     ) {
-      entity.seasons.forEach((season) => {
+      for (const season of entity.seasons) {
         season.status = MediaRequestStatus.APPROVED;
-        seasonRequestRepository.save(season);
-      });
+        await seasonRequestRepository.save(season);
+      }
     }
   }
 


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

While working on something, I noticed the movie branch was calling `save()` without a proper `await`.

After fixing that, I did a quick grep for other `Repository.save` usages to make sure they were properly awaited (or intentionally handled with something like `Promise.all`).

I might've missed a few spots, but this should cover the obvious ones.

- Fixes #XXXX

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data persistence issues affecting media request submissions, user notification preferences, and status management. All database operations now complete fully before confirming changes, improving reliability and preventing potential data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->