### PR TITLE
refactor: extract hardcoded route paths into shared constants

### DIFF
--- a/server/constants/routes.ts
+++ b/server/constants/routes.ts
@@ -1,0 +1,4 @@
+export const API_BASE_PATH = '/api/v1';
+export const API_DOCS_PATH = '/api-docs';
+export const IMAGE_PROXY_PATH = '/imageproxy';
+export const AVATAR_PROXY_PATH = '/avatarproxy';

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,11 @@
 import csurf from '@dr.pogodin/csurf';
 import PlexAPI from '@server/api/plexapi';
+import {
+  API_BASE_PATH,
+  API_DOCS_PATH,
+  AVATAR_PROXY_PATH,
+  IMAGE_PROXY_PATH,
+} from '@server/constants/routes';
 import dataSource, { getRepository, isPgsql } from '@server/datasource';
 import DiscoverSlider from '@server/entity/DiscoverSlider';
 import { Session } from '@server/entity/Session';
@@ -219,7 +225,7 @@ app
       })
     );
     const apiDocs = YAML.load(API_SPEC_PATH);
-    server.use('/api-docs', swaggerUi.serve, swaggerUi.setup(apiDocs));
+    server.use(API_DOCS_PATH, swaggerUi.serve, swaggerUi.setup(apiDocs));
     server.use(
       OpenApiValidator.middleware({
         apiSpec: API_SPEC_PATH,
@@ -238,11 +244,11 @@ app
       };
       next();
     });
-    server.use('/api/v1', routes);
+    server.use(API_BASE_PATH, routes);
 
     // Do not set cookies so CDNs can cache them
-    server.use('/imageproxy', clearCookies, imageproxy);
-    server.use('/avatarproxy', clearCookies, avatarproxy);
+    server.use(IMAGE_PROXY_PATH, clearCookies, imageproxy);
+    server.use(AVATAR_PROXY_PATH, clearCookies, avatarproxy);
 
     server.get('*', (req, res) => handle(req, res));
     server.use(

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -5,6 +5,7 @@ import type {
   TmdbMovieResult,
   TmdbTvResult,
 } from '@server/api/themoviedb/interfaces';
+import { API_BASE_PATH } from '@server/constants/routes';
 import { getRepository } from '@server/datasource';
 import DiscoverSlider from '@server/entity/DiscoverSlider';
 import type { StatusResponse } from '@server/interfaces/api/settingsInterfaces';
@@ -157,8 +158,8 @@ router.use(
   '/blacklist',
   isAuthenticated(),
   deprecatedRoute({
-    oldPath: '/api/v1/blacklist',
-    newPath: '/api/v1/blocklist',
+    oldPath: `${API_BASE_PATH}/blacklist`,
+    newPath: `${API_BASE_PATH}/blocklist`,
     sunsetDate: '2026-06-01',
   }),
   blocklistRoutes

--- a/src/components/AppDataWarning/index.tsx
+++ b/src/components/AppDataWarning/index.tsx
@@ -1,4 +1,5 @@
 import Alert from '@app/components/Common/Alert';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { useIntl } from 'react-intl';
 import useSWR from 'swr';
@@ -11,7 +12,7 @@ const messages = defineMessages('components.AppDataWarning', {
 const AppDataWarning = () => {
   const intl = useIntl();
   const { data, error } = useSWR<{ appData: boolean; appDataPath: string }>(
-    '/api/v1/status/appdata'
+    apiUrl('/status/appdata')
   );
 
   if (!data && !error) {

--- a/src/components/Blocklist/index.tsx
+++ b/src/components/Blocklist/index.tsx
@@ -11,6 +11,7 @@ import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import {
   ChevronLeftIcon,
@@ -76,11 +77,13 @@ const Blocklist = () => {
     error,
     mutate: revalidate,
   } = useSWR<BlocklistResultsResponse>(
-    `/api/v1/blocklist/?take=${currentPageSize}&skip=${
-      pageIndex * currentPageSize
-    }&filter=${currentFilter}${
-      debouncedSearchFilter ? `&search=${debouncedSearchFilter}` : ''
-    }`,
+    apiUrl(
+      `/blocklist?take=${currentPageSize}&skip=${
+        pageIndex * currentPageSize
+      }&filter=${currentFilter}${
+        debouncedSearchFilter ? `&search=${debouncedSearchFilter}` : ''
+      }`
+    ),
     {
       refreshInterval: 0,
       revalidateOnFocus: false,
@@ -281,8 +284,8 @@ const BlocklistedItem = ({ item, revalidateList }: BlocklistedItemProps) => {
 
   const url =
     item.mediaType === 'movie'
-      ? `/api/v1/movie/${item.tmdbId}`
-      : `/api/v1/tv/${item.tmdbId}`;
+      ? apiUrl(`/movie/${item.tmdbId}`)
+      : apiUrl(`/tv/${item.tmdbId}`);
   const { data: title, error } = useSWR<MovieDetails | TvDetails>(
     inView ? url : null
   );
@@ -301,7 +304,7 @@ const BlocklistedItem = ({ item, revalidateList }: BlocklistedItemProps) => {
 
     try {
       await axios.delete(
-        `/api/v1/blocklist/${tmdbId}?mediaType=${item.mediaType}`
+        apiUrl(`/blocklist/${tmdbId}?mediaType=${item.mediaType}`)
       );
 
       addToast(

--- a/src/components/BlocklistBlock/index.tsx
+++ b/src/components/BlocklistBlock/index.tsx
@@ -5,6 +5,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import Tooltip from '@app/components/Common/Tooltip';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { CalendarIcon, TrashIcon, UserIcon } from '@heroicons/react/24/solid';
 import type { MediaType } from '@server/constants/media';
@@ -39,14 +40,14 @@ const BlocklistBlock = ({
   const [isUpdating, setIsUpdating] = useState(false);
   const { addToast } = useToasts();
   const { data } = useSWR<Blocklist>(
-    `/api/v1/blocklist/${tmdbId}?mediaType=${mediaType}`
+    apiUrl(`/blocklist/${tmdbId}?mediaType=${mediaType}`)
   );
 
   const removeFromBlocklist = async (tmdbId: number, title?: string) => {
     setIsUpdating(true);
 
     try {
-      await axios.delete(`/api/v1/blocklist/${tmdbId}?mediaType=${mediaType}`);
+      await axios.delete(apiUrl(`/blocklist/${tmdbId}?mediaType=${mediaType}`));
 
       addToast(
         <span>

--- a/src/components/BlocklistModal/index.tsx
+++ b/src/components/BlocklistModal/index.tsx
@@ -1,5 +1,6 @@
 import Modal from '@app/components/Common/Modal';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 
@@ -59,7 +60,7 @@ const BlocklistModal = ({
       if (!show) return;
       try {
         setError(null);
-        const response = await axios.get(`/api/v1/${type}/${tmdbId}`);
+        const response = await axios.get(apiUrl(`/${type}/${tmdbId}`));
         setData(response.data);
       } catch (err) {
         setError(err);

--- a/src/components/BlocklistedTagsBadge/index.tsx
+++ b/src/components/BlocklistedTagsBadge/index.tsx
@@ -1,5 +1,6 @@
 import Badge from '@app/components/Common/Badge';
 import Tooltip from '@app/components/Common/Tooltip';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { TagIcon } from '@heroicons/react/20/solid';
 import type { BlocklistItem } from '@server/interfaces/api/blocklistInterfaces';
@@ -30,7 +31,7 @@ const BlocklistedTagsBadge = ({ data }: BlocklistedTagsBadgeProps) => {
     Promise.all(
       keywordIds.map(async (keywordId) => {
         const { data } = await axios.get<Keyword | null>(
-          `/api/v1/keyword/${keywordId}`
+          apiUrl(`/keyword/${keywordId}`)
         );
         return data?.name || `[Invalid: ${keywordId}]`;
       })

--- a/src/components/BlocklistedTagsSelector/index.tsx
+++ b/src/components/BlocklistedTagsSelector/index.tsx
@@ -2,6 +2,7 @@ import Modal from '@app/components/Common/Modal';
 import Tooltip from '@app/components/Common/Tooltip';
 import CopyButton from '@app/components/Settings/CopyButton';
 import { encodeURIExtraParams } from '@app/hooks/useDiscover';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import { ArrowDownIcon } from '@heroicons/react/24/solid';
@@ -128,7 +129,7 @@ const ControlledKeywordSelector = ({
       const keywords = await Promise.all(
         defaultValue.split(',').map(async (keywordId) => {
           const { data } = await axios.get<Keyword | null>(
-            `/api/v1/keyword/${keywordId}`
+            apiUrl(`/keyword/${keywordId}`)
           );
           return data;
         })
@@ -151,7 +152,7 @@ const ControlledKeywordSelector = ({
 
   const loadKeywordOptions = async (inputValue: string) => {
     const { data } = await axios.get<TmdbKeywordSearchResponse>(
-      `/api/v1/search/keyword?query=${encodeURIExtraParams(inputValue)}`
+      apiUrl(`/search/keyword?query=${encodeURIExtraParams(inputValue)}`)
     );
 
     return data.results.map((result) => ({
@@ -270,7 +271,7 @@ const BlocklistedTagImportForm = forwardRef<
       formValue.split(',').map(async (keywordId) => {
         try {
           const { data } = await axios.get<Keyword>(
-            `/api/v1/keyword/${keywordId}`
+            apiUrl(`/keyword/${keywordId}`)
           );
           return {
             label: data.name,

--- a/src/components/CollectionDetails/index.tsx
+++ b/src/components/CollectionDetails/index.tsx
@@ -13,6 +13,7 @@ import useSettings from '@app/hooks/useSettings';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
 import {
@@ -72,7 +73,7 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR<Collection>(`/api/v1/collection/${router.query.collectionId}`, {
+  } = useSWR<Collection>(apiUrl(`/collection/${router.query.collectionId}`), {
     fallbackData: collection,
     revalidateOnMount: true,
     refreshInterval: refreshIntervalHelper(
@@ -81,8 +82,9 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
     ),
   });
 
-  const { data: genres } =
-    useSWR<{ id: number; name: string }[]>(`/api/v1/genres/movie`);
+  const { data: genres } = useSWR<{ id: number; name: string }[]>(
+    apiUrl(`/genres/movie`)
+  );
 
   const onClickHideItemBtn = async (): Promise<void> => {
     setIsBlocklistUpdating(true);

--- a/src/components/Common/CachedImage/index.tsx
+++ b/src/components/Common/CachedImage/index.tsx
@@ -1,4 +1,5 @@
 import useSettings from '@app/hooks/useSettings';
+import { IMAGE_PROXY_PATH } from '@server/constants/routes';
 import type { ImageLoader, ImageProps } from 'next/image';
 import Image from 'next/image';
 
@@ -22,14 +23,17 @@ const CachedImage = ({ src, type, ...props }: CachedImageProps) => {
     // tmdb stuff
     imageUrl =
       currentSettings.cacheImages && !src.startsWith('/')
-        ? src.replace(/^https:\/\/image\.tmdb\.org\//, '/imageproxy/tmdb/')
+        ? src.replace(
+            /^https:\/\/image\.tmdb\.org\//,
+            `${IMAGE_PROXY_PATH}/tmdb/`
+          )
         : src;
   } else if (type === 'tvdb') {
     imageUrl =
       currentSettings.cacheImages && !src.startsWith('/')
         ? src.replace(
             /^https:\/\/artworks\.thetvdb\.com\//,
-            '/imageproxy/tvdb/'
+            `${IMAGE_PROXY_PATH}/tvdb/`
           )
         : src;
   } else if (type === 'avatar') {

--- a/src/components/CompanyTag/index.tsx
+++ b/src/components/CompanyTag/index.tsx
@@ -1,5 +1,6 @@
 import Spinner from '@app/assets/spinner.svg';
 import Tag from '@app/components/Common/Tag';
+import { apiUrl } from '@app/utils/apiUrl';
 import { BuildingOffice2Icon } from '@heroicons/react/24/outline';
 import type { ProductionCompany, TvNetwork } from '@server/models/common';
 import useSWR from 'swr';
@@ -11,7 +12,7 @@ type CompanyTagProps = {
 
 const CompanyTag = ({ companyId, type }: CompanyTagProps) => {
   const { data, error } = useSWR<TvNetwork | ProductionCompany>(
-    `/api/v1/${type}/${companyId}`
+    apiUrl(`/${type}/${companyId}`)
   );
 
   if (!data && !error) {

--- a/src/components/Discover/CreateSlider/index.tsx
+++ b/src/components/Discover/CreateSlider/index.tsx
@@ -4,6 +4,7 @@ import { sliderTitles } from '@app/components/Discover/constants';
 import MediaSlider from '@app/components/MediaSlider';
 import { WatchProviderSelector } from '@app/components/Selector';
 import { encodeURIExtraParams } from '@app/hooks/useDiscover';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type {
   TmdbCompanySearchResponse,
@@ -78,7 +79,7 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
         const keywords = await Promise.all(
           slider.data.split(',').map(async (keywordId) => {
             const keyword = await axios.get<Keyword | null>(
-              `/api/v1/keyword/${keywordId}`
+              apiUrl(`/keyword/${keywordId}`)
             );
             return keyword.data;
           })
@@ -102,9 +103,13 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
         }
 
         const response = await axios.get<TmdbGenre[]>(
-          `/api/v1/genres/${
-            slider.type === DiscoverSliderType.TMDB_MOVIE_GENRE ? 'movie' : 'tv'
-          }`
+          apiUrl(
+            `/genres/${
+              slider.type === DiscoverSliderType.TMDB_MOVIE_GENRE
+                ? 'movie'
+                : 'tv'
+            }`
+          )
         );
 
         const genre = response.data.find(
@@ -125,7 +130,7 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
         }
 
         const response = await axios.get<ProductionCompany>(
-          `/api/v1/studio/${slider.data}`
+          apiUrl(`/studio/${slider.data}`)
         );
 
         const studio = response.data;
@@ -172,7 +177,7 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
 
   const loadKeywordOptions = async (inputValue: string) => {
     const results = await axios.get<TmdbKeywordSearchResponse>(
-      '/api/v1/search/keyword',
+      apiUrl('/search/keyword'),
       {
         params: {
           query: encodeURIExtraParams(inputValue),
@@ -192,7 +197,7 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
     }
 
     const results = await axios.get<TmdbCompanySearchResponse>(
-      '/api/v1/search/company',
+      apiUrl('/search/company'),
       {
         params: {
           query: encodeURIExtraParams(inputValue),
@@ -208,7 +213,7 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
 
   const loadMovieGenreOptions = async () => {
     const results = await axios.get<GenreSliderItem[]>(
-      '/api/v1/discover/genreslider/movie'
+      apiUrl('/discover/genreslider/movie')
     );
 
     return results.data.map((result) => ({
@@ -219,7 +224,7 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
 
   const loadTvGenreOptions = async () => {
     const results = await axios.get<GenreSliderItem[]>(
-      '/api/v1/discover/genreslider/tv'
+      apiUrl('/discover/genreslider/tv')
     );
 
     return results.data.map((result) => ({
@@ -232,7 +237,7 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
     {
       type: DiscoverSliderType.TMDB_MOVIE_KEYWORD,
       title: intl.formatMessage(sliderTitles.tmdbmoviekeyword),
-      dataUrl: '/api/v1/discover/movies',
+      dataUrl: apiUrl('/discover/movies'),
       params: 'keywords=$value',
       titlePlaceholderText: intl.formatMessage(messages.slidernameplaceholder),
       dataPlaceholderText: intl.formatMessage(messages.providetmdbkeywordid),
@@ -240,7 +245,7 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
     {
       type: DiscoverSliderType.TMDB_TV_KEYWORD,
       title: intl.formatMessage(sliderTitles.tmdbtvkeyword),
-      dataUrl: '/api/v1/discover/tv',
+      dataUrl: apiUrl('/discover/tv'),
       params: 'keywords=$value',
       titlePlaceholderText: intl.formatMessage(messages.slidernameplaceholder),
       dataPlaceholderText: intl.formatMessage(messages.providetmdbkeywordid),
@@ -248,35 +253,35 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
     {
       type: DiscoverSliderType.TMDB_MOVIE_GENRE,
       title: intl.formatMessage(sliderTitles.tmdbmoviegenre),
-      dataUrl: '/api/v1/discover/movies/genre/$value',
+      dataUrl: apiUrl('/discover/movies/genre/$value'),
       titlePlaceholderText: intl.formatMessage(messages.slidernameplaceholder),
       dataPlaceholderText: intl.formatMessage(messages.providetmdbgenreid),
     },
     {
       type: DiscoverSliderType.TMDB_TV_GENRE,
       title: intl.formatMessage(sliderTitles.tmdbtvgenre),
-      dataUrl: '/api/v1/discover/tv/genre/$value',
+      dataUrl: apiUrl('/discover/tv/genre/$value'),
       titlePlaceholderText: intl.formatMessage(messages.slidernameplaceholder),
       dataPlaceholderText: intl.formatMessage(messages.providetmdbgenreid),
     },
     {
       type: DiscoverSliderType.TMDB_STUDIO,
       title: intl.formatMessage(sliderTitles.tmdbstudio),
-      dataUrl: '/api/v1/discover/movies/studio/$value',
+      dataUrl: apiUrl('/discover/movies/studio/$value'),
       titlePlaceholderText: intl.formatMessage(messages.slidernameplaceholder),
       dataPlaceholderText: intl.formatMessage(messages.providetmdbstudio),
     },
     {
       type: DiscoverSliderType.TMDB_NETWORK,
       title: intl.formatMessage(sliderTitles.tmdbnetwork),
-      dataUrl: '/api/v1/discover/tv/network/$value',
+      dataUrl: apiUrl('/discover/tv/network/$value'),
       titlePlaceholderText: intl.formatMessage(messages.slidernameplaceholder),
       dataPlaceholderText: intl.formatMessage(messages.providetmdbnetwork),
     },
     {
       type: DiscoverSliderType.TMDB_SEARCH,
       title: intl.formatMessage(sliderTitles.tmdbsearch),
-      dataUrl: '/api/v1/search',
+      dataUrl: apiUrl('/search'),
       params: 'query=$value',
       titlePlaceholderText: intl.formatMessage(messages.slidernameplaceholder),
       dataPlaceholderText: intl.formatMessage(messages.providetmdbsearch),
@@ -284,14 +289,14 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
     {
       type: DiscoverSliderType.TMDB_MOVIE_STREAMING_SERVICES,
       title: intl.formatMessage(sliderTitles.tmdbmoviestreamingservices),
-      dataUrl: '/api/v1/discover/movies',
+      dataUrl: apiUrl('/discover/movies'),
       params: 'watchRegion=$regionValue&watchProviders=$providersValue',
       titlePlaceholderText: intl.formatMessage(messages.slidernameplaceholder),
     },
     {
       type: DiscoverSliderType.TMDB_TV_STREAMING_SERVICES,
       title: intl.formatMessage(sliderTitles.tmdbtvstreamingservices),
-      dataUrl: '/api/v1/discover/tv',
+      dataUrl: apiUrl('/discover/tv'),
       params: 'watchRegion=$regionValue&watchProviders=$providersValue',
       titlePlaceholderText: intl.formatMessage(messages.slidernameplaceholder),
     },
@@ -317,13 +322,13 @@ const CreateSlider = ({ onCreate, slider }: CreateSliderProps) => {
       onSubmit={async (values, { resetForm }) => {
         try {
           if (slider) {
-            await axios.put(`/api/v1/settings/discover/${slider.id}`, {
+            await axios.put(apiUrl(`/settings/discover/${slider.id}`), {
               type: Number(values.sliderType),
               title: values.title,
               data: values.data,
             });
           } else {
-            await axios.post('/api/v1/settings/discover/add', {
+            await axios.post(apiUrl('/settings/discover/add'), {
               type: Number(values.sliderType),
               title: values.title,
               data: values.data,

--- a/src/components/Discover/DiscoverMovieGenre/index.tsx
+++ b/src/components/Discover/DiscoverMovieGenre/index.tsx
@@ -4,6 +4,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { MovieResult } from '@server/models/Search';
 import { useRouter } from 'next/router';
@@ -27,7 +28,7 @@ const DiscoverMovieGenre = () => {
     error,
     firstResultData,
   } = useDiscover<MovieResult, { genre: { id: number; name: string } }>(
-    `/api/v1/discover/movies/genre/${router.query.genreId}`
+    apiUrl(`/discover/movies/genre/${router.query.genreId}`)
   );
 
   if (error) {

--- a/src/components/Discover/DiscoverMovieKeyword/index.tsx
+++ b/src/components/Discover/DiscoverMovieKeyword/index.tsx
@@ -4,6 +4,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover, { encodeURIExtraParams } from '@app/hooks/useDiscover';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { TmdbKeyword } from '@server/api/themoviedb/interfaces';
 import type { MovieResult } from '@server/models/Search';
@@ -28,7 +29,7 @@ const DiscoverMovieKeyword = () => {
     error,
     firstResultData,
   } = useDiscover<MovieResult, { keywords: TmdbKeyword[] }>(
-    `/api/v1/discover/movies`,
+    apiUrl(`/discover/movies`),
     {
       keywords: encodeURIExtraParams(router.query.keywords as string),
     }

--- a/src/components/Discover/DiscoverMovieLanguage/index.tsx
+++ b/src/components/Discover/DiscoverMovieLanguage/index.tsx
@@ -4,6 +4,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { MovieResult } from '@server/models/Search';
 import { useRouter } from 'next/router';
@@ -34,7 +35,7 @@ const DiscoverMovieLanguage = () => {
         name: string;
       };
     }
-  >(`/api/v1/discover/movies/language/${router.query.language}`);
+  >(apiUrl(`/discover/movies/language/${router.query.language}`));
 
   if (error) {
     return <ErrorPage statusCode={500} />;

--- a/src/components/Discover/DiscoverMovies/index.tsx
+++ b/src/components/Discover/DiscoverMovies/index.tsx
@@ -11,6 +11,7 @@ import FilterSlideover from '@app/components/Discover/FilterSlideover';
 import useDiscover from '@app/hooks/useDiscover';
 import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
 import type { SortOptions as TMDBSortOptions } from '@server/api/themoviedb';
@@ -60,7 +61,7 @@ const DiscoverMovies = () => {
     fetchMore,
     error,
   } = useDiscover<MovieResult, unknown, FilterOptions>(
-    '/api/v1/discover/movies',
+    apiUrl('/discover/movies'),
     preparedFilters
   );
   const [showFilters, setShowFilters] = useState(false);

--- a/src/components/Discover/DiscoverNetwork/index.tsx
+++ b/src/components/Discover/DiscoverNetwork/index.tsx
@@ -5,6 +5,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { TvNetwork } from '@server/models/common';
 import type { TvResult } from '@server/models/Search';
@@ -29,7 +30,7 @@ const DiscoverTvNetwork = () => {
     error,
     firstResultData,
   } = useDiscover<TvResult, { network: TvNetwork }>(
-    `/api/v1/discover/tv/network/${router.query.networkId}`
+    apiUrl(`/discover/tv/network/${router.query.networkId}`)
   );
 
   if (error) {

--- a/src/components/Discover/DiscoverSliderEdit/index.tsx
+++ b/src/components/Discover/DiscoverSliderEdit/index.tsx
@@ -8,6 +8,7 @@ import CreateSlider from '@app/components/Discover/CreateSlider';
 import GenreTag from '@app/components/GenreTag';
 import KeywordTag from '@app/components/KeywordTag';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import {
@@ -78,7 +79,7 @@ const DiscoverSliderEdit = ({
 
   const deleteSlider = async () => {
     try {
-      await axios.delete(`/api/v1/settings/discover/${slider.id}`);
+      await axios.delete(apiUrl(`/settings/discover/${slider.id}`));
       addToast(intl.formatMessage(messages.deletesuccess), {
         appearance: 'success',
         autoDismiss: true,

--- a/src/components/Discover/DiscoverStudio/index.tsx
+++ b/src/components/Discover/DiscoverStudio/index.tsx
@@ -5,6 +5,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { ProductionCompany } from '@server/models/common';
 import type { MovieResult } from '@server/models/Search';
@@ -29,7 +30,7 @@ const DiscoverMovieStudio = () => {
     error,
     firstResultData,
   } = useDiscover<MovieResult, { studio: ProductionCompany }>(
-    `/api/v1/discover/movies/studio/${router.query.studioId}`
+    apiUrl(`/discover/movies/studio/${router.query.studioId}`)
   );
 
   if (error) {

--- a/src/components/Discover/DiscoverTv/index.tsx
+++ b/src/components/Discover/DiscoverTv/index.tsx
@@ -11,6 +11,7 @@ import FilterSlideover from '@app/components/Discover/FilterSlideover';
 import useDiscover from '@app/hooks/useDiscover';
 import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
 import type { SortOptions as TMDBSortOptions } from '@server/api/themoviedb';
@@ -59,7 +60,7 @@ const DiscoverTv = () => {
     titles,
     fetchMore,
     error,
-  } = useDiscover<TvResult, never, FilterOptions>('/api/v1/discover/tv', {
+  } = useDiscover<TvResult, never, FilterOptions>(apiUrl('/discover/tv'), {
     ...preparedFilters,
   });
 

--- a/src/components/Discover/DiscoverTvGenre/index.tsx
+++ b/src/components/Discover/DiscoverTvGenre/index.tsx
@@ -4,6 +4,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { TvResult } from '@server/models/Search';
 import { useRouter } from 'next/router';
@@ -27,7 +28,7 @@ const DiscoverTvGenre = () => {
     error,
     firstResultData,
   } = useDiscover<TvResult, { genre: { id: number; name: string } }>(
-    `/api/v1/discover/tv/genre/${router.query.genreId}`
+    apiUrl(`/discover/tv/genre/${router.query.genreId}`)
   );
 
   if (error) {

--- a/src/components/Discover/DiscoverTvKeyword/index.tsx
+++ b/src/components/Discover/DiscoverTvKeyword/index.tsx
@@ -4,6 +4,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover, { encodeURIExtraParams } from '@app/hooks/useDiscover';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { TmdbKeyword } from '@server/api/themoviedb/interfaces';
 import type { TvResult } from '@server/models/Search';
@@ -28,7 +29,7 @@ const DiscoverTvKeyword = () => {
     error,
     firstResultData,
   } = useDiscover<TvResult, { keywords: TmdbKeyword[] }>(
-    `/api/v1/discover/tv`,
+    apiUrl(`/discover/tv`),
     {
       keywords: encodeURIExtraParams(router.query.keywords as string),
     }

--- a/src/components/Discover/DiscoverTvLanguage/index.tsx
+++ b/src/components/Discover/DiscoverTvLanguage/index.tsx
@@ -4,6 +4,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { TvResult } from '@server/models/Search';
 import { useRouter } from 'next/router';
@@ -34,7 +35,7 @@ const DiscoverTvLanguage = () => {
         name: string;
       };
     }
-  >(`/api/v1/discover/tv/language/${router.query.language}`);
+  >(apiUrl(`/discover/tv/language/${router.query.language}`));
 
   if (error) {
     return <ErrorPage statusCode={500} />;

--- a/src/components/Discover/DiscoverTvUpcoming.tsx
+++ b/src/components/Discover/DiscoverTvUpcoming.tsx
@@ -3,6 +3,7 @@ import ListView from '@app/components/Common/ListView';
 import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { TvResult } from '@server/models/Search';
 import { useIntl } from 'react-intl';
@@ -22,7 +23,7 @@ const DiscoverTvUpcoming = () => {
     titles,
     fetchMore,
     error,
-  } = useDiscover<TvResult>('/api/v1/discover/tv/upcoming');
+  } = useDiscover<TvResult>(apiUrl('/discover/tv/upcoming'));
 
   if (error) {
     return <ErrorPage statusCode={500} />;

--- a/src/components/Discover/DiscoverWatchlist/index.tsx
+++ b/src/components/Discover/DiscoverWatchlist/index.tsx
@@ -4,6 +4,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import { useUser } from '@app/hooks/useUser';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { WatchlistItem } from '@server/interfaces/api/discoverInterfaces';
 import Link from 'next/link';
@@ -33,13 +34,15 @@ const DiscoverWatchlist = () => {
     error,
     mutate,
   } = useDiscover<WatchlistItem>(
-    `/api/v1/${
-      router.pathname.startsWith('/profile')
-        ? `user/${currentUser?.id}`
-        : router.query.userId
-          ? `user/${router.query.userId}`
-          : 'discover'
-    }/watchlist`
+    apiUrl(
+      `/${
+        router.pathname.startsWith('/profile')
+          ? `user/${currentUser?.id}`
+          : router.query.userId
+            ? `user/${router.query.userId}`
+            : 'discover'
+      }/watchlist`
+    )
   );
 
   if (error) {

--- a/src/components/Discover/MovieGenreList/index.tsx
+++ b/src/components/Discover/MovieGenreList/index.tsx
@@ -4,6 +4,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import { genreColorMap } from '@app/components/Discover/constants';
 import GenreCard from '@app/components/GenreCard';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { GenreSliderItem } from '@server/interfaces/api/discoverInterfaces';
 import { useIntl } from 'react-intl';
@@ -16,7 +17,7 @@ const messages = defineMessages('components.Discover.MovieGenreList', {
 const MovieGenreList = () => {
   const intl = useIntl();
   const { data, error } = useSWR<GenreSliderItem[]>(
-    `/api/v1/discover/genreslider/movie`
+    apiUrl(`/discover/genreslider/movie`)
   );
 
   if (!data && !error) {

--- a/src/components/Discover/MovieGenreSlider/index.tsx
+++ b/src/components/Discover/MovieGenreSlider/index.tsx
@@ -1,6 +1,7 @@
 import { genreColorMap } from '@app/components/Discover/constants';
 import GenreCard from '@app/components/GenreCard';
 import Slider from '@app/components/Slider';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/outline';
 import type { GenreSliderItem } from '@server/interfaces/api/discoverInterfaces';
@@ -16,7 +17,7 @@ const messages = defineMessages('components.Discover.MovieGenreSlider', {
 const MovieGenreSlider = () => {
   const intl = useIntl();
   const { data, error } = useSWR<GenreSliderItem[]>(
-    `/api/v1/discover/genreslider/movie`,
+    apiUrl(`/discover/genreslider/movie`),
     {
       refreshInterval: 0,
       revalidateOnFocus: false,

--- a/src/components/Discover/PlexWatchlistSlider/index.tsx
+++ b/src/components/Discover/PlexWatchlistSlider/index.tsx
@@ -1,6 +1,7 @@
 import Slider from '@app/components/Slider';
 import TmdbTitleCard from '@app/components/TitleCard/TmdbTitleCard';
 import { useUser } from '@app/hooks/useUser';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/outline';
 import type { WatchlistItem } from '@server/interfaces/api/discoverInterfaces';
@@ -23,7 +24,7 @@ const PlexWatchlistSlider = () => {
     totalPages: number;
     totalResults: number;
     results: WatchlistItem[];
-  }>('/api/v1/discover/watchlist', {
+  }>(apiUrl('/discover/watchlist'), {
     revalidateOnMount: true,
   });
 

--- a/src/components/Discover/RecentRequestsSlider/index.tsx
+++ b/src/components/Discover/RecentRequestsSlider/index.tsx
@@ -2,6 +2,7 @@ import { sliderTitles } from '@app/components/Discover/constants';
 import RequestCard from '@app/components/RequestCard';
 import Slider from '@app/components/Slider';
 import { Permission, useUser } from '@app/hooks/useUser';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import {
   ArrowRightCircleIcon,
@@ -22,7 +23,7 @@ const RecentRequestsSlider = () => {
   const { hasPermission } = useUser();
   const { data: requests, error: requestError } =
     useSWR<RequestResultsResponse>(
-      '/api/v1/request?filter=all&take=10&sort=modified&skip=0',
+      apiUrl('/request?filter=all&take=10&sort=modified&skip=0'),
       {
         revalidateOnMount: true,
       }

--- a/src/components/Discover/RecentlyAddedSlider/index.tsx
+++ b/src/components/Discover/RecentlyAddedSlider/index.tsx
@@ -1,6 +1,7 @@
 import Slider from '@app/components/Slider';
 import TmdbTitleCard from '@app/components/TitleCard/TmdbTitleCard';
 import { Permission, useUser } from '@app/hooks/useUser';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { MediaResultsResponse } from '@server/interfaces/api/mediaInterfaces';
 import { useIntl } from 'react-intl';
@@ -14,7 +15,7 @@ const RecentlyAddedSlider = () => {
   const intl = useIntl();
   const { hasPermission } = useUser();
   const { data: media, error: mediaError } = useSWR<MediaResultsResponse>(
-    '/api/v1/media?filter=allavailable&take=20&sort=mediaAdded',
+    apiUrl('/media?filter=allavailable&take=20&sort=mediaAdded'),
     { revalidateOnMount: true }
   );
 

--- a/src/components/Discover/Trending.tsx
+++ b/src/components/Discover/Trending.tsx
@@ -4,6 +4,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { CircleStackIcon, FunnelIcon } from '@heroicons/react/24/solid';
 import type {
@@ -37,7 +38,7 @@ const Trending = () => {
     fetchMore,
     error,
   } = useDiscover<MovieResult | TvResult | PersonResult>(
-    '/api/v1/discover/trending',
+    apiUrl('/discover/trending'),
     { mediaType: currentMediaType, timeWindow: currentTimeWindow }
   );
 

--- a/src/components/Discover/TvGenreList/index.tsx
+++ b/src/components/Discover/TvGenreList/index.tsx
@@ -4,6 +4,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import { genreColorMap } from '@app/components/Discover/constants';
 import GenreCard from '@app/components/GenreCard';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { GenreSliderItem } from '@server/interfaces/api/discoverInterfaces';
 import { useIntl } from 'react-intl';
@@ -16,7 +17,7 @@ const messages = defineMessages('components.Discover.TvGenreList', {
 const TvGenreList = () => {
   const intl = useIntl();
   const { data, error } = useSWR<GenreSliderItem[]>(
-    `/api/v1/discover/genreslider/tv`
+    apiUrl(`/discover/genreslider/tv`)
   );
 
   if (!data && !error) {

--- a/src/components/Discover/TvGenreSlider/index.tsx
+++ b/src/components/Discover/TvGenreSlider/index.tsx
@@ -1,6 +1,7 @@
 import { genreColorMap } from '@app/components/Discover/constants';
 import GenreCard from '@app/components/GenreCard';
 import Slider from '@app/components/Slider';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/outline';
 import type { GenreSliderItem } from '@server/interfaces/api/discoverInterfaces';
@@ -16,7 +17,7 @@ const messages = defineMessages('components.Discover.TvGenreSlider', {
 const TvGenreSlider = () => {
   const intl = useIntl();
   const { data, error } = useSWR<GenreSliderItem[]>(
-    `/api/v1/discover/genreslider/tv`,
+    apiUrl(`/discover/genreslider/tv`),
     {
       refreshInterval: 0,
       revalidateOnFocus: false,

--- a/src/components/Discover/Upcoming.tsx
+++ b/src/components/Discover/Upcoming.tsx
@@ -3,6 +3,7 @@ import ListView from '@app/components/Common/ListView';
 import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { MovieResult } from '@server/models/Search';
 import { useIntl } from 'react-intl';
@@ -22,7 +23,7 @@ const UpcomingMovies = () => {
     titles,
     fetchMore,
     error,
-  } = useDiscover<MovieResult>('/api/v1/discover/movies/upcoming');
+  } = useDiscover<MovieResult>(apiUrl('/discover/movies/upcoming'));
 
   if (error) {
     return <ErrorPage statusCode={500} />;

--- a/src/components/Discover/index.tsx
+++ b/src/components/Discover/index.tsx
@@ -17,6 +17,7 @@ import MediaSlider from '@app/components/MediaSlider';
 import { encodeURIExtraParams } from '@app/hooks/useDiscover';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import {
@@ -60,7 +61,7 @@ const Discover = () => {
     data: discoverData,
     error: discoverError,
     mutate,
-  } = useSWR<DiscoverSlider[]>('/api/v1/settings/discover');
+  } = useSWR<DiscoverSlider[]>(apiUrl('/settings/discover'));
   const [sliders, setSliders] = useState<Partial<DiscoverSlider>[]>([]);
   const [isEditing, setIsEditing] = useState(false);
 
@@ -76,7 +77,7 @@ const Discover = () => {
 
   const updateSliders = async () => {
     try {
-      await axios.post('/api/v1/settings/discover', sliders);
+      await axios.post(apiUrl('/settings/discover'), sliders);
 
       addToast(intl.formatMessage(messages.updatesuccess), {
         appearance: 'success',
@@ -94,7 +95,7 @@ const Discover = () => {
 
   const resetSliders = async () => {
     try {
-      await axios.get('/api/v1/settings/discover/reset');
+      await axios.get(apiUrl('/settings/discover/reset'));
 
       addToast(intl.formatMessage(messages.resetsuccess), {
         appearance: 'success',
@@ -224,7 +225,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey="trending"
                 title={intl.formatMessage(sliderTitles.trending)}
-                url="/api/v1/discover/trending"
+                url={apiUrl('/discover/trending')}
                 linkUrl="/discover/trending"
               />
             );
@@ -234,7 +235,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey="popular-movies"
                 title={intl.formatMessage(sliderTitles.popularmovies)}
-                url="/api/v1/discover/movies"
+                url={apiUrl('/discover/movies')}
                 linkUrl="/discover/movies"
               />
             );
@@ -248,7 +249,7 @@ const Discover = () => {
                 sliderKey="upcoming"
                 title={intl.formatMessage(sliderTitles.upcoming)}
                 linkUrl={`/discover/movies?primaryReleaseDateGte=${upcomingDate}`}
-                url="/api/v1/discover/movies"
+                url={apiUrl('/discover/movies')}
                 extraParams={`primaryReleaseDateGte=${upcomingDate}`}
               />
             );
@@ -261,7 +262,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey="popular-tv"
                 title={intl.formatMessage(sliderTitles.populartv)}
-                url="/api/v1/discover/tv"
+                url={apiUrl('/discover/tv')}
                 linkUrl="/discover/tv"
               />
             );
@@ -275,7 +276,7 @@ const Discover = () => {
                 sliderKey="upcoming-tv"
                 title={intl.formatMessage(sliderTitles.upcomingtv)}
                 linkUrl={`/discover/tv?firstAirDateGte=${upcomingDate}`}
-                url="/api/v1/discover/tv"
+                url={apiUrl('/discover/tv')}
                 extraParams={`firstAirDateGte=${upcomingDate}`}
               />
             );
@@ -288,7 +289,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey={`custom-slider-${slider.id}`}
                 title={slider.title ?? ''}
-                url="/api/v1/discover/movies"
+                url={apiUrl('/discover/movies')}
                 extraParams={
                   slider.data
                     ? `keywords=${encodeURIExtraParams(slider.data)}`
@@ -303,7 +304,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey={`custom-slider-${slider.id}`}
                 title={slider.title ?? ''}
-                url="/api/v1/discover/tv"
+                url={apiUrl('/discover/tv')}
                 extraParams={
                   slider.data
                     ? `keywords=${encodeURIExtraParams(slider.data)}`
@@ -318,7 +319,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey={`custom-slider-${slider.id}`}
                 title={slider.title ?? ''}
-                url={`/api/v1/discover/movies`}
+                url={apiUrl(`/discover/movies`)}
                 extraParams={`genre=${slider.data}`}
                 linkUrl={`/discover/movies?genre=${slider.data}`}
               />
@@ -329,7 +330,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey={`custom-slider-${slider.id}`}
                 title={slider.title ?? ''}
-                url={`/api/v1/discover/tv`}
+                url={apiUrl(`/discover/tv`)}
                 extraParams={`genre=${slider.data}`}
                 linkUrl={`/discover/tv?genre=${slider.data}`}
               />
@@ -340,7 +341,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey={`custom-slider-${slider.id}`}
                 title={slider.title ?? ''}
-                url={`/api/v1/discover/movies/studio/${slider.data}`}
+                url={apiUrl(`/discover/movies/studio/${slider.data}`)}
                 linkUrl={`/discover/movies/studio/${slider.data}`}
               />
             );
@@ -350,7 +351,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey={`custom-slider-${slider.id}`}
                 title={slider.title ?? ''}
-                url={`/api/v1/discover/tv/network/${slider.data}`}
+                url={apiUrl(`/discover/tv/network/${slider.data}`)}
                 linkUrl={`/discover/tv/network/${slider.data}`}
               />
             );
@@ -360,7 +361,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey={`custom-slider-${slider.id}`}
                 title={slider.title ?? ''}
-                url="/api/v1/search"
+                url={apiUrl('/search')}
                 extraParams={`query=${slider.data}`}
                 linkUrl={`/search?query=${slider.data}`}
               />
@@ -371,7 +372,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey={`custom-slider-${slider.id}`}
                 title={slider.title ?? ''}
-                url="/api/v1/discover/movies"
+                url={apiUrl('/discover/movies')}
                 extraParams={`watchRegion=${
                   slider.data?.split(',')[0]
                 }&watchProviders=${slider.data?.split(',')[1]}`}
@@ -386,7 +387,7 @@ const Discover = () => {
               <MediaSlider
                 sliderKey={`custom-slider-${slider.id}`}
                 title={slider.title ?? ''}
-                url="/api/v1/discover/tv"
+                url={apiUrl('/discover/tv')}
                 extraParams={`watchRegion=${
                   slider.data?.split(',')[0]
                 }&watchProviders=${slider.data?.split(',')[1]}`}

--- a/src/components/GenreTag/index.tsx
+++ b/src/components/GenreTag/index.tsx
@@ -1,5 +1,6 @@
 import Spinner from '@app/assets/spinner.svg';
 import Tag from '@app/components/Common/Tag';
+import { apiUrl } from '@app/utils/apiUrl';
 import { RectangleStackIcon } from '@heroicons/react/24/outline';
 import type { TmdbGenre } from '@server/api/themoviedb/interfaces';
 import useSWR from 'swr';
@@ -10,7 +11,7 @@ type GenreTagProps = {
 };
 
 const GenreTag = ({ genreId, type }: GenreTagProps) => {
-  const { data, error } = useSWR<TmdbGenre[]>(`/api/v1/genres/${type}`);
+  const { data, error } = useSWR<TmdbGenre[]>(apiUrl(`/genres/${type}`));
 
   if (!data && !error) {
     return (

--- a/src/components/IssueDetails/IssueComment/index.tsx
+++ b/src/components/IssueDetails/IssueComment/index.tsx
@@ -3,6 +3,7 @@ import CachedImage from '@app/components/Common/CachedImage';
 import Modal from '@app/components/Common/Modal';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Menu, Transition } from '@headlessui/react';
 import { EllipsisVerticalIcon } from '@heroicons/react/24/solid';
@@ -50,7 +51,7 @@ const IssueComment = ({
 
   const deleteComment = async () => {
     try {
-      await axios.delete(`/api/v1/issueComment/${comment.id}`);
+      await axios.delete(apiUrl(`/issueComment/${comment.id}`));
     } catch {
       // something went wrong deleting the comment
     } finally {
@@ -177,7 +178,7 @@ const IssueComment = ({
               <Formik
                 initialValues={{ newMessage: comment.message }}
                 onSubmit={async (values) => {
-                  await axios.put(`/api/v1/issueComment/${comment.id}`, {
+                  await axios.put(apiUrl(`/issueComment/${comment.id}`), {
                     message: values.newMessage,
                   });
 

--- a/src/components/IssueDetails/index.tsx
+++ b/src/components/IssueDetails/index.tsx
@@ -12,6 +12,7 @@ import useSettings from '@app/hooks/useSettings';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import {
@@ -84,11 +85,11 @@ const IssueDetails = () => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { user: currentUser, hasPermission } = useUser();
   const { data: issueData, mutate: revalidateIssue } = useSWR<Issue>(
-    `/api/v1/issue/${router.query.issueId}`
+    apiUrl(`/issue/${router.query.issueId}`)
   );
   const { data, error } = useSWR<MovieDetails | TvDetails>(
     issueData?.media.tmdbId
-      ? `/api/v1/${issueData.media.mediaType}/${issueData.media.tmdbId}`
+      ? apiUrl(`/${issueData.media.mediaType}/${issueData.media.tmdbId}`)
       : null
   );
 
@@ -122,7 +123,7 @@ const IssueDetails = () => {
 
   const editFirstComment = async (newMessage: string) => {
     try {
-      await axios.put(`/api/v1/issueComment/${firstComment.id}`, {
+      await axios.put(apiUrl(`/issueComment/${firstComment.id}`), {
         message: newMessage,
       });
 
@@ -141,14 +142,14 @@ const IssueDetails = () => {
 
   const updateIssueStatus = async (newStatus: 'open' | 'resolved') => {
     try {
-      await axios.post(`/api/v1/issue/${issueData.id}/${newStatus}`);
+      await axios.post(apiUrl(`/issue/${issueData.id}/${newStatus}`));
 
       addToast(intl.formatMessage(messages.toaststatusupdated), {
         appearance: 'success',
         autoDismiss: true,
       });
       revalidateIssue();
-      mutate('/api/v1/issue/count');
+      mutate(apiUrl('/issue/count'));
     } catch {
       addToast(intl.formatMessage(messages.toaststatusupdatefailed), {
         appearance: 'error',
@@ -159,8 +160,8 @@ const IssueDetails = () => {
 
   const deleteIssue = async () => {
     try {
-      await axios.delete(`/api/v1/issue/${issueData.id}`);
-      mutate('/api/v1/issue/count');
+      await axios.delete(apiUrl(`/issue/${issueData.id}`));
+      mutate(apiUrl('/issue/count'));
 
       addToast(intl.formatMessage(messages.toastissuedeleted), {
         appearance: 'success',
@@ -494,7 +495,7 @@ const IssueDetails = () => {
                 }}
                 validationSchema={CommentSchema}
                 onSubmit={async (values, { resetForm }) => {
-                  await axios.post(`/api/v1/issue/${issueData?.id}/comment`, {
+                  await axios.post(apiUrl(`/issue/${issueData?.id}/comment`), {
                     message: values.message,
                   });
                   revalidateIssue();

--- a/src/components/IssueList/IssueItem/index.tsx
+++ b/src/components/IssueList/IssueItem/index.tsx
@@ -5,6 +5,7 @@ import Tooltip from '@app/components/Common/Tooltip';
 import { issueOptions } from '@app/components/IssueModal/constants';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { EyeIcon } from '@heroicons/react/24/solid';
 import { IssueStatus } from '@server/constants/issue';
@@ -46,8 +47,8 @@ const IssueItem = ({ issue }: IssueItemProps) => {
   });
   const url =
     issue.media.mediaType === 'movie'
-      ? `/api/v1/movie/${issue.media.tmdbId}`
-      : `/api/v1/tv/${issue.media.tmdbId}`;
+      ? apiUrl(`/movie/${issue.media.tmdbId}`)
+      : apiUrl(`/tv/${issue.media.tmdbId}`);
   const { data: title, error } = useSWR<MovieDetails | TvDetails>(
     inView ? url : null
   );

--- a/src/components/IssueList/index.tsx
+++ b/src/components/IssueList/index.tsx
@@ -5,6 +5,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import IssueItem from '@app/components/IssueList/IssueItem';
 import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import {
   BarsArrowDownIcon,
@@ -45,9 +46,11 @@ const IssueList = () => {
   const updateQueryParams = useUpdateQueryParams({ page: page.toString() });
 
   const { data, error } = useSWR<IssueResultsResponse>(
-    `/api/v1/issue?take=${currentPageSize}&skip=${
-      pageIndex * currentPageSize
-    }&filter=${currentFilter}&sort=${currentSort}`
+    apiUrl(
+      `/issue?take=${currentPageSize}&skip=${
+        pageIndex * currentPageSize
+      }&filter=${currentFilter}&sort=${currentSort}`
+    )
   );
 
   // Restore last set filter values on component mount

--- a/src/components/IssueModal/CreateIssueModal/index.tsx
+++ b/src/components/IssueModal/CreateIssueModal/index.tsx
@@ -4,6 +4,7 @@ import { issueOptions } from '@app/components/IssueModal/constants';
 import useSettings from '@app/hooks/useSettings';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { RadioGroup } from '@headlessui/react';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/solid';
@@ -63,7 +64,7 @@ const CreateIssueModal = ({
   const { hasPermission } = useUser();
   const { addToast } = useToasts();
   const { data, error } = useSWR<MovieDetails | TvDetails>(
-    tmdbId ? `/api/v1/${mediaType}/${tmdbId}` : null
+    tmdbId ? apiUrl(`/${mediaType}/${tmdbId}`) : null
   );
 
   if (!tmdbId) {
@@ -101,7 +102,7 @@ const CreateIssueModal = ({
       validationSchema={CreateIssueModalSchema}
       onSubmit={async (values) => {
         try {
-          const newIssue = await axios.post<Issue>('/api/v1/issue', {
+          const newIssue = await axios.post<Issue>(apiUrl('/issue'), {
             issueType: values.selectedIssue.issueType,
             message: values.message,
             mediaId: data?.mediaInfo?.id,
@@ -132,7 +133,7 @@ const CreateIssueModal = ({
               }
             );
 
-            mutate('/api/v1/issue/count');
+            mutate(apiUrl('/issue/count'));
           }
 
           if (onCancel) {

--- a/src/components/KeywordTag/index.tsx
+++ b/src/components/KeywordTag/index.tsx
@@ -1,5 +1,6 @@
 import Spinner from '@app/assets/spinner.svg';
 import Tag from '@app/components/Common/Tag';
+import { apiUrl } from '@app/utils/apiUrl';
 import type { Keyword } from '@server/models/common';
 import useSWR from 'swr';
 
@@ -8,7 +9,7 @@ type KeywordTagProps = {
 };
 
 const KeywordTag = ({ keywordId }: KeywordTagProps) => {
-  const { data, error } = useSWR<Keyword>(`/api/v1/keyword/${keywordId}`);
+  const { data, error } = useSWR<Keyword>(apiUrl(`/keyword/${keywordId}`));
 
   if (!data && !error) {
     return (

--- a/src/components/LanguageSelector/index.tsx
+++ b/src/components/LanguageSelector/index.tsx
@@ -1,4 +1,5 @@
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { Language } from '@server/lib/settings';
 import { sortBy } from 'lodash';
@@ -44,7 +45,7 @@ const LanguageSelector = ({
   isDisabled,
 }: LanguageSelectorProps) => {
   const intl = useIntl();
-  const { data: languages } = useSWR<Language[]>('/api/v1/languages');
+  const { data: languages } = useSWR<Language[]>(apiUrl('/languages'));
 
   const sortedLanguages = useMemo(() => {
     languages?.forEach((language) => {

--- a/src/components/Layout/UserDropdown/MiniQuotaDisplay/index.tsx
+++ b/src/components/Layout/UserDropdown/MiniQuotaDisplay/index.tsx
@@ -1,6 +1,7 @@
 import InfinityIcon from '@app/assets/infinity.svg';
 import { SmallLoadingSpinner } from '@app/components/Common/LoadingSpinner';
 import ProgressCircle from '@app/components/Common/ProgressCircle';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { QuotaResponse } from '@server/interfaces/api/userInterfaces';
 import { useIntl } from 'react-intl';
@@ -20,7 +21,9 @@ type MiniQuotaDisplayProps = {
 
 const MiniQuotaDisplay = ({ userId }: MiniQuotaDisplayProps) => {
   const intl = useIntl();
-  const { data, error } = useSWR<QuotaResponse>(`/api/v1/user/${userId}/quota`);
+  const { data, error } = useSWR<QuotaResponse>(
+    apiUrl(`/user/${userId}/quota`)
+  );
 
   if (error) {
     return null;

--- a/src/components/Layout/UserDropdown/index.tsx
+++ b/src/components/Layout/UserDropdown/index.tsx
@@ -1,6 +1,7 @@
 import CachedImage from '@app/components/Common/CachedImage';
 import MiniQuotaDisplay from '@app/components/Layout/UserDropdown/MiniQuotaDisplay';
 import { Permission, useUser } from '@app/hooks/useUser';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Menu, Transition } from '@headlessui/react';
 import {
@@ -39,7 +40,7 @@ const UserDropdown = () => {
   const { user, revalidate, hasPermission } = useUser();
 
   const logout = async () => {
-    const response = await axios.post('/api/v1/auth/logout');
+    const response = await axios.post(apiUrl('/auth/logout'));
 
     if (response.data?.status === 'ok') {
       revalidate();

--- a/src/components/Layout/VersionStatus/index.tsx
+++ b/src/components/Layout/VersionStatus/index.tsx
@@ -1,3 +1,4 @@
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import {
   ArrowUpCircleIcon,
@@ -24,7 +25,7 @@ interface VersionStatusProps {
 
 const VersionStatus = ({ onClick }: VersionStatusProps) => {
   const intl = useIntl();
-  const { data } = useSWR<StatusResponse>('/api/v1/status', {
+  const { data } = useSWR<StatusResponse>(apiUrl('/status'), {
     refreshInterval: 60 * 1000,
   });
 

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -6,6 +6,7 @@ import UserDropdown from '@app/components/Layout/UserDropdown';
 import useLocale from '@app/hooks/useLocale';
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
+import { apiUrl } from '@app/utils/apiUrl';
 import { ArrowLeftIcon, Bars3BottomLeftIcon } from '@heroicons/react/24/solid';
 import type { AvailableLocale } from '@server/types/languages';
 import { useRouter } from 'next/router';
@@ -24,13 +25,13 @@ const Layout = ({ children }: LayoutProps) => {
   const { currentSettings } = useSettings();
   const { setLocale } = useLocale();
   const { data: requestResponse, mutate: revalidateRequestsCount } = useSWR(
-    '/api/v1/request/count',
+    apiUrl('/request/count'),
     {
       revalidateOnMount: true,
     }
   );
   const { data: issueResponse, mutate: revalidateIssueCount } = useSWR(
-    '/api/v1/issue/count',
+    apiUrl('/issue/count'),
     {
       revalidateOnMount: true,
     }

--- a/src/components/Login/AddEmailModal.tsx
+++ b/src/components/Login/AddEmailModal.tsx
@@ -1,5 +1,6 @@
 import Modal from '@app/components/Common/Modal';
 import useSettings from '@app/hooks/useSettings';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import axios from 'axios';
@@ -63,7 +64,7 @@ const AddEmailModal: React.FC<AddEmailModalProps> = ({
         validationSchema={EmailSettingsSchema}
         onSubmit={async (values) => {
           try {
-            await axios.post('/api/v1/auth/jellyfin', {
+            await axios.post(apiUrl('/auth/jellyfin'), {
               username: username,
               password: password,
               email: values.email,

--- a/src/components/Login/JellyfinLogin.tsx
+++ b/src/components/Login/JellyfinLogin.tsx
@@ -1,6 +1,7 @@
 import Button from '@app/components/Common/Button';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import useSettings from '@app/hooks/useSettings';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowLeftOnRectangleIcon } from '@heroicons/react/24/outline';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/solid';
@@ -74,7 +75,7 @@ const JellyfinLogin: React.FC<JellyfinLoginProps> = ({
         validateOnBlur={false}
         onSubmit={async (values) => {
           try {
-            await axios.post('/api/v1/auth/jellyfin', {
+            await axios.post(apiUrl('/auth/jellyfin'), {
               username: values.username,
               password: values.password,
               email: values.username,

--- a/src/components/Login/LocalLogin.tsx
+++ b/src/components/Login/LocalLogin.tsx
@@ -1,6 +1,7 @@
 import Button from '@app/components/Common/Button';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import useSettings from '@app/hooks/useSettings';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowLeftOnRectangleIcon } from '@heroicons/react/24/outline';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/solid';
@@ -57,7 +58,7 @@ const LocalLogin = ({ revalidate }: LocalLoginProps) => {
       validateOnBlur={false}
       onSubmit={async (values) => {
         try {
-          await axios.post('/api/v1/auth/local', {
+          await axios.post(apiUrl('/auth/local'), {
             email: values.email,
             password: values.password,
           });

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -10,6 +10,7 @@ import LocalLogin from '@app/components/Login/LocalLogin';
 import PlexLoginButton from '@app/components/Login/PlexLoginButton';
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import { XCircleIcon } from '@heroicons/react/24/solid';
@@ -51,7 +52,7 @@ const Login = () => {
     const login = async () => {
       setProcessing(true);
       try {
-        const response = await axios.post('/api/v1/auth/plex', { authToken });
+        const response = await axios.post(apiUrl('/auth/plex'), { authToken });
 
         if (response.data?.id) {
           revalidate();
@@ -75,7 +76,7 @@ const Login = () => {
     }
   }, [user, router]);
 
-  const { data: backdrops } = useSWR<string[]>('/api/v1/backdrops', {
+  const { data: backdrops } = useSWR<string[]>(apiUrl('/backdrops'), {
     refreshInterval: 0,
     refreshWhenHidden: false,
     revalidateOnFocus: false,

--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -10,6 +10,7 @@ import RequestBlock from '@app/components/RequestBlock';
 import useSettings from '@app/hooks/useSettings';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Bars4Icon, ServerIcon } from '@heroicons/react/24/outline';
 import {
@@ -112,19 +113,19 @@ const ManageSlideOver = ({
     settings.currentSettings.mediaServerType === MediaServerType.PLEX &&
       data.mediaInfo &&
       hasPermission(Permission.ADMIN)
-      ? `/api/v1/media/${data.mediaInfo.id}/watch_data`
+      ? apiUrl(`/media/${data.mediaInfo.id}/watch_data`)
       : null
   );
   const { data: radarrData } = useSWR<RadarrSettings[]>(
-    hasPermission(Permission.ADMIN) ? '/api/v1/settings/radarr' : null
+    hasPermission(Permission.ADMIN) ? apiUrl('/settings/radarr') : null
   );
   const { data: sonarrData } = useSWR<SonarrSettings[]>(
-    hasPermission(Permission.ADMIN) ? '/api/v1/settings/sonarr' : null
+    hasPermission(Permission.ADMIN) ? apiUrl('/settings/sonarr') : null
   );
 
   const deleteMedia = async () => {
     if (data.mediaInfo) {
-      await axios.delete(`/api/v1/media/${data.mediaInfo.id}`);
+      await axios.delete(apiUrl(`/media/${data.mediaInfo.id}`));
       revalidate();
       onClose();
     }
@@ -133,9 +134,9 @@ const ManageSlideOver = ({
   const deleteMediaFile = async (is4k = false) => {
     if (data.mediaInfo) {
       await axios.delete(
-        `/api/v1/media/${data.mediaInfo.id}/file?is4k=${is4k}`
+        apiUrl(`/media/${data.mediaInfo.id}/file?is4k=${is4k}`)
       );
-      await axios.delete(`/api/v1/media/${data.mediaInfo.id}`);
+      await axios.delete(apiUrl(`/media/${data.mediaInfo.id}`));
       revalidate();
       onClose();
     }
@@ -189,7 +190,7 @@ const ManageSlideOver = ({
 
   const markAvailable = async (is4k = false) => {
     if (data.mediaInfo) {
-      await axios.post(`/api/v1/media/${data.mediaInfo?.id}/available`, {
+      await axios.post(apiUrl(`/media/${data.mediaInfo?.id}/available`), {
         is4k,
         ...(mediaType === 'tv' && {
           seasons: data.seasons.filter((season) => season.seasonNumber !== 0),

--- a/src/components/MovieDetails/MovieCast/index.tsx
+++ b/src/components/MovieDetails/MovieCast/index.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import PageTitle from '@app/components/Common/PageTitle';
 import PersonCard from '@app/components/PersonCard';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { MovieDetails } from '@server/models/Movie';
 import Link from 'next/link';
@@ -18,7 +19,7 @@ const MovieCast = () => {
   const router = useRouter();
   const intl = useIntl();
   const { data, error } = useSWR<MovieDetails>(
-    `/api/v1/movie/${router.query.movieId}`
+    apiUrl(`/movie/${router.query.movieId}`)
   );
 
   if (!data && !error) {

--- a/src/components/MovieDetails/MovieCrew/index.tsx
+++ b/src/components/MovieDetails/MovieCrew/index.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import PageTitle from '@app/components/Common/PageTitle';
 import PersonCard from '@app/components/PersonCard';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { MovieDetails } from '@server/models/Movie';
 import Link from 'next/link';
@@ -18,7 +19,7 @@ const MovieCrew = () => {
   const router = useRouter();
   const intl = useIntl();
   const { data, error } = useSWR<MovieDetails>(
-    `/api/v1/movie/${router.query.movieId}`
+    apiUrl(`/movie/${router.query.movieId}`)
   );
 
   if (!data && !error) {

--- a/src/components/MovieDetails/MovieRecommendations.tsx
+++ b/src/components/MovieDetails/MovieRecommendations.tsx
@@ -3,6 +3,7 @@ import ListView from '@app/components/Common/ListView';
 import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { MovieDetails } from '@server/models/Movie';
 import type { MovieResult } from '@server/models/Search';
@@ -19,7 +20,7 @@ const MovieRecommendations = () => {
   const intl = useIntl();
   const router = useRouter();
   const { data: movieData } = useSWR<MovieDetails>(
-    `/api/v1/movie/${router.query.movieId}`
+    apiUrl(`/movie/${router.query.movieId}`)
   );
   const {
     isLoadingInitialData,
@@ -30,7 +31,7 @@ const MovieRecommendations = () => {
     fetchMore,
     error,
   } = useDiscover<MovieResult>(
-    `/api/v1/movie/${router.query.movieId}/recommendations`
+    apiUrl(`/movie/${router.query.movieId}/recommendations`)
   );
 
   if (error) {

--- a/src/components/MovieDetails/MovieSimilar.tsx
+++ b/src/components/MovieDetails/MovieSimilar.tsx
@@ -3,6 +3,7 @@ import ListView from '@app/components/Common/ListView';
 import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { MovieDetails } from '@server/models/Movie';
 import type { MovieResult } from '@server/models/Search';
@@ -19,7 +20,7 @@ const MovieSimilar = () => {
   const router = useRouter();
   const intl = useIntl();
   const { data: movieData } = useSWR<MovieDetails>(
-    `/api/v1/movie/${router.query.movieId}`
+    apiUrl(`/movie/${router.query.movieId}`)
   );
   const {
     isLoadingInitialData,
@@ -29,7 +30,9 @@ const MovieSimilar = () => {
     titles,
     fetchMore,
     error,
-  } = useDiscover<MovieResult>(`/api/v1/movie/${router.query.movieId}/similar`);
+  } = useDiscover<MovieResult>(
+    apiUrl(`/movie/${router.query.movieId}/similar`)
+  );
 
   if (error) {
     return <ErrorPage statusCode={500} />;

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -28,6 +28,7 @@ import useSettings from '@app/hooks/useSettings';
 import { Permission, UserType, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import { sortCrewPriority } from '@app/utils/creditHelpers';
 import defineMessages from '@app/utils/defineMessages';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
@@ -137,7 +138,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR<MovieDetailsType>(`/api/v1/movie/${router.query.movieId}`, {
+  } = useSWR<MovieDetailsType>(apiUrl(`/movie/${router.query.movieId}`), {
     fallbackData: movie,
     refreshInterval: refreshIntervalHelper(
       {
@@ -149,7 +150,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
   });
 
   const { data: ratingData } = useSWR<RatingResponse>(
-    `/api/v1/movie/${router.query.movieId}/ratingscombined`
+    apiUrl(`/movie/${router.query.movieId}/ratingscombined`)
   );
 
   const sortedCrew = useMemo(
@@ -327,7 +328,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
     setIsUpdating(true);
 
     try {
-      const response = await axios.post('/api/v1/watchlist', {
+      const response = await axios.post(apiUrl('/watchlist'), {
         tmdbId: movie?.id,
         mediaType: MediaType.MOVIE,
         title: movie?.title,
@@ -359,7 +360,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
     setIsUpdating(true);
     try {
       await axios.delete(
-        `/api/v1/watchlist/${movie?.id}?mediaType=${MediaType.MOVIE}`
+        apiUrl(`/watchlist/${movie?.id}?mediaType=${MediaType.MOVIE}`)
       );
 
       addToast(
@@ -386,7 +387,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
     setIsBlocklistUpdating(true);
 
     try {
-      await axios.post('/api/v1/blocklist', {
+      await axios.post(apiUrl('/blocklist'), {
         tmdbId: movie?.id,
         mediaType: 'movie',
         title: movie?.title,
@@ -1133,14 +1134,14 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
       <MediaSlider
         sliderKey="recommendations"
         title={intl.formatMessage(messages.recommendations)}
-        url={`/api/v1/movie/${router.query.movieId}/recommendations`}
+        url={apiUrl(`/movie/${router.query.movieId}/recommendations`)}
         linkUrl={`/movie/${data.id}/recommendations`}
         hideWhenEmpty
       />
       <MediaSlider
         sliderKey="similar"
         title={intl.formatMessage(messages.similar)}
-        url={`/api/v1/movie/${router.query.movieId}/similar`}
+        url={apiUrl(`/movie/${router.query.movieId}/similar`)}
         linkUrl={`/movie/${data.id}/similar`}
         hideWhenEmpty
       />

--- a/src/components/PersonDetails/index.tsx
+++ b/src/components/PersonDetails/index.tsx
@@ -7,6 +7,7 @@ import ExternalLinkBlock from '@app/components/ExternalLinkBlock';
 import TitleCard from '@app/components/TitleCard';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { CircleStackIcon } from '@heroicons/react/24/solid';
 import type { PersonCombinedCreditsResponse } from '@server/interfaces/api/personInterfaces';
@@ -34,13 +35,13 @@ const PersonDetails = () => {
   const router = useRouter();
   const [currentMediaType, setCurrentMediaType] = useState<string>('all');
   const { data, error } = useSWR<PersonDetailsType>(
-    `/api/v1/person/${router.query.personId}`
+    apiUrl(`/person/${router.query.personId}`)
   );
   const [showBio, setShowBio] = useState(false);
 
   const { data: combinedCredits, error: errorCombinedCredits } =
     useSWR<PersonCombinedCreditsResponse>(
-      `/api/v1/person/${router.query.personId}/combined_credits`
+      apiUrl(`/person/${router.query.personId}/combined_credits`)
     );
 
   const sortedCast = useMemo(() => {

--- a/src/components/RegionSelector/index.tsx
+++ b/src/components/RegionSelector/index.tsx
@@ -1,4 +1,5 @@
 import useSettings from '@app/hooks/useSettings';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Listbox, Transition } from '@headlessui/react';
 import { CheckIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
@@ -37,7 +38,7 @@ const RegionSelector = ({
   const { currentSettings } = useSettings();
   const intl = useIntl();
   const { data: regions } = useSWR<Region[]>(
-    watchProviders ? '/api/v1/watchproviders/regions' : '/api/v1/regions'
+    watchProviders ? apiUrl('/watchproviders/regions') : apiUrl('/regions')
   );
   const [selectedRegion, setSelectedRegion] = useState<Region | null>(null);
 

--- a/src/components/RequestBlock/index.tsx
+++ b/src/components/RequestBlock/index.tsx
@@ -6,6 +6,7 @@ import RequestModal from '@app/components/RequestModal';
 import useRequestOverride from '@app/hooks/useRequestOverride';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import {
   CalendarIcon,
@@ -55,22 +56,22 @@ const RequestBlock = ({ request, onUpdate }: RequestBlockProps) => {
 
   const updateRequest = async (type: 'approve' | 'decline'): Promise<void> => {
     setIsUpdating(true);
-    await axios.post(`/api/v1/request/${request.id}/${type}`);
+    await axios.post(apiUrl(`/request/${request.id}/${type}`));
 
     if (onUpdate) {
       onUpdate();
-      mutate('/api/v1/request/count');
+      mutate(apiUrl('/request/count'));
     }
     setIsUpdating(false);
   };
 
   const deleteRequest = async () => {
     setIsUpdating(true);
-    await axios.delete(`/api/v1/request/${request.id}`);
+    await axios.delete(apiUrl(`/request/${request.id}`));
 
     if (onUpdate) {
       onUpdate();
-      mutate('/api/v1/request/count');
+      mutate(apiUrl('/request/count'));
     }
 
     setIsUpdating(false);

--- a/src/components/RequestButton/index.tsx
+++ b/src/components/RequestButton/index.tsx
@@ -3,6 +3,7 @@ import RequestModal from '@app/components/RequestModal';
 import useSettings from '@app/hooks/useSettings';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownTrayIcon } from '@heroicons/react/24/outline';
 import {
@@ -96,11 +97,11 @@ const RequestButton = ({
     request: MediaRequest,
     type: 'approve' | 'decline'
   ) => {
-    const response = await axios.post(`/api/v1/request/${request.id}/${type}`);
+    const response = await axios.post(apiUrl(`/request/${request.id}/${type}`));
 
     if (response) {
       onUpdate();
-      mutate('/api/v1/request/count');
+      mutate(apiUrl('/request/count'));
     }
   };
 
@@ -114,12 +115,12 @@ const RequestButton = ({
 
     await Promise.all(
       requests.map(async (request) => {
-        return axios.post(`/api/v1/request/${request.id}/${type}`);
+        return axios.post(apiUrl(`/request/${request.id}/${type}`));
       })
     );
 
     onUpdate();
-    mutate('/api/v1/request/count');
+    mutate(apiUrl('/request/count'));
   };
 
   const buttons: ButtonOption[] = [];

--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -7,6 +7,7 @@ import StatusBadge from '@app/components/StatusBadge';
 import useDeepLinks from '@app/hooks/useDeepLinks';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
 import { withProperties } from '@app/utils/typeHelpers';
@@ -74,10 +75,10 @@ const RequestCardError = ({ requestData }: RequestCardErrorProps) => {
   });
 
   const deleteRequest = async () => {
-    await axios.delete(`/api/v1/media/${requestData?.media.id}`);
-    mutate('/api/v1/media?filter=allavailable&take=20&sort=mediaAdded');
-    mutate('/api/v1/request?filter=all&take=10&sort=modified&skip=0');
-    mutate('/api/v1/request/count');
+    await axios.delete(apiUrl(`/media/${requestData?.media.id}`));
+    mutate(apiUrl('/media?filter=allavailable&take=20&sort=mediaAdded'));
+    mutate(apiUrl('/request?filter=all&take=10&sort=modified&skip=0'));
+    mutate(apiUrl('/request/count'));
   };
 
   return (
@@ -228,8 +229,8 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
   const [showEditModal, setShowEditModal] = useState(false);
   const url =
     request.type === 'movie'
-      ? `/api/v1/movie/${request.media.tmdbId}`
-      : `/api/v1/tv/${request.media.tmdbId}`;
+      ? apiUrl(`/movie/${request.media.tmdbId}`)
+      : apiUrl(`/tv/${request.media.tmdbId}`);
 
   const { data: title, error } = useSWR<MovieDetails | TvDetails>(
     inView ? `${url}` : null
@@ -239,7 +240,7 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
     error: requestError,
     mutate: revalidate,
   } = useSWR<NonFunctionProperties<MediaRequest>>(
-    `/api/v1/request/${request.id}`,
+    apiUrl(`/request/${request.id}`),
     {
       fallbackData: request,
       refreshInterval: refreshIntervalHelper(
@@ -260,25 +261,25 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
   });
 
   const modifyRequest = async (type: 'approve' | 'decline') => {
-    const response = await axios.post(`/api/v1/request/${request.id}/${type}`);
+    const response = await axios.post(apiUrl(`/request/${request.id}/${type}`));
 
     if (response) {
       revalidate();
-      mutate('/api/v1/request/count');
+      mutate(apiUrl('/request/count'));
     }
   };
 
   const deleteRequest = async () => {
-    await axios.delete(`/api/v1/request/${request.id}`);
-    mutate('/api/v1/request?filter=all&take=10&sort=modified&skip=0');
-    mutate('/api/v1/request/count');
+    await axios.delete(apiUrl(`/request/${request.id}`));
+    mutate(apiUrl('/request?filter=all&take=10&sort=modified&skip=0'));
+    mutate(apiUrl('/request/count'));
   };
 
   const retryRequest = async () => {
     setRetrying(true);
 
     try {
-      const response = await axios.post(`/api/v1/request/${request.id}/retry`);
+      const response = await axios.post(apiUrl(`/request/${request.id}/retry`));
 
       if (response) {
         revalidate();

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -7,6 +7,7 @@ import StatusBadge from '@app/components/StatusBadge';
 import useDeepLinks from '@app/hooks/useDeepLinks';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
 import {
@@ -65,9 +66,9 @@ const RequestItemError = ({
   const { hasPermission } = useUser();
 
   const deleteRequest = async () => {
-    await axios.delete(`/api/v1/media/${requestData?.media.id}`);
+    await axios.delete(apiUrl(`/media/${requestData?.media.id}`));
     revalidateList();
-    mutate('/api/v1/request/count');
+    mutate(apiUrl('/request/count'));
   };
 
   const { mediaUrl: plexUrl, mediaUrl4k: plexUrl4k } = useDeepLinks({
@@ -303,14 +304,14 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
   const [showEditModal, setShowEditModal] = useState(false);
   const url =
     request.type === 'movie'
-      ? `/api/v1/movie/${request.media.tmdbId}`
-      : `/api/v1/tv/${request.media.tmdbId}`;
+      ? apiUrl(`/movie/${request.media.tmdbId}`)
+      : apiUrl(`/tv/${request.media.tmdbId}`);
   const { data: title, error } = useSWR<MovieDetails | TvDetails>(
     inView ? url : null
   );
   const { data: requestData, mutate: revalidate } = useSWR<
     NonFunctionProperties<MediaRequest>
-  >(`/api/v1/request/${request.id}`, {
+  >(apiUrl(`/request/${request.id}`), {
     fallbackData: request,
     refreshInterval: refreshIntervalHelper(
       {
@@ -324,27 +325,27 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
   const [isRetrying, setRetrying] = useState(false);
 
   const modifyRequest = async (type: 'approve' | 'decline') => {
-    const response = await axios.post(`/api/v1/request/${request.id}/${type}`);
+    const response = await axios.post(apiUrl(`/request/${request.id}/${type}`));
 
     if (response) {
       revalidate();
-      mutate('/api/v1/request/count');
+      mutate(apiUrl('/request/count'));
     }
   };
 
   const deleteRequest = async () => {
-    await axios.delete(`/api/v1/request/${request.id}`);
+    await axios.delete(apiUrl(`/request/${request.id}`));
 
     revalidateList();
-    mutate('/api/v1/request/count');
+    mutate(apiUrl('/request/count'));
   };
 
   const deleteMediaFile = async () => {
     if (request.media) {
       await axios.delete(
-        `/api/v1/media/${request.media.id}/file?is4k=${request.is4k}`
+        apiUrl(`/media/${request.media.id}/file?is4k=${request.is4k}`)
       );
-      await axios.delete(`/api/v1/media/${request.media.id}`);
+      await axios.delete(apiUrl(`/media/${request.media.id}`));
       revalidateList();
     }
   };
@@ -353,7 +354,7 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
     setRetrying(true);
 
     try {
-      const result = await axios.post(`/api/v1/request/${request.id}/retry`);
+      const result = await axios.post(apiUrl(`/request/${request.id}/retry`));
       revalidate(result.data);
     } catch {
       addToast(intl.formatMessage(messages.failedretry), {

--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -7,6 +7,7 @@ import RequestItem from '@app/components/RequestList/RequestItem';
 import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import {
@@ -76,15 +77,17 @@ const RequestList = () => {
     error,
     mutate: revalidate,
   } = useSWR<RequestResultsResponse>(
-    `/api/v1/request?take=${currentPageSize}&skip=${
-      pageIndex * currentPageSize
-    }&filter=${currentFilter}&mediaType=${currentMediaType}&sort=${currentSort}&sortDirection=${currentSortDirection}${
-      router.pathname.startsWith('/profile')
-        ? `&requestedBy=${currentUser?.id}`
-        : router.query.userId
-          ? `&requestedBy=${router.query.userId}`
-          : ''
-    }`
+    apiUrl(
+      `/request?take=${currentPageSize}&skip=${
+        pageIndex * currentPageSize
+      }&filter=${currentFilter}&mediaType=${currentMediaType}&sort=${currentSort}&sortDirection=${currentSortDirection}${
+        router.pathname.startsWith('/profile')
+          ? `&requestedBy=${currentUser?.id}`
+          : router.query.userId
+            ? `&requestedBy=${router.query.userId}`
+            : ''
+      }`
+    )
   );
 
   // Restore last set filter values on component mount

--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -4,6 +4,7 @@ import { SmallLoadingSpinner } from '@app/components/Common/LoadingSpinner';
 import type { User } from '@app/hooks/useUser';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { formatBytes } from '@app/utils/numberHelpers';
 import { Listbox, Transition } from '@headlessui/react';
@@ -69,7 +70,7 @@ const AdvancedRequester = ({
   const intl = useIntl();
   const { user: currentUser, hasPermission: currentHasPermission } = useUser();
   const { data, error } = useSWR<ServiceCommonServer[]>(
-    `/api/v1/service/${type === 'movie' ? 'radarr' : 'sonarr'}`,
+    apiUrl(`/service/${type === 'movie' ? 'radarr' : 'sonarr'}`),
     {
       refreshInterval: 0,
       refreshWhenHidden: false,
@@ -100,9 +101,11 @@ const AdvancedRequester = ({
   const { data: serverData, isValidating } =
     useSWR<ServiceCommonServerWithDetails>(
       selectedServer !== null
-        ? `/api/v1/service/${
-            type === 'movie' ? 'radarr' : 'sonarr'
-          }/${selectedServer}`
+        ? apiUrl(
+            `/service/${
+              type === 'movie' ? 'radarr' : 'sonarr'
+            }/${selectedServer}`
+          )
         : null,
       {
         refreshInterval: 0,
@@ -117,7 +120,7 @@ const AdvancedRequester = ({
 
   const { data: userData } = useSWR<UserResultsResponse>(
     currentHasPermission([Permission.MANAGE_REQUESTS, Permission.MANAGE_USERS])
-      ? '/api/v1/user?take=1000&sort=displayname'
+      ? apiUrl('/user?take=1000&sort=displayname')
       : null
   );
   const filteredUserData = useMemo(

--- a/src/components/RequestModal/CollectionRequestModal.tsx
+++ b/src/components/RequestModal/CollectionRequestModal.tsx
@@ -7,6 +7,7 @@ import AdvancedRequester from '@app/components/RequestModal/AdvancedRequester';
 import QuotaDisplay from '@app/components/RequestModal/QuotaDisplay';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { MediaRequestStatus, MediaStatus } from '@server/constants/media';
 import type { MediaRequest } from '@server/entity/MediaRequest';
@@ -51,7 +52,7 @@ const CollectionRequestModal = ({
     useState<RequestOverrides | null>(null);
   const [selectedParts, setSelectedParts] = useState<number[]>([]);
   const { addToast } = useToasts();
-  const { data, error } = useSWR<Collection>(`/api/v1/collection/${tmdbId}`, {
+  const { data, error } = useSWR<Collection>(apiUrl(`/collection/${tmdbId}`), {
     revalidateOnMount: true,
   });
   const intl = useIntl();
@@ -59,7 +60,7 @@ const CollectionRequestModal = ({
   const { data: quota } = useSWR<QuotaResponse>(
     user &&
       (!requestOverrides?.user?.id || hasPermission(Permission.MANAGE_USERS))
-      ? `/api/v1/user/${requestOverrides?.user?.id ?? user.id}/quota`
+      ? apiUrl(`/user/${requestOverrides?.user?.id ?? user.id}/quota`)
       : null
   );
 
@@ -202,7 +203,7 @@ const CollectionRequestModal = ({
         (
           data?.parts.filter((part) => selectedParts.includes(part.id)) ?? []
         ).map(async (part) => {
-          await axios.post<MediaRequest>('/api/v1/request', {
+          await axios.post<MediaRequest>(apiUrl('/request'), {
             mediaId: part.id,
             mediaType: 'movie',
             is4k,
@@ -217,7 +218,7 @@ const CollectionRequestModal = ({
             ? MediaStatus.UNKNOWN
             : MediaStatus.PARTIALLY_AVAILABLE
         );
-        mutate('/api/v1/request/count');
+        mutate(apiUrl('/request/count'));
       }
 
       addToast(

--- a/src/components/RequestModal/MovieRequestModal.tsx
+++ b/src/components/RequestModal/MovieRequestModal.tsx
@@ -5,6 +5,7 @@ import AdvancedRequester from '@app/components/RequestModal/AdvancedRequester';
 import QuotaDisplay from '@app/components/RequestModal/QuotaDisplay';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { MediaStatus } from '@server/constants/media';
 import type { MediaRequest } from '@server/entity/MediaRequest';
@@ -58,7 +59,7 @@ const MovieRequestModal = ({
   const [requestOverrides, setRequestOverrides] =
     useState<RequestOverrides | null>(null);
   const { addToast } = useToasts();
-  const { data, error } = useSWR<MovieDetails>(`/api/v1/movie/${tmdbId}`, {
+  const { data, error } = useSWR<MovieDetails>(apiUrl(`/movie/${tmdbId}`), {
     revalidateOnMount: true,
   });
   const intl = useIntl();
@@ -66,7 +67,7 @@ const MovieRequestModal = ({
   const { data: quota } = useSWR<QuotaResponse>(
     user &&
       (!requestOverrides?.user?.id || hasPermission(Permission.MANAGE_USERS))
-      ? `/api/v1/user/${requestOverrides?.user?.id ?? user.id}/quota`
+      ? apiUrl(`/user/${requestOverrides?.user?.id ?? user.id}/quota`)
       : null
   );
 
@@ -90,14 +91,14 @@ const MovieRequestModal = ({
           tags: requestOverrides.tags,
         };
       }
-      const response = await axios.post<MediaRequest>('/api/v1/request', {
+      const response = await axios.post<MediaRequest>(apiUrl('/request'), {
         mediaId: data?.id,
         mediaType: 'movie',
         is4k,
         ...overrideParams,
       });
-      mutate('/api/v1/request?filter=all&take=10&sort=modified&skip=0');
-      mutate('/api/v1/request/count');
+      mutate(apiUrl('/request?filter=all&take=10&sort=modified&skip=0'));
+      mutate(apiUrl('/request/count'));
 
       if (response.data) {
         if (onComplete) {
@@ -148,10 +149,10 @@ const MovieRequestModal = ({
 
     try {
       const response = await axios.delete<MediaRequest>(
-        `/api/v1/request/${editRequest?.id}`
+        apiUrl(`/request/${editRequest?.id}`)
       );
-      mutate('/api/v1/request?filter=all&take=10&sort=modified&skip=0');
-      mutate('/api/v1/request/count');
+      mutate(apiUrl('/request?filter=all&take=10&sort=modified&skip=0'));
+      mutate(apiUrl('/request/count'));
 
       if (response.status === 204) {
         if (onComplete) {
@@ -176,7 +177,7 @@ const MovieRequestModal = ({
     setIsUpdating(true);
 
     try {
-      await axios.put(`/api/v1/request/${editRequest?.id}`, {
+      await axios.put(apiUrl(`/request/${editRequest?.id}`), {
         mediaType: 'movie',
         serverId: requestOverrides?.server,
         profileId: requestOverrides?.profile,
@@ -186,10 +187,10 @@ const MovieRequestModal = ({
       });
 
       if (alsoApproveRequest) {
-        await axios.post(`/api/v1/request/${editRequest?.id}/approve`);
+        await axios.post(apiUrl(`/request/${editRequest?.id}/approve`));
       }
-      mutate('/api/v1/request?filter=all&take=10&sort=modified&skip=0');
-      mutate('/api/v1/request/count');
+      mutate(apiUrl('/request?filter=all&take=10&sort=modified&skip=0'));
+      mutate(apiUrl('/request/count'));
 
       addToast(
         <span>

--- a/src/components/RequestModal/SearchByNameModal/index.tsx
+++ b/src/components/RequestModal/SearchByNameModal/index.tsx
@@ -2,6 +2,7 @@ import Alert from '@app/components/Common/Alert';
 import CachedImage from '@app/components/Common/CachedImage';
 import Modal from '@app/components/Common/Modal';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { SonarrSeries } from '@server/api/servarr/sonarr';
 import { useIntl } from 'react-intl';
@@ -36,7 +37,7 @@ const SearchByNameModal = ({
 }: SearchByNameModalProps) => {
   const intl = useIntl();
   const { data, error } = useSWR<SonarrSeries[]>(
-    `/api/v1/service/sonarr/lookup/${tmdbId}`
+    apiUrl(`/service/sonarr/lookup/${tmdbId}`)
   );
 
   const handleClick = (tvdbId: number) => {

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -8,6 +8,7 @@ import SearchByNameModal from '@app/components/RequestModal/SearchByNameModal';
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ANIME_KEYWORD_ID } from '@server/api/themoviedb/constants';
 import { MediaRequestStatus, MediaStatus } from '@server/constants/media';
@@ -74,7 +75,7 @@ const TvRequestModal = ({
   const editingSeasons: number[] = (editRequest?.seasons ?? []).map(
     (season) => season.seasonNumber
   );
-  const { data, error } = useSWR<TvDetails>(`/api/v1/tv/${tmdbId}`);
+  const { data, error } = useSWR<TvDetails>(apiUrl(`/tv/${tmdbId}`));
   const [requestOverrides, setRequestOverrides] =
     useState<RequestOverrides | null>(null);
   const [selectedSeasons, setSelectedSeasons] = useState<number[]>(
@@ -91,7 +92,7 @@ const TvRequestModal = ({
   const { data: quota } = useSWR<QuotaResponse>(
     user &&
       (!requestOverrides?.user?.id || hasPermission(Permission.MANAGE_USERS))
-      ? `/api/v1/user/${requestOverrides?.user?.id ?? user.id}/quota`
+      ? apiUrl(`/user/${requestOverrides?.user?.id ?? user.id}/quota`)
       : null
   );
 
@@ -107,12 +108,12 @@ const TvRequestModal = ({
 
     if (onUpdating) {
       onUpdating(true);
-      mutate('/api/v1/request/count');
+      mutate(apiUrl('/request/count'));
     }
 
     try {
       if (selectedSeasons.length > 0) {
-        await axios.put(`/api/v1/request/${editRequest.id}`, {
+        await axios.put(apiUrl(`/request/${editRequest.id}`), {
           mediaType: 'tv',
           serverId: requestOverrides?.server,
           profileId: requestOverrides?.profile,
@@ -124,13 +125,13 @@ const TvRequestModal = ({
         });
 
         if (alsoApproveRequest) {
-          await axios.post(`/api/v1/request/${editRequest.id}/approve`);
+          await axios.post(apiUrl(`/request/${editRequest.id}/approve`));
         }
       } else {
-        await axios.delete(`/api/v1/request/${editRequest.id}`);
+        await axios.delete(apiUrl(`/request/${editRequest.id}`));
       }
-      mutate('/api/v1/request?filter=all&take=10&sort=modified&skip=0');
-      mutate('/api/v1/request/count');
+      mutate(apiUrl('/request?filter=all&take=10&sort=modified&skip=0'));
+      mutate(apiUrl('/request/count'));
 
       addToast(
         <span>
@@ -179,7 +180,7 @@ const TvRequestModal = ({
 
     if (onUpdating) {
       onUpdating(true);
-      mutate('/api/v1/request/count');
+      mutate(apiUrl('/request/count'));
     }
 
     try {
@@ -194,7 +195,7 @@ const TvRequestModal = ({
           tags: requestOverrides.tags,
         };
       }
-      const response = await axios.post<MediaRequest>('/api/v1/request', {
+      const response = await axios.post<MediaRequest>(apiUrl('/request'), {
         mediaId: data?.id,
         tvdbId: tvdbId ?? data?.externalIds.tvdbId,
         mediaType: 'tv',
@@ -207,7 +208,7 @@ const TvRequestModal = ({
             ),
         ...overrideParams,
       });
-      mutate('/api/v1/request?filter=all&take=10&sort=modified&skip=0');
+      mutate(apiUrl('/request?filter=all&take=10&sort=modified&skip=0'));
 
       if (response.data) {
         if (onComplete) {

--- a/src/components/ResetPassword/RequestResetLink.tsx
+++ b/src/components/ResetPassword/RequestResetLink.tsx
@@ -2,6 +2,7 @@ import Button from '@app/components/Common/Button';
 import ImageFader from '@app/components/Common/ImageFader';
 import PageTitle from '@app/components/Common/PageTitle';
 import LanguagePicker from '@app/components/Layout/LanguagePicker';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowLeftIcon, EnvelopeIcon } from '@heroicons/react/24/solid';
 import axios from 'axios';
@@ -91,7 +92,7 @@ const ResetPassword = () => {
                 validationSchema={ResetSchema}
                 onSubmit={async (values) => {
                   const response = await axios.post(
-                    `/api/v1/auth/reset-password`,
+                    apiUrl(`/auth/reset-password`),
                     {
                       email: values.email,
                     }

--- a/src/components/ResetPassword/index.tsx
+++ b/src/components/ResetPassword/index.tsx
@@ -3,6 +3,7 @@ import ImageFader from '@app/components/Common/ImageFader';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import LanguagePicker from '@app/components/Layout/LanguagePicker';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { LifebuoyIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
@@ -101,7 +102,7 @@ const ResetPassword = () => {
                 validationSchema={ResetSchema}
                 onSubmit={async (values) => {
                   const response = await axios.post(
-                    `/api/v1/auth/reset-password/${guid}`,
+                    apiUrl(`/auth/reset-password/${guid}`),
                     {
                       password: values.password,
                     }

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -3,6 +3,7 @@ import ListView from '@app/components/Common/ListView';
 import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type {
   MovieResult,
@@ -30,7 +31,7 @@ const Search = () => {
     fetchMore,
     error,
   } = useDiscover<MovieResult | TvResult | PersonResult>(
-    `/api/v1/search`,
+    apiUrl(`/search`),
     {
       query: router.query.query,
     },

--- a/src/components/Selector/CertificationSelector.tsx
+++ b/src/components/Selector/CertificationSelector.tsx
@@ -1,4 +1,5 @@
 import { SmallLoadingSpinner } from '@app/components/Common/LoadingSpinner';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { Region } from '@server/lib/settings';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -76,9 +77,9 @@ const CertificationSelector: React.FC<CertificationSelectorProps> = ({
     data: certificationData,
     error: certificationError,
     isLoading: certificationLoading,
-  } = useSWR<CertificationResponse>(`/api/v1/certifications/${type}`);
+  } = useSWR<CertificationResponse>(apiUrl(`/certifications/${type}`));
 
-  const { data: regionsData } = useSWR<Region[]>('/api/v1/regions');
+  const { data: regionsData } = useSWR<Region[]>(apiUrl('/regions'));
 
   // Get the country name from its code
   const getCountryName = useCallback(

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -4,6 +4,7 @@ import Tooltip from '@app/components/Common/Tooltip';
 import RegionSelector from '@app/components/RegionSelector';
 import { encodeURIExtraParams } from '@app/hooks/useDiscover';
 import useSettings from '@app/hooks/useSettings';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownIcon, ArrowUpIcon } from '@heroicons/react/20/solid';
 import { CheckCircleIcon } from '@heroicons/react/24/solid';
@@ -81,7 +82,7 @@ export const CompanySelector = ({
       }
 
       const response = await axios.get<ProductionCompany>(
-        `/api/v1/studio/${defaultValue}`
+        apiUrl(`/studio/${defaultValue}`)
       );
 
       const studio = response.data;
@@ -103,7 +104,7 @@ export const CompanySelector = ({
     }
 
     const results = await axios.get<TmdbCompanySearchResponse>(
-      '/api/v1/search/company',
+      apiUrl('/search/company'),
       {
         params: {
           query: encodeURIExtraParams(inputValue),
@@ -167,7 +168,7 @@ export const GenreSelector = ({
 
       const genres = defaultValue.split(',');
 
-      const response = await axios.get<TmdbGenre[]>(`/api/v1/genres/${type}`);
+      const response = await axios.get<TmdbGenre[]>(apiUrl(`/genres/${type}`));
 
       const genreData = genres
         .filter((genre) => response.data.find((gd) => gd.id === Number(genre)))
@@ -184,7 +185,7 @@ export const GenreSelector = ({
   }, [defaultValue, type]);
 
   const loadGenreOptions = async (inputValue: string) => {
-    const results = await axios.get<TmdbGenre[]>(`/api/v1/genres/${type}`);
+    const results = await axios.get<TmdbGenre[]>(apiUrl(`/genres/${type}`));
 
     return results.data
       .map((result) => ({
@@ -307,7 +308,7 @@ export const KeywordSelector = ({
       const keywords = await Promise.all(
         defaultValue.split(',').map(async (keywordId) => {
           const keyword = await axios.get<Keyword | null>(
-            `/api/v1/keyword/${keywordId}`
+            apiUrl(`/keyword/${keywordId}`)
           );
           return keyword.data;
         })
@@ -330,7 +331,7 @@ export const KeywordSelector = ({
 
   const loadKeywordOptions = async (inputValue: string) => {
     const results = await axios.get<TmdbKeywordSearchResponse>(
-      '/api/v1/search/keyword',
+      apiUrl('/search/keyword'),
       {
         params: {
           query: encodeURIExtraParams(inputValue),
@@ -395,9 +396,11 @@ export const WatchProviderSelector = ({
     activeProviders ?? []
   );
   const { data, isLoading } = useSWR<WatchProviderDetails[]>(
-    `/api/v1/watchproviders/${
-      type === 'movie' ? 'movies' : 'tv'
-    }?watchRegion=${watchRegion}`
+    apiUrl(
+      `/watchproviders/${
+        type === 'movie' ? 'movies' : 'tv'
+      }?watchRegion=${watchRegion}`
+    )
   );
 
   useEffect(() => {
@@ -578,7 +581,7 @@ export const UserSelector = ({
       const users = defaultValue.split(',');
 
       const res = await axios.get(
-        `/api/v1/user?includeIds=${encodeURIComponent(defaultValue)}`
+        apiUrl(`/user?includeIds=${encodeURIComponent(defaultValue)}`)
       );
       const response: UserResultsResponse = res.data;
 
@@ -598,7 +601,7 @@ export const UserSelector = ({
 
   const loadUserOptions = async (inputValue: string) => {
     const res = await axios.get(
-      `/api/v1/user${inputValue ? `?q=${encodeURIComponent(inputValue)}` : ''}`
+      apiUrl(`/user${inputValue ? `?q=${encodeURIComponent(inputValue)}` : ''}`)
     );
     const results: UserResultsResponse = res.data;
 

--- a/src/components/Settings/Notifications/NotificationsDiscord.tsx
+++ b/src/components/Settings/Notifications/NotificationsDiscord.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import useSettings from '@app/hooks/useSettings';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon, BeakerIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
@@ -44,7 +45,7 @@ const NotificationsDiscord = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR('/api/v1/settings/notifications/discord');
+  } = useSWR(apiUrl('/settings/notifications/discord'));
 
   const NotificationsDiscordSchema = Yup.object().shape({
     botAvatarUrl: Yup.string()
@@ -86,7 +87,7 @@ const NotificationsDiscord = () => {
       validationSchema={NotificationsDiscordSchema}
       onSubmit={async (values) => {
         try {
-          await axios.post('/api/v1/settings/notifications/discord', {
+          await axios.post(apiUrl('/settings/notifications/discord'), {
             enabled: values.enabled,
             embedPoster: values.embedPoster,
             types: values.types,
@@ -136,7 +137,7 @@ const NotificationsDiscord = () => {
                 toastId = id;
               }
             );
-            await axios.post('/api/v1/settings/notifications/discord/test', {
+            await axios.post(apiUrl('/settings/notifications/discord/test'), {
               enabled: true,
               embedPoster: values.embedPoster,
               types: values.types,

--- a/src/components/Settings/Notifications/NotificationsEmail.tsx
+++ b/src/components/Settings/Notifications/NotificationsEmail.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import SettingsBadge from '@app/components/Settings/SettingsBadge';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon, BeakerIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
@@ -66,7 +67,7 @@ const NotificationsEmail = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR('/api/v1/settings/notifications/email');
+  } = useSWR(apiUrl('/settings/notifications/email'));
 
   const NotificationsEmailSchema = Yup.object().shape(
     {
@@ -150,7 +151,7 @@ const NotificationsEmail = () => {
       validationSchema={NotificationsEmailSchema}
       onSubmit={async (values) => {
         try {
-          await axios.post('/api/v1/settings/notifications/email', {
+          await axios.post(apiUrl('/settings/notifications/email'), {
             enabled: values.enabled,
             embedPoster: values.embedPoster,
             options: {
@@ -169,7 +170,7 @@ const NotificationsEmail = () => {
               pgpPassword: values.pgpPassword,
             },
           });
-          mutate('/api/v1/settings/public');
+          mutate(apiUrl('/settings/public'));
 
           addToast(intl.formatMessage(messages.emailsettingssaved), {
             appearance: 'success',
@@ -200,7 +201,7 @@ const NotificationsEmail = () => {
                 toastId = id;
               }
             );
-            await axios.post('/api/v1/settings/notifications/email/test', {
+            await axios.post(apiUrl('/settings/notifications/email/test'), {
               enabled: true,
               embedPoster: values.embedPoster,
               options: {

--- a/src/components/Settings/Notifications/NotificationsGotify/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsGotify/index.tsx
@@ -2,6 +2,7 @@ import Button from '@app/components/Common/Button';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { isValidURL } from '@app/utils/urlValidationHelper';
 import { ArrowDownOnSquareIcon, BeakerIcon } from '@heroicons/react/24/solid';
@@ -41,7 +42,7 @@ const NotificationsGotify = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR('/api/v1/settings/notifications/gotify');
+  } = useSWR(apiUrl('/settings/notifications/gotify'));
 
   const NotificationsGotifySchema = Yup.object().shape({
     url: Yup.string()
@@ -96,7 +97,7 @@ const NotificationsGotify = () => {
       validationSchema={NotificationsGotifySchema}
       onSubmit={async (values) => {
         try {
-          await axios.post('/api/v1/settings/notifications/gotify', {
+          await axios.post(apiUrl('/settings/notifications/gotify'), {
             enabled: values.enabled,
             types: values.types,
             options: {
@@ -142,7 +143,7 @@ const NotificationsGotify = () => {
                 toastId = id;
               }
             );
-            await axios.post('/api/v1/settings/notifications/gotify/test', {
+            await axios.post(apiUrl('/settings/notifications/gotify/test'), {
               enabled: true,
               types: values.types,
               options: {

--- a/src/components/Settings/Notifications/NotificationsNtfy/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsNtfy/index.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { isValidURL } from '@app/utils/urlValidationHelper';
 import { ArrowDownOnSquareIcon, BeakerIcon } from '@heroicons/react/24/outline';
@@ -48,7 +49,7 @@ const NotificationsNtfy = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR<NotificationAgentNtfy>('/api/v1/settings/notifications/ntfy');
+  } = useSWR<NotificationAgentNtfy>(apiUrl('/settings/notifications/ntfy'));
 
   const NotificationsNtfySchema = Yup.object().shape({
     url: Yup.string()
@@ -105,7 +106,7 @@ const NotificationsNtfy = () => {
       validationSchema={NotificationsNtfySchema}
       onSubmit={async (values) => {
         try {
-          await axios.post('/api/v1/settings/notifications/ntfy', {
+          await axios.post(apiUrl('/settings/notifications/ntfy'), {
             enabled: values.enabled,
             embedPoster: values.embedPoster,
             types: values.types,
@@ -158,7 +159,7 @@ const NotificationsNtfy = () => {
                 toastId = id;
               }
             );
-            await axios.post('/api/v1/settings/notifications/ntfy/test', {
+            await axios.post(apiUrl('/settings/notifications/ntfy/test'), {
               enabled: true,
               types: values.types,
               options: {

--- a/src/components/Settings/Notifications/NotificationsPushbullet/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsPushbullet/index.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon, BeakerIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
@@ -41,7 +42,7 @@ const NotificationsPushbullet = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR('/api/v1/settings/notifications/pushbullet');
+  } = useSWR(apiUrl('/settings/notifications/pushbullet'));
 
   const NotificationsPushbulletSchema = Yup.object().shape({
     accessToken: Yup.string().when('enabled', {
@@ -68,7 +69,7 @@ const NotificationsPushbullet = () => {
       validationSchema={NotificationsPushbulletSchema}
       onSubmit={async (values) => {
         try {
-          await axios.post('/api/v1/settings/notifications/pushbullet', {
+          await axios.post(apiUrl('/settings/notifications/pushbullet'), {
             enabled: values.enabled,
             types: values.types,
             options: {
@@ -113,14 +114,17 @@ const NotificationsPushbullet = () => {
                 toastId = id;
               }
             );
-            await axios.post('/api/v1/settings/notifications/pushbullet/test', {
-              enabled: true,
-              types: values.types,
-              options: {
-                accessToken: values.accessToken,
-                channelTag: values.channelTag,
-              },
-            });
+            await axios.post(
+              apiUrl('/settings/notifications/pushbullet/test'),
+              {
+                enabled: true,
+                types: values.types,
+                options: {
+                  accessToken: values.accessToken,
+                  channelTag: values.channelTag,
+                },
+              }
+            );
 
             if (toastId) {
               removeToast(toastId);

--- a/src/components/Settings/Notifications/NotificationsPushover/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsPushover/index.tsx
@@ -2,6 +2,7 @@ import Button from '@app/components/Common/Button';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon, BeakerIcon } from '@heroicons/react/24/outline';
 import type { PushoverSound } from '@server/api/pushover';
@@ -45,10 +46,12 @@ const NotificationsPushover = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR('/api/v1/settings/notifications/pushover');
+  } = useSWR(apiUrl('/settings/notifications/pushover'));
   const { data: soundsData } = useSWR<PushoverSound[]>(
     data?.options.accessToken
-      ? `/api/v1/settings/notifications/pushover/sounds?token=${data.options.accessToken}`
+      ? apiUrl(
+          `/settings/notifications/pushover/sounds?token=${data.options.accessToken}`
+        )
       : null,
     {
       revalidateOnFocus: false,
@@ -101,7 +104,7 @@ const NotificationsPushover = () => {
       validationSchema={NotificationsPushoverSchema}
       onSubmit={async (values) => {
         try {
-          await axios.post('/api/v1/settings/notifications/pushover', {
+          await axios.post(apiUrl('/settings/notifications/pushover'), {
             enabled: values.enabled,
             embedPoster: values.embedPoster,
             types: values.types,
@@ -148,7 +151,7 @@ const NotificationsPushover = () => {
                 toastId = id;
               }
             );
-            await axios.post('/api/v1/settings/notifications/pushover/test', {
+            await axios.post(apiUrl('/settings/notifications/pushover/test'), {
               enabled: true,
               embedPoster: values.embedPoster,
               types: values.types,

--- a/src/components/Settings/Notifications/NotificationsSlack/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsSlack/index.tsx
@@ -2,6 +2,7 @@ import Button from '@app/components/Common/Button';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon, BeakerIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
@@ -38,7 +39,7 @@ const NotificationsSlack = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR('/api/v1/settings/notifications/slack');
+  } = useSWR(apiUrl('/settings/notifications/slack'));
 
   const NotificationsSlackSchema = Yup.object().shape({
     webhookUrl: Yup.string()
@@ -67,7 +68,7 @@ const NotificationsSlack = () => {
       validationSchema={NotificationsSlackSchema}
       onSubmit={async (values) => {
         try {
-          await axios.post('/api/v1/settings/notifications/slack', {
+          await axios.post(apiUrl('/settings/notifications/slack'), {
             enabled: values.enabled,
             embedPoster: values.embedPoster,
             types: values.types,
@@ -112,7 +113,7 @@ const NotificationsSlack = () => {
                 toastId = id;
               }
             );
-            await axios.post('/api/v1/settings/notifications/slack/test', {
+            await axios.post(apiUrl('/settings/notifications/slack/test'), {
               enabled: true,
               embedPoster: values.embedPoster,
               types: values.types,

--- a/src/components/Settings/Notifications/NotificationsTelegram.tsx
+++ b/src/components/Settings/Notifications/NotificationsTelegram.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon, BeakerIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
@@ -48,7 +49,7 @@ const NotificationsTelegram = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR('/api/v1/settings/notifications/telegram');
+  } = useSWR(apiUrl('/settings/notifications/telegram'));
 
   const NotificationsTelegramSchema = Yup.object().shape({
     botAPI: Yup.string().when('enabled', {
@@ -100,7 +101,7 @@ const NotificationsTelegram = () => {
       validationSchema={NotificationsTelegramSchema}
       onSubmit={async (values) => {
         try {
-          await axios.post('/api/v1/settings/notifications/telegram', {
+          await axios.post(apiUrl('/settings/notifications/telegram'), {
             enabled: values.enabled,
             embedPoster: values.embedPoster,
             types: values.types,
@@ -150,7 +151,7 @@ const NotificationsTelegram = () => {
                 toastId = id;
               }
             );
-            await axios.post('/api/v1/settings/notifications/telegram/test', {
+            await axios.post(apiUrl('/settings/notifications/telegram/test'), {
               enabled: true,
               types: values.types,
               options: {

--- a/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebPush/index.tsx
@@ -2,6 +2,7 @@ import Alert from '@app/components/Common/Alert';
 import Button from '@app/components/Common/Button';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon, BeakerIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
@@ -35,7 +36,7 @@ const NotificationsWebPush = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR('/api/v1/settings/notifications/webpush');
+  } = useSWR(apiUrl('/settings/notifications/webpush'));
 
   useEffect(() => {
     setIsHttps(window.location.protocol.startsWith('https'));
@@ -60,12 +61,12 @@ const NotificationsWebPush = () => {
         }}
         onSubmit={async (values) => {
           try {
-            await axios.post('/api/v1/settings/notifications/webpush', {
+            await axios.post(apiUrl('/settings/notifications/webpush'), {
               enabled: values.enabled,
               embedPoster: values.embedPoster,
               options: {},
             });
-            mutate('/api/v1/settings/public');
+            mutate(apiUrl('/settings/public'));
             addToast(intl.formatMessage(messages.webpushsettingssaved), {
               appearance: 'success',
               autoDismiss: true,
@@ -95,7 +96,7 @@ const NotificationsWebPush = () => {
                   toastId = id;
                 }
               );
-              await axios.post('/api/v1/settings/notifications/webpush/test', {
+              await axios.post(apiUrl('/settings/notifications/webpush/test'), {
                 enabled: true,
                 embedPoster: values.embedPoster,
                 options: {},

--- a/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import SettingsBadge from '@app/components/Settings/SettingsBadge';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { isValidURL } from '@app/utils/urlValidationHelper';
 import {
@@ -120,7 +121,7 @@ const NotificationsWebhook = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR('/api/v1/settings/notifications/webhook');
+  } = useSWR(apiUrl('/settings/notifications/webhook'));
 
   const NotificationsWebhookSchema = Yup.object().shape({
     webhookUrl: Yup.string()
@@ -219,7 +220,7 @@ const NotificationsWebhook = () => {
       validationSchema={NotificationsWebhookSchema}
       onSubmit={async (values) => {
         try {
-          await axios.post('/api/v1/settings/notifications/webhook', {
+          await axios.post(apiUrl('/settings/notifications/webhook'), {
             enabled: values.enabled,
             types: values.types,
             options: {
@@ -286,7 +287,7 @@ const NotificationsWebhook = () => {
                 toastId = id;
               }
             );
-            await axios.post('/api/v1/settings/notifications/webhook/test', {
+            await axios.post(apiUrl('/settings/notifications/webhook/test'), {
               enabled: true,
               types: values.types,
               options: {

--- a/src/components/Settings/OverrideRule/OverrideRuleModal.tsx
+++ b/src/components/Settings/OverrideRule/OverrideRuleModal.tsx
@@ -8,6 +8,7 @@ import {
 import type { DVRTestResponse } from '@app/components/Settings/SettingsServices';
 import useSettings from '@app/hooks/useSettings';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import type OverrideRule from '@server/entity/OverrideRule';
@@ -96,7 +97,7 @@ const OverrideRuleModal = ({
       setIsTesting(true);
       try {
         const response = await axios.post<DVRTestResponse>(
-          `/api/v1/settings/${type}/test`,
+          apiUrl(`/settings/${type}/test`),
           {
             hostname,
             apiKey,
@@ -178,13 +179,13 @@ const OverrideRuleModal = ({
               sonarrServiceId: values.sonarrServiceId,
             };
             if (!rule) {
-              await axios.post('/api/v1/overrideRule', submission);
+              await axios.post(apiUrl('/overrideRule'), submission);
               addToast(intl.formatMessage(messages.ruleCreated), {
                 appearance: 'success',
                 autoDismiss: true,
               });
             } else {
-              await axios.put(`/api/v1/overrideRule/${rule.id}`, submission);
+              await axios.put(apiUrl(`/overrideRule/${rule.id}`), submission);
               addToast(intl.formatMessage(messages.ruleUpdated), {
                 appearance: 'success',
                 autoDismiss: true,

--- a/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
+++ b/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
@@ -1,5 +1,6 @@
 import type { DVRTestResponse } from '@app/components/Settings/SettingsServices';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/solid';
 import type { TmdbGenre } from '@server/api/themoviedb/interfaces';
@@ -53,8 +54,8 @@ const OverrideRuleTiles = ({
   const intl = useIntl();
   const [users, setUsers] = useState<User[] | null>(null);
   const [keywords, setKeywords] = useState<Keyword[] | null>(null);
-  const { data: languages } = useSWR<Language[]>('/api/v1/languages');
-  const { data: genres } = useSWR<TmdbGenre[]>('/api/v1/genres/movie');
+  const { data: languages } = useSWR<Language[]>(apiUrl('/languages'));
+  const { data: genres } = useSWR<TmdbGenre[]>(apiUrl('/genres/movie'));
   const [testResponses, setTestResponses] = useState<
     (DVRTestResponse & { type: string; id: number })[]
   >([]);
@@ -66,11 +67,13 @@ const OverrideRuleTiles = ({
       const { hostname, port, apiKey, baseUrl, useSsl = false } = service;
       try {
         const response = await axios.post<DVRTestResponse>(
-          `/api/v1/settings/${
-            radarrServices.includes(service as RadarrSettings)
-              ? 'radarr'
-              : 'sonarr'
-          }/test`,
+          apiUrl(
+            `/settings/${
+              radarrServices.includes(service as RadarrSettings)
+                ? 'radarr'
+                : 'sonarr'
+            }/test`
+          ),
           {
             hostname,
             apiKey,
@@ -114,7 +117,7 @@ const OverrideRuleTiles = ({
           .filter((keywordId) => keywordId)
           .map(async (keywordId) => {
             const response = await axios.get<Keyword | null>(
-              `/api/v1/keyword/${keywordId}`
+              apiUrl(`/keyword/${keywordId}`)
             );
             return response.data;
           })
@@ -129,7 +132,7 @@ const OverrideRuleTiles = ({
         .join(',');
       if (allUsersFromRules) {
         const response = await axios.get(
-          `/api/v1/user?includeIds=${encodeURIComponent(allUsersFromRules)}`
+          apiUrl(`/user?includeIds=${encodeURIComponent(allUsersFromRules)}`)
         );
         const users: User[] = response.data.results;
         setUsers(users);
@@ -289,7 +292,7 @@ const OverrideRuleTiles = ({
               <div className="-ml-px flex w-0 flex-1">
                 <button
                   onClick={async () => {
-                    await axios.delete(`/api/v1/overrideRule/${rule.id}`);
+                    await axios.delete(apiUrl(`/overrideRule/${rule.id}`));
                     revalidate();
                   }}
                   className="focus:ring-blue relative inline-flex w-0 flex-1 items-center justify-center rounded-br-lg border border-transparent py-4 text-sm font-medium leading-5 text-gray-200 transition duration-150 ease-in-out hover:text-white focus:z-10 focus:border-gray-500 focus:outline-none"

--- a/src/components/Settings/RadarrModal/index.tsx
+++ b/src/components/Settings/RadarrModal/index.tsx
@@ -2,6 +2,7 @@ import Modal from '@app/components/Common/Modal';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import type { RadarrTestResponse } from '@app/components/Settings/SettingsServices';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { isValidURL } from '@app/utils/urlValidationHelper';
 import { Transition } from '@headlessui/react';
@@ -155,7 +156,7 @@ const RadarrModal = ({ onClose, radarr, onSave }: RadarrModalProps) => {
       setIsTesting(true);
       try {
         const response = await axios.post<RadarrTestResponse>(
-          '/api/v1/settings/radarr/test',
+          apiUrl('/settings/radarr/test'),
           {
             hostname,
             apiKey,
@@ -259,10 +260,10 @@ const RadarrModal = ({ onClose, radarr, onSave }: RadarrModalProps) => {
               tagRequests: values.tagRequests,
             };
             if (!radarr) {
-              await axios.post('/api/v1/settings/radarr', submission);
+              await axios.post(apiUrl('/settings/radarr'), submission);
             } else {
               await axios.put(
-                `/api/v1/settings/radarr/${radarr.id}`,
+                apiUrl(`/settings/radarr/${radarr.id}`),
                 submission
               );
             }

--- a/src/components/Settings/SettingsAbout/index.tsx
+++ b/src/components/Settings/SettingsAbout/index.tsx
@@ -6,6 +6,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import Releases from '@app/components/Settings/SettingsAbout/Releases';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type {
   SettingsAboutResponse,
@@ -36,10 +37,10 @@ const messages = defineMessages('components.Settings.SettingsAbout', {
 const SettingsAbout = () => {
   const intl = useIntl();
   const { data, error } = useSWR<SettingsAboutResponse>(
-    '/api/v1/settings/about'
+    apiUrl('/settings/about')
   );
 
-  const { data: status } = useSWR<StatusResponse>('/api/v1/status');
+  const { data: status } = useSWR<StatusResponse>(apiUrl('/status'));
 
   if (!data && !error) {
     return <LoadingSpinner />;

--- a/src/components/Settings/SettingsJellyfin.tsx
+++ b/src/components/Settings/SettingsJellyfin.tsx
@@ -5,6 +5,7 @@ import SensitiveInput from '@app/components/Common/SensitiveInput';
 import LibraryItem from '@app/components/Settings/LibraryItem';
 import useSettings from '@app/hooks/useSettings';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { isValidURL } from '@app/utils/urlValidationHelper';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
@@ -99,9 +100,9 @@ const SettingsJellyfin: React.FC<SettingsJellyfinProps> = ({
     data,
     error,
     mutate: revalidate,
-  } = useSWR<JellyfinSettings>('/api/v1/settings/jellyfin');
+  } = useSWR<JellyfinSettings>(apiUrl('/settings/jellyfin'));
   const { data: dataSync, mutate: revalidateSync } = useSWR<SyncStatus>(
-    '/api/v1/settings/jellyfin/sync',
+    apiUrl('/settings/jellyfin/sync'),
     {
       refreshInterval: 1000,
     }
@@ -170,7 +171,7 @@ const SettingsJellyfin: React.FC<SettingsJellyfinProps> = ({
     }
 
     try {
-      await axios.get('/api/v1/settings/jellyfin/library', {
+      await axios.get(apiUrl('/settings/jellyfin/library'), {
         params,
       });
       setIsSyncing(false);
@@ -209,14 +210,14 @@ const SettingsJellyfin: React.FC<SettingsJellyfinProps> = ({
   };
 
   const startScan = async () => {
-    await axios.post('/api/v1/settings/jellyfin/sync', {
+    await axios.post(apiUrl('/settings/jellyfin/sync'), {
       start: true,
     });
     revalidateSync();
   };
 
   const cancelScan = async () => {
-    await axios.post('/api/v1/settings/jellyfin/sync', {
+    await axios.post(apiUrl('/settings/jellyfin/sync'), {
       cancel: true,
     });
     revalidateSync();
@@ -233,11 +234,11 @@ const SettingsJellyfin: React.FC<SettingsJellyfinProps> = ({
           .join(',');
       }
 
-      await axios.get('/api/v1/settings/jellyfin/library', {
+      await axios.get(apiUrl('/settings/jellyfin/library'), {
         params,
       });
     } else {
-      await axios.get('/api/v1/settings/jellyfin/library', {
+      await axios.get(apiUrl('/settings/jellyfin/library'), {
         params: {
           enable: [...activeLibraries, libraryId].join(','),
         },
@@ -451,7 +452,7 @@ const SettingsJellyfin: React.FC<SettingsJellyfinProps> = ({
         validationSchema={JellyfinSettingsSchema}
         onSubmit={async (values) => {
           try {
-            await axios.post('/api/v1/settings/jellyfin', {
+            await axios.post(apiUrl('/settings/jellyfin'), {
               ip: values.hostname,
               port: Number(values.port),
               useSsl: values.useSsl,

--- a/src/components/Settings/SettingsJobsCache/index.tsx
+++ b/src/components/Settings/SettingsJobsCache/index.tsx
@@ -9,6 +9,7 @@ import useLocale from '@app/hooks/useLocale';
 import useSettings from '@app/hooks/useSettings';
 
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { formatBytes } from '@app/utils/numberHelpers';
 import { Transition } from '@headlessui/react';
@@ -184,12 +185,12 @@ const SettingsJobs = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR<Job[]>('/api/v1/settings/jobs', {
+  } = useSWR<Job[]>(apiUrl('/settings/jobs'), {
     refreshInterval: 5000,
   });
-  const { data: appData } = useSWR('/api/v1/status/appdata');
+  const { data: appData } = useSWR(apiUrl('/status/appdata'));
   const { data: cacheData, mutate: cacheRevalidate } = useSWR<CacheResponse>(
-    '/api/v1/settings/cache',
+    apiUrl('/settings/cache'),
     {
       refreshInterval: 10000,
     }
@@ -224,7 +225,7 @@ const SettingsJobs = () => {
   }
 
   const runJob = async (job: Job) => {
-    await axios.post(`/api/v1/settings/jobs/${job.id}/run`);
+    await axios.post(apiUrl(`/settings/jobs/${job.id}/run`));
     addToast(
       intl.formatMessage(messages.jobstarted, {
         jobname: intl.formatMessage(messages[job.id] ?? messages.unknownJob),
@@ -238,7 +239,7 @@ const SettingsJobs = () => {
   };
 
   const cancelJob = async (job: Job) => {
-    await axios.post(`/api/v1/settings/jobs/${job.id}/cancel`);
+    await axios.post(apiUrl(`/settings/jobs/${job.id}/cancel`));
     addToast(
       intl.formatMessage(messages.jobcancelled, {
         jobname: intl.formatMessage(messages[job.id] ?? messages.unknownJob),
@@ -252,7 +253,7 @@ const SettingsJobs = () => {
   };
 
   const flushCache = async (cache: CacheItem) => {
-    await axios.post(`/api/v1/settings/cache/${cache.id}/flush`);
+    await axios.post(apiUrl(`/settings/cache/${cache.id}/flush`));
     addToast(
       intl.formatMessage(messages.cacheflushed, { cachename: cache.name }),
       {
@@ -264,7 +265,7 @@ const SettingsJobs = () => {
   };
 
   const flushDnsCache = async (hostname: string) => {
-    await axios.post(`/api/v1/settings/cache/dns/${hostname}/flush`);
+    await axios.post(apiUrl(`/settings/cache/dns/${hostname}/flush`));
     addToast(
       intl.formatMessage(messages.dnscacheflushed, { hostname: hostname }),
       {
@@ -295,7 +296,7 @@ const SettingsJobs = () => {
 
       setIsSaving(true);
       await axios.post(
-        `/api/v1/settings/jobs/${jobModalState.job.id}/schedule`,
+        apiUrl(`/settings/jobs/${jobModalState.job.id}/schedule`),
         {
           schedule: jobScheduleCron.join(' '),
         }

--- a/src/components/Settings/SettingsLogs/index.tsx
+++ b/src/components/Settings/SettingsLogs/index.tsx
@@ -9,6 +9,7 @@ import useDebouncedState from '@app/hooks/useDebouncedState';
 import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import {
@@ -79,18 +80,20 @@ const SettingsLogs = () => {
   };
 
   const { data, error } = useSWR<LogsResultsResponse>(
-    `/api/v1/settings/logs?take=${currentPageSize}&skip=${
-      pageIndex * currentPageSize
-    }&filter=${currentFilter}${
-      debouncedSearchFilter ? `&search=${debouncedSearchFilter}` : ''
-    }`,
+    apiUrl(
+      `/settings/logs?take=${currentPageSize}&skip=${
+        pageIndex * currentPageSize
+      }&filter=${currentFilter}${
+        debouncedSearchFilter ? `&search=${debouncedSearchFilter}` : ''
+      }`
+    ),
     {
       refreshInterval: refreshInterval,
       revalidateOnFocus: false,
     }
   );
 
-  const { data: appData } = useSWR('/api/v1/status/appdata');
+  const { data: appData } = useSWR(apiUrl('/status/appdata'));
 
   useEffect(() => {
     const filterString = window.localStorage.getItem('logs-display-settings');

--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -11,6 +11,7 @@ import { availableLanguages } from '@app/context/LanguageContext';
 import useLocale from '@app/hooks/useLocale';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { isValidURL } from '@app/utils/urlValidationHelper';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
@@ -81,9 +82,9 @@ const SettingsMain = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR<MainSettings>('/api/v1/settings/main');
+  } = useSWR<MainSettings>(apiUrl('/settings/main'));
   const { data: userData } = useSWR<UserSettingsGeneralResponse>(
-    currentUser ? `/api/v1/user/${currentUser.id}/settings/main` : null
+    currentUser ? apiUrl(`/user/${currentUser.id}/settings/main`) : null
   );
 
   const MainSettingsSchema = Yup.object().shape({
@@ -123,7 +124,7 @@ const SettingsMain = () => {
 
   const regenerate = async () => {
     try {
-      await axios.post('/api/v1/settings/main/regenerate');
+      await axios.post(apiUrl('/settings/main/regenerate'));
 
       revalidate();
       addToast(intl.formatMessage(messages.toastApiKeySuccess), {
@@ -180,7 +181,7 @@ const SettingsMain = () => {
           validationSchema={MainSettingsSchema}
           onSubmit={async (values) => {
             try {
-              await axios.post('/api/v1/settings/main', {
+              await axios.post(apiUrl('/settings/main'), {
                 applicationTitle: values.applicationTitle,
                 applicationUrl: values.applicationUrl,
                 hideAvailable: values.hideAvailable,
@@ -196,8 +197,8 @@ const SettingsMain = () => {
                 cacheImages: values.cacheImages,
                 youtubeUrl: values.youtubeUrl,
               });
-              mutate('/api/v1/settings/public');
-              mutate('/api/v1/status');
+              mutate(apiUrl('/settings/public'));
+              mutate(apiUrl('/status'));
 
               if (setLocale) {
                 setLocale(

--- a/src/components/Settings/SettingsMetadata.tsx
+++ b/src/components/Settings/SettingsMetadata.tsx
@@ -6,6 +6,7 @@ import MetadataSelector, {
   MetadataProviderType,
 } from '@app/components/MetadataSelector';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon, BeakerIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
@@ -70,7 +71,7 @@ const SettingsMetadata = () => {
     useState<ProviderResponse>(defaultStatus);
 
   const { data, error } = useSWR<MetadataSettings>(
-    '/api/v1/settings/metadatas',
+    apiUrl('/settings/metadatas'),
     async (url: string) => {
       const response = await axios.get<{
         tv: MetadataProviderType;
@@ -105,7 +106,7 @@ const SettingsMetadata = () => {
       const response = await axios.post<{
         success: boolean;
         tests: ProviderResponse;
-      }>('/api/v1/settings/metadatas/test', testData);
+      }>(apiUrl('/settings/metadatas/test'), testData);
 
       const newStatus: ProviderResponse = {
         tmdb: useTmdb ? response.data.tests.tmdb : 'not tested',
@@ -150,7 +151,7 @@ const SettingsMetadata = () => {
           tvdb: ProviderStatus;
           tmdb: ProviderStatus;
         };
-      }>('/api/v1/settings/metadatas', {
+      }>(apiUrl('/settings/metadatas'), {
         tv: values.tv,
         anime: values.anime,
       });

--- a/src/components/Settings/SettingsNetwork/index.tsx
+++ b/src/components/Settings/SettingsNetwork/index.tsx
@@ -4,6 +4,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import Tooltip from '@app/components/Common/Tooltip';
 import SettingsBadge from '@app/components/Settings/SettingsBadge';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
 import type { NetworkSettings } from '@server/lib/settings';
@@ -69,7 +70,7 @@ const SettingsNetwork = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR<NetworkSettings>('/api/v1/settings/network');
+  } = useSWR<NetworkSettings>(apiUrl('/settings/network'));
 
   const NetworkSettingsSchema = Yup.object().shape({
     dnsCacheForceMinTtl: Yup.number().when('dnsCacheEnabled', {
@@ -147,7 +148,7 @@ const SettingsNetwork = () => {
           validationSchema={NetworkSettingsSchema}
           onSubmit={async (values) => {
             try {
-              await axios.post('/api/v1/settings/network', {
+              await axios.post(apiUrl('/settings/network'), {
                 csrfProtection: values.csrfProtection,
                 forceIpv4First: values.forceIpv4First,
                 trustProxy: values.trustProxy,
@@ -168,8 +169,8 @@ const SettingsNetwork = () => {
                 },
                 apiRequestTimeout: Number(values.apiRequestTimeout) * 1000,
               });
-              mutate('/api/v1/settings/public');
-              mutate('/api/v1/status');
+              mutate(apiUrl('/settings/public'));
+              mutate(apiUrl('/status'));
 
               addToast(intl.formatMessage(messages.toastSettingsSuccess), {
                 autoDismiss: true,

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -7,6 +7,7 @@ import SensitiveInput from '@app/components/Common/SensitiveInput';
 import LibraryItem from '@app/components/Settings/LibraryItem';
 import SettingsBadge from '@app/components/Settings/SettingsBadge';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { isValidURL } from '@app/utils/urlValidationHelper';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
@@ -121,11 +122,11 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR<PlexSettings>('/api/v1/settings/plex');
+  } = useSWR<PlexSettings>(apiUrl('/settings/plex'));
   const { data: dataTautulli, mutate: revalidateTautulli } =
-    useSWR<TautulliSettings>('/api/v1/settings/tautulli');
+    useSWR<TautulliSettings>(apiUrl('/settings/tautulli'));
   const { data: dataSync, mutate: revalidateSync } = useSWR<SyncStatus>(
-    '/api/v1/settings/plex/sync',
+    apiUrl('/settings/plex/sync'),
     {
       refreshInterval: 1000,
     }
@@ -242,7 +243,7 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
       params.enable = activeLibraries.join(',');
     }
 
-    await axios.get('/api/v1/settings/plex/library', {
+    await axios.get(apiUrl('/settings/plex/library'), {
       params,
     });
     setIsSyncing(false);
@@ -264,7 +265,7 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
         }
       );
       const response = await axios.get<PlexDevice[]>(
-        '/api/v1/settings/plex/devices/servers'
+        apiUrl('/settings/plex/devices/servers')
       );
       if (response.data) {
         setAvailableServers(response.data);
@@ -290,14 +291,14 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
   };
 
   const startScan = async () => {
-    await axios.post('/api/v1/settings/plex/sync', {
+    await axios.post(apiUrl('/settings/plex/sync'), {
       start: true,
     });
     revalidateSync();
   };
 
   const cancelScan = async () => {
-    await axios.post('/api/v1/settings/plex/sync', {
+    await axios.post(apiUrl('/settings/plex/sync'), {
       cancel: true,
     });
     revalidateSync();
@@ -314,11 +315,11 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
           .join(',');
       }
 
-      await axios.get('/api/v1/settings/plex/library', {
+      await axios.get(apiUrl('/settings/plex/library'), {
         params,
       });
     } else {
-      await axios.get('/api/v1/settings/plex/library', {
+      await axios.get(apiUrl('/settings/plex/library'), {
         params: {
           enable: [...activeLibraries, libraryId].join(','),
         },
@@ -391,7 +392,7 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
                 toastId = id;
               }
             );
-            await axios.post('/api/v1/settings/plex', {
+            await axios.post(apiUrl('/settings/plex'), {
               ip: values.hostname,
               port: Number(values.port),
               useSsl: values.useSsl,
@@ -754,7 +755,7 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
             validationSchema={TautulliSettingsSchema}
             onSubmit={async (values) => {
               try {
-                await axios.post('/api/v1/settings/tautulli', {
+                await axios.post(apiUrl('/settings/tautulli'), {
                   hostname: values.tautulliHostname,
                   port: Number(values.tautulliPort),
                   useSsl: values.tautulliUseSsl,

--- a/src/components/Settings/SettingsServices.tsx
+++ b/src/components/Settings/SettingsServices.tsx
@@ -11,6 +11,7 @@ import OverrideRuleTiles from '@app/components/Settings/OverrideRule/OverrideRul
 import RadarrModal from '@app/components/Settings/RadarrModal';
 import SonarrModal from '@app/components/Settings/SonarrModal';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import { PencilIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/solid';
@@ -209,14 +210,14 @@ const SettingsServices = () => {
     data: radarrData,
     error: radarrError,
     mutate: revalidateRadarr,
-  } = useSWR<RadarrSettings[]>('/api/v1/settings/radarr');
+  } = useSWR<RadarrSettings[]>(apiUrl('/settings/radarr'));
   const {
     data: sonarrData,
     error: sonarrError,
     mutate: revalidateSonarr,
-  } = useSWR<SonarrSettings[]>('/api/v1/settings/sonarr');
+  } = useSWR<SonarrSettings[]>(apiUrl('/settings/sonarr'));
   const { data: rules, mutate: revalidate } =
-    useSWR<OverrideRuleResultsResponse>('/api/v1/overrideRule');
+    useSWR<OverrideRuleResultsResponse>(apiUrl('/overrideRule'));
   const [editRadarrModal, setEditRadarrModal] = useState<{
     open: boolean;
     radarr: RadarrSettings | null;
@@ -250,12 +251,14 @@ const SettingsServices = () => {
 
   const deleteServer = async () => {
     await axios.delete(
-      `/api/v1/settings/${deleteServerModal.type}/${deleteServerModal.serverId}`
+      apiUrl(
+        `/settings/${deleteServerModal.type}/${deleteServerModal.serverId}`
+      )
     );
     setDeleteServerModal({ open: false, serverId: null, type: 'radarr' });
     revalidateRadarr();
     revalidateSonarr();
-    mutate('/api/v1/settings/public');
+    mutate(apiUrl('/settings/public'));
   };
 
   return (
@@ -285,7 +288,7 @@ const SettingsServices = () => {
           }}
           onSave={() => {
             revalidateRadarr();
-            mutate('/api/v1/settings/public');
+            mutate(apiUrl('/settings/public'));
             setEditRadarrModal({ open: false, radarr: null });
           }}
         />
@@ -299,7 +302,7 @@ const SettingsServices = () => {
           }}
           onSave={() => {
             revalidateSonarr();
-            mutate('/api/v1/settings/public');
+            mutate(apiUrl('/settings/public'));
             setEditSonarrModal({ open: false, sonarr: null });
           }}
         />

--- a/src/components/Settings/SettingsUsers/index.tsx
+++ b/src/components/Settings/SettingsUsers/index.tsx
@@ -6,6 +6,7 @@ import PermissionEdit from '@app/components/PermissionEdit';
 import QuotaSelector from '@app/components/QuotaSelector';
 import useSettings from '@app/hooks/useSettings';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
 import { MediaServerType } from '@server/constants/server';
@@ -48,7 +49,7 @@ const SettingsUsers = () => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR<MainSettings>('/api/v1/settings/main');
+  } = useSWR<MainSettings>(apiUrl('/settings/main'));
   const settings = useSettings();
 
   const schema = yup
@@ -117,7 +118,7 @@ const SettingsUsers = () => {
           enableReinitialize
           onSubmit={async (values) => {
             try {
-              await axios.post('/api/v1/settings/main', {
+              await axios.post(apiUrl('/settings/main'), {
                 localLogin: values.localLogin,
                 mediaServerLogin: values.mediaServerLogin,
                 newPlexLogin: values.newPlexLogin,
@@ -133,7 +134,7 @@ const SettingsUsers = () => {
                 },
                 defaultPermissions: values.defaultPermissions,
               });
-              mutate('/api/v1/settings/public');
+              mutate(apiUrl('/settings/public'));
 
               addToast(intl.formatMessage(messages.toastSettingsSuccess), {
                 autoDismiss: true,

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -2,6 +2,7 @@ import Modal from '@app/components/Common/Modal';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import type { SonarrTestResponse } from '@app/components/Settings/SettingsServices';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { isValidURL } from '@app/utils/urlValidationHelper';
 import { Transition } from '@headlessui/react';
@@ -165,7 +166,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
       setIsTesting(true);
       try {
         const response = await axios.post<SonarrTestResponse>(
-          '/api/v1/settings/sonarr/test',
+          apiUrl('/settings/sonarr/test'),
           {
             hostname,
             apiKey,
@@ -295,10 +296,10 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
               monitorNewItems: values.monitorNewItems,
             };
             if (!sonarr) {
-              await axios.post('/api/v1/settings/sonarr', submission);
+              await axios.post(apiUrl('/settings/sonarr'), submission);
             } else {
               await axios.put(
-                `/api/v1/settings/sonarr/${sonarr.id}`,
+                apiUrl(`/settings/sonarr/${sonarr.id}`),
                 submission
               );
             }

--- a/src/components/Setup/JellyfinSetup.tsx
+++ b/src/components/Setup/JellyfinSetup.tsx
@@ -1,5 +1,6 @@
 import Button from '@app/components/Common/Button';
 import Tooltip from '@app/components/Common/Tooltip';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { InformationCircleIcon } from '@heroicons/react/24/solid';
 import { ApiErrorCode } from '@server/constants/error';
@@ -117,7 +118,7 @@ function JellyfinSetup({
       validationSchema={LoginSchema}
       onSubmit={async (values) => {
         try {
-          await axios.post('/api/v1/auth/jellyfin', {
+          await axios.post(apiUrl('/auth/jellyfin'), {
             username: values.username,
             password: values.password,
             hostname: values.hostname,

--- a/src/components/Setup/LoginWithPlex.tsx
+++ b/src/components/Setup/LoginWithPlex.tsx
@@ -1,5 +1,6 @@
 import PlexLoginButton from '@app/components/Login/PlexLoginButton';
 import { useUser } from '@app/hooks/useUser';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
@@ -26,9 +27,9 @@ const LoginWithPlex = ({ onComplete }: LoginWithPlexProps) => {
   useEffect(() => {
     const login = async () => {
       try {
-        const response = await axios.post('/api/v1/auth/plex', { authToken });
+        const response = await axios.post(apiUrl('/auth/plex'), { authToken });
         if (response.data?.id) {
-          const { data: user } = await axios.get('/api/v1/auth/me');
+          const { data: user } = await axios.get(apiUrl('/auth/me'));
           revalidate(user, false);
         }
       } catch {

--- a/src/components/Setup/SetupLogin.tsx
+++ b/src/components/Setup/SetupLogin.tsx
@@ -2,6 +2,7 @@ import Button from '@app/components/Common/Button';
 import PlexLoginButton from '@app/components/Login/PlexLoginButton';
 import JellyfinSetup from '@app/components/Setup/JellyfinSetup';
 import { useUser } from '@app/hooks/useUser';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { MediaServerType } from '@server/constants/server';
 import axios from 'axios';
@@ -42,12 +43,12 @@ const SetupLogin: React.FC<LoginWithMediaServerProps> = ({
   useEffect(() => {
     const login = async () => {
       try {
-        const response = await axios.post('/api/v1/auth/plex', {
+        const response = await axios.post(apiUrl('/auth/plex'), {
           authToken: authToken,
         });
 
         if (response.data?.id) {
-          const { data: user } = await axios.get('/api/v1/auth/me');
+          const { data: user } = await axios.get(apiUrl('/auth/me'));
           revalidate(user, false);
         }
       } catch {

--- a/src/components/Setup/index.tsx
+++ b/src/components/Setup/index.tsx
@@ -12,6 +12,7 @@ import SettingsServices from '@app/components/Settings/SettingsServices';
 import SetupSteps from '@app/components/Setup/SetupSteps';
 import useLocale from '@app/hooks/useLocale';
 import useSettings from '@app/hooks/useSettings';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { MediaServerType } from '@server/constants/server';
 import type { Library } from '@server/lib/settings';
@@ -59,13 +60,13 @@ const Setup = () => {
   const finishSetup = async () => {
     setIsUpdating(true);
     const response = await axios.post<{ initialized: boolean }>(
-      '/api/v1/settings/initialize'
+      apiUrl('/settings/initialize')
     );
 
     setIsUpdating(false);
     if (response.data.initialized) {
-      await axios.post('/api/v1/settings/main', { locale });
-      mutate('/api/v1/settings/public');
+      await axios.post(apiUrl('/settings/main'), { locale });
+      mutate(apiUrl('/settings/public'));
 
       router.push('/');
     }
@@ -74,9 +75,9 @@ const Setup = () => {
   const validateLibraries = useCallback(async () => {
     try {
       const endpointMap: Record<MediaServerType, string> = {
-        [MediaServerType.JELLYFIN]: '/api/v1/settings/jellyfin',
-        [MediaServerType.EMBY]: '/api/v1/settings/jellyfin',
-        [MediaServerType.PLEX]: '/api/v1/settings/plex',
+        [MediaServerType.JELLYFIN]: apiUrl('/settings/jellyfin'),
+        [MediaServerType.EMBY]: apiUrl('/settings/jellyfin'),
+        [MediaServerType.PLEX]: apiUrl('/settings/plex'),
         [MediaServerType.NOT_CONFIGURED]: '',
       };
 
@@ -100,7 +101,7 @@ const Setup = () => {
     }
   }, [intl, mediaServerType, toasts]);
 
-  const { data: backdrops } = useSWR<string[]>('/api/v1/backdrops', {
+  const { data: backdrops } = useSWR<string[]>(apiUrl('/backdrops'), {
     refreshInterval: 0,
     refreshWhenHidden: false,
     revalidateOnFocus: false,

--- a/src/components/StatusChecker/index.tsx
+++ b/src/components/StatusChecker/index.tsx
@@ -2,6 +2,7 @@ import Modal from '@app/components/Common/Modal';
 import useSettings from '@app/hooks/useSettings';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import type { StatusResponse } from '@server/interfaces/api/settingsInterfaces';
@@ -23,7 +24,7 @@ const StatusChecker = () => {
   const intl = useIntl();
   const settings = useSettings();
   const { hasPermission } = useUser();
-  const { data, error } = useSWR<StatusResponse>('/api/v1/status', {
+  const { data, error } = useSWR<StatusResponse>(apiUrl('/status'), {
     refreshInterval: 60 * 1000,
   });
   const [alertDismissed, setAlertDismissed] = useState(false);

--- a/src/components/TitleCard/ErrorCard.tsx
+++ b/src/components/TitleCard/ErrorCard.tsx
@@ -1,5 +1,6 @@
 import Button from '@app/components/Common/Button';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { CheckIcon, TrashIcon } from '@heroicons/react/24/solid';
 import axios from 'axios';
@@ -25,9 +26,9 @@ const ErrorCard = ({ id, tmdbId, tvdbId, type, canExpand }: ErrorCardProps) => {
   const intl = useIntl();
 
   const deleteMedia = async () => {
-    await axios.delete(`/api/v1/media/${id}`);
-    mutate('/api/v1/media?filter=allavailable&take=20&sort=mediaAdded');
-    mutate('/api/v1/request?filter=all&take=10&sort=modified&skip=0');
+    await axios.delete(apiUrl(`/media/${id}`));
+    mutate(apiUrl('/media?filter=allavailable&take=20&sort=mediaAdded'));
+    mutate(apiUrl('/request?filter=all&take=10&sort=modified&skip=0'));
   };
 
   return (

--- a/src/components/TitleCard/TmdbTitleCard.tsx
+++ b/src/components/TitleCard/TmdbTitleCard.tsx
@@ -1,5 +1,6 @@
 import TitleCard from '@app/components/TitleCard';
 import { Permission, useUser } from '@app/hooks/useUser';
+import { apiUrl } from '@app/utils/apiUrl';
 import type { MovieDetails } from '@server/models/Movie';
 import type { TvDetails } from '@server/models/Tv';
 import { useInView } from 'react-intersection-observer';
@@ -34,7 +35,7 @@ const TmdbTitleCard = ({
     triggerOnce: true,
   });
   const url =
-    type === 'movie' ? `/api/v1/movie/${tmdbId}` : `/api/v1/tv/${tmdbId}`;
+    type === 'movie' ? apiUrl(`/movie/${tmdbId}`) : apiUrl(`/tv/${tmdbId}`);
   const { data: title, error } = useSWR<MovieDetails | TvDetails>(
     inView ? `${url}` : null
   );

--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -10,6 +10,7 @@ import Placeholder from '@app/components/TitleCard/Placeholder';
 import { useIsTouch } from '@app/hooks/useIsTouch';
 import { Permission, UserType, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { withProperties } from '@app/utils/typeHelpers';
 import { Transition } from '@headlessui/react';
@@ -108,12 +109,12 @@ const TitleCard = ({
   const onClickWatchlistBtn = async (): Promise<void> => {
     setIsUpdating(true);
     try {
-      const response = await axios.post<Watchlist>('/api/v1/watchlist', {
+      const response = await axios.post<Watchlist>(apiUrl('/watchlist'), {
         tmdbId: id,
         mediaType,
         title,
       });
-      mutate('/api/v1/discover/watchlist');
+      mutate(apiUrl('/discover/watchlist'));
       if (response.data) {
         addToast(
           <span>
@@ -140,7 +141,7 @@ const TitleCard = ({
     setIsUpdating(true);
     try {
       const response = await axios.delete<Watchlist>(
-        `/api/v1/watchlist/${id}?mediaType=${mediaType}`
+        apiUrl(`/watchlist/${id}?mediaType=${mediaType}`)
       );
 
       if (response.status === 204) {
@@ -161,7 +162,7 @@ const TitleCard = ({
       });
     } finally {
       setIsUpdating(false);
-      mutate('/api/v1/discover/watchlist');
+      mutate(apiUrl('/discover/watchlist'));
       if (mutateParent) {
         mutateParent();
       }
@@ -176,9 +177,9 @@ const TitleCard = ({
     if (topNode) {
       try {
         if (mediaType === 'collection') {
-          await axios.post(`/api/v1/blocklist/collection/${id}`);
+          await axios.post(apiUrl(`/blocklist/collection/${id}`));
         } else {
-          await axios.post('/api/v1/blocklist', {
+          await axios.post(apiUrl('/blocklist'), {
             tmdbId: id,
             mediaType,
             title,
@@ -234,7 +235,9 @@ const TitleCard = ({
     if (topNode) {
       try {
         if (mediaType === 'collection') {
-          const res = await axios.delete(`/api/v1/blocklist/collection/${id}`);
+          const res = await axios.delete(
+            apiUrl(`/blocklist/collection/${id}`)
+          );
 
           if (res.status === 204) {
             addToast(
@@ -258,7 +261,7 @@ const TitleCard = ({
           }
         } else {
           const res = await axios.delete(
-            `/api/v1/blocklist/${id}?mediaType=${mediaType}`
+            apiUrl(`/blocklist/${id}?mediaType=${mediaType}`)
           );
 
           if (res.status === 204) {

--- a/src/components/TvDetails/Season/index.tsx
+++ b/src/components/TvDetails/Season/index.tsx
@@ -1,6 +1,7 @@
 import AirDateBadge from '@app/components/AirDateBadge';
 import CachedImage from '@app/components/Common/CachedImage';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { SeasonWithEpisodes } from '@server/models/Tv';
 import { useIntl } from 'react-intl';
@@ -19,7 +20,7 @@ type SeasonProps = {
 const Season = ({ seasonNumber, tvId }: SeasonProps) => {
   const intl = useIntl();
   const { data, error } = useSWR<SeasonWithEpisodes>(
-    `/api/v1/tv/${tvId}/season/${seasonNumber}`
+    apiUrl(`/tv/${tvId}/season/${seasonNumber}`)
   );
 
   if (!data && !error) {

--- a/src/components/TvDetails/TvCast/index.tsx
+++ b/src/components/TvDetails/TvCast/index.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import PageTitle from '@app/components/Common/PageTitle';
 import PersonCard from '@app/components/PersonCard';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { TvDetails } from '@server/models/Tv';
 import Link from 'next/link';
@@ -17,7 +18,7 @@ const messages = defineMessages('components.TvDetails.TvCast', {
 const TvCast = () => {
   const router = useRouter();
   const intl = useIntl();
-  const { data, error } = useSWR<TvDetails>(`/api/v1/tv/${router.query.tvId}`);
+  const { data, error } = useSWR<TvDetails>(apiUrl(`/tv/${router.query.tvId}`));
 
   if (!data && !error) {
     return <LoadingSpinner />;

--- a/src/components/TvDetails/TvCrew/index.tsx
+++ b/src/components/TvDetails/TvCrew/index.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import PageTitle from '@app/components/Common/PageTitle';
 import PersonCard from '@app/components/PersonCard';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { TvDetails } from '@server/models/Tv';
 import Link from 'next/link';
@@ -17,7 +18,7 @@ const messages = defineMessages('components.TvDetails.TvCrew', {
 const TvCrew = () => {
   const router = useRouter();
   const intl = useIntl();
-  const { data, error } = useSWR<TvDetails>(`/api/v1/tv/${router.query.tvId}`);
+  const { data, error } = useSWR<TvDetails>(apiUrl(`/tv/${router.query.tvId}`));
 
   if (!data && !error) {
     return <LoadingSpinner />;

--- a/src/components/TvDetails/TvRecommendations.tsx
+++ b/src/components/TvDetails/TvRecommendations.tsx
@@ -3,6 +3,7 @@ import ListView from '@app/components/Common/ListView';
 import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { TvResult } from '@server/models/Search';
 import type { TvDetails } from '@server/models/Tv';
@@ -18,7 +19,9 @@ const messages = defineMessages('components.TvDetails', {
 const TvRecommendations = () => {
   const router = useRouter();
   const intl = useIntl();
-  const { data: tvData } = useSWR<TvDetails>(`/api/v1/tv/${router.query.tvId}`);
+  const { data: tvData } = useSWR<TvDetails>(
+    apiUrl(`/tv/${router.query.tvId}`)
+  );
   const {
     isLoadingInitialData,
     isEmpty,
@@ -27,7 +30,7 @@ const TvRecommendations = () => {
     titles,
     fetchMore,
     error,
-  } = useDiscover<TvResult>(`/api/v1/tv/${router.query.tvId}/recommendations`);
+  } = useDiscover<TvResult>(apiUrl(`/tv/${router.query.tvId}/recommendations`));
 
   if (error) {
     return <ErrorPage statusCode={500} />;

--- a/src/components/TvDetails/TvSimilar.tsx
+++ b/src/components/TvDetails/TvSimilar.tsx
@@ -3,6 +3,7 @@ import ListView from '@app/components/Common/ListView';
 import PageTitle from '@app/components/Common/PageTitle';
 import useDiscover from '@app/hooks/useDiscover';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { TvResult } from '@server/models/Search';
 import type { TvDetails } from '@server/models/Tv';
@@ -18,7 +19,9 @@ const messages = defineMessages('components.TvDetails', {
 const TvSimilar = () => {
   const router = useRouter();
   const intl = useIntl();
-  const { data: tvData } = useSWR<TvDetails>(`/api/v1/tv/${router.query.tvId}`);
+  const { data: tvData } = useSWR<TvDetails>(
+    apiUrl(`/tv/${router.query.tvId}`)
+  );
   const {
     isLoadingInitialData,
     isEmpty,
@@ -27,7 +30,7 @@ const TvSimilar = () => {
     titles,
     fetchMore,
     error,
-  } = useDiscover<TvResult>(`/api/v1/tv/${router.query.tvId}/similar`);
+  } = useDiscover<TvResult>(apiUrl(`/tv/${router.query.tvId}/similar`));
 
   if (error) {
     return <ErrorPage statusCode={500} />;

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -31,6 +31,7 @@ import useSettings from '@app/hooks/useSettings';
 import { Permission, UserType, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import { sortCrewPriority } from '@app/utils/creditHelpers';
 import defineMessages from '@app/utils/defineMessages';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
@@ -133,7 +134,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     data,
     error,
     mutate: revalidate,
-  } = useSWR<TvDetailsType>(`/api/v1/tv/${router.query.tvId}`, {
+  } = useSWR<TvDetailsType>(apiUrl(`/tv/${router.query.tvId}`), {
     fallbackData: tv,
     refreshInterval: refreshIntervalHelper(
       {
@@ -145,7 +146,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
   });
 
   const { data: ratingData } = useSWR<RTRating>(
-    `/api/v1/tv/${router.query.tvId}/ratings`
+    apiUrl(`/tv/${router.query.tvId}/ratings`)
   );
 
   const sortedCrew = useMemo(
@@ -355,7 +356,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     setIsUpdating(true);
 
     try {
-      await axios.post('/api/v1/watchlist', {
+      await axios.post(apiUrl('/watchlist'), {
         tmdbId: tv?.id,
         mediaType: MediaType.TV,
         title: tv?.name,
@@ -387,7 +388,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
 
     try {
       await axios.delete(
-        `/api/v1/watchlist/${tv?.id}?mediaType=${MediaType.TV}`
+        apiUrl(`/watchlist/${tv?.id}?mediaType=${MediaType.TV}`)
       );
 
       addToast(
@@ -416,7 +417,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     setIsBlocklistUpdating(true);
 
     try {
-      const res = await axios.post('/api/v1/blocklist', {
+      const res = await axios.post(apiUrl('/blocklist'), {
         tmdbId: tv?.id,
         mediaType: 'tv',
         title: tv?.name,
@@ -1351,14 +1352,14 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
       <MediaSlider
         sliderKey="recommendations"
         title={intl.formatMessage(messages.recommendations)}
-        url={`/api/v1/tv/${router.query.tvId}/recommendations`}
+        url={apiUrl(`/tv/${router.query.tvId}/recommendations`)}
         linkUrl={`/tv/${data.id}/recommendations`}
         hideWhenEmpty
       />
       <MediaSlider
         sliderKey="similar"
         title={intl.formatMessage(messages.similar)}
-        url={`/api/v1/tv/${router.query.tvId}/similar`}
+        url={apiUrl(`/tv/${router.query.tvId}/similar`)}
         linkUrl={`/tv/${data.id}/similar`}
         hideWhenEmpty
       />

--- a/src/components/UserList/BulkEditModal.tsx
+++ b/src/components/UserList/BulkEditModal.tsx
@@ -3,6 +3,7 @@ import PermissionEdit from '@app/components/PermissionEdit';
 import type { User } from '@app/hooks/useUser';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { hasPermission } from '@server/lib/permissions';
 import axios from 'axios';
@@ -46,7 +47,7 @@ const BulkEditModal = ({
   const updateUsers = async () => {
     try {
       setIsSaving(true);
-      const { data: updated } = await axios.put<User[]>(`/api/v1/user`, {
+      const { data: updated } = await axios.put<User[]>(apiUrl(`/user`), {
         ids: selectedUserIds,
         permissions: currentPermission,
       });

--- a/src/components/UserList/JellyfinImportModal.tsx
+++ b/src/components/UserList/JellyfinImportModal.tsx
@@ -3,6 +3,7 @@ import CachedImage from '@app/components/Common/CachedImage';
 import Modal from '@app/components/Common/Modal';
 import useSettings from '@app/hooks/useSettings';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { MediaServerType } from '@server/constants/server';
 import type { UserResultsResponse } from '@server/interfaces/api/userInterfaces';
@@ -48,12 +49,12 @@ const JellyfinImportModal: React.FC<JellyfinImportProps> = ({
       email: string;
       thumb: string;
     }[]
-  >(`/api/v1/settings/jellyfin/users`, {
+  >(apiUrl(`/settings/jellyfin/users`), {
     revalidateOnMount: true,
   });
 
   const { data: existingUsers } = useSWR<UserResultsResponse>(
-    `/api/v1/user?take=${children}`
+    apiUrl(`/user?take=${children}`)
   );
 
   const importUsers = async () => {
@@ -61,7 +62,7 @@ const JellyfinImportModal: React.FC<JellyfinImportProps> = ({
 
     try {
       const { data: createdUsers } = await axios.post(
-        '/api/v1/user/import-from-jellyfin',
+        apiUrl('/user/import-from-jellyfin'),
         { jellyfinUserIds: selectedUsers }
       );
 

--- a/src/components/UserList/PlexImportModal.tsx
+++ b/src/components/UserList/PlexImportModal.tsx
@@ -2,6 +2,7 @@ import Alert from '@app/components/Common/Alert';
 import Modal from '@app/components/Common/Modal';
 import useSettings from '@app/hooks/useSettings';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import axios from 'axios';
 import Image from 'next/image';
@@ -40,7 +41,7 @@ const PlexImportModal = ({ onCancel, onComplete }: PlexImportProps) => {
       email: string;
       thumb: string;
     }[]
-  >(`/api/v1/settings/plex/users`, {
+  >(apiUrl(`/settings/plex/users`), {
     revalidateOnMount: true,
   });
 
@@ -49,7 +50,7 @@ const PlexImportModal = ({ onCancel, onComplete }: PlexImportProps) => {
 
     try {
       const { data: createdUsers } = await axios.post(
-        '/api/v1/user/import-from-plex',
+        apiUrl('/user/import-from-plex'),
         { plexIds: selectedUsers }
       );
 

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -15,6 +15,7 @@ import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import type { User } from '@app/hooks/useUser';
 import { Permission, UserType, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import {
@@ -129,9 +130,11 @@ const UserList = () => {
     error,
     mutate: revalidate,
   } = useSWR<UserResultsResponse>(
-    `/api/v1/user?take=${currentPageSize}&skip=${
-      pageIndex * currentPageSize
-    }&sort=${currentSort}&sortDirection=${sortDirection}`
+    apiUrl(
+      `/user?take=${currentPageSize}&skip=${
+        pageIndex * currentPageSize
+      }&sort=${currentSort}&sortDirection=${sortDirection}`
+    )
   );
 
   const handleSortChange = (sortKey: Sort) => {
@@ -285,7 +288,7 @@ const UserList = () => {
     setDeleting(true);
 
     try {
-      await axios.delete(`/api/v1/user/${deleteModal.user?.id}`);
+      await axios.delete(apiUrl(`/user/${deleteModal.user?.id}`));
 
       addToast(intl.formatMessage(messages.userdeleted), {
         autoDismiss: true,
@@ -391,7 +394,7 @@ const UserList = () => {
           validationSchema={CreateUserSchema}
           onSubmit={async (values) => {
             try {
-              await axios.post('/api/v1/user', {
+              await axios.post(apiUrl('/user'), {
                 username: values.username,
                 email: values.email,
                 password: values.genpassword ? null : values.password,

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -11,6 +11,7 @@ import useSettings from '@app/hooks/useSettings';
 import { Permission, UserType, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
 import { ApiErrorCode } from '@server/constants/error';
@@ -97,7 +98,7 @@ const UserGeneralSettings = () => {
     error,
     mutate: revalidate,
   } = useSWR<UserSettingsGeneralResponse>(
-    user ? `/api/v1/user/${user?.id}/settings/main` : null
+    user ? apiUrl(`/user/${user?.id}/settings/main`) : null
   );
 
   const UserGeneralSettingsSchema = Yup.object().shape({
@@ -174,7 +175,7 @@ const UserGeneralSettings = () => {
         enableReinitialize
         onSubmit={async (values) => {
           try {
-            await axios.post(`/api/v1/user/${user?.id}/settings/main`, {
+            await axios.post(apiUrl(`/user/${user?.id}/settings/main`), {
               username: values.displayName,
               email:
                 values.email || user?.jellyfinUsername || user?.plexUsername,

--- a/src/components/UserProfile/UserSettings/UserLinkedAccountsSettings/LinkJellyfinModal.tsx
+++ b/src/components/UserProfile/UserSettings/UserLinkedAccountsSettings/LinkJellyfinModal.tsx
@@ -2,6 +2,7 @@ import Alert from '@app/components/Common/Alert';
 import Modal from '@app/components/Common/Modal';
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { Transition } from '@headlessui/react';
 import { MediaServerType } from '@server/constants/server';
@@ -82,7 +83,7 @@ const LinkJellyfinModal: React.FC<LinkJellyfinModalProps> = ({
           try {
             setError(null);
             await axios.post(
-              `/api/v1/user/${user?.id}/settings/linked-accounts/jellyfin`,
+              apiUrl(`/user/${user?.id}/settings/linked-accounts/jellyfin`),
               {
                 username,
                 password,

--- a/src/components/UserProfile/UserSettings/UserLinkedAccountsSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserLinkedAccountsSettings/index.tsx
@@ -8,6 +8,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import useSettings from '@app/hooks/useSettings';
 import { Permission, UserType, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import PlexOAuth from '@app/utils/plex';
 import { TrashIcon } from '@heroicons/react/24/solid';
@@ -60,7 +61,7 @@ const UserLinkedAccountsSettings = () => {
     revalidate: revalidateUser,
   } = useUser({ id: Number(router.query.userId) });
   const { data: passwordInfo } = useSWR<{ hasPassword: boolean }>(
-    user ? `/api/v1/user/${user?.id}/settings/password` : null
+    user ? apiUrl(`/user/${user?.id}/settings/password`) : null
   );
   const [showJellyfinModal, setShowJellyfinModal] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -93,7 +94,7 @@ const UserLinkedAccountsSettings = () => {
     try {
       const authToken = await plexOAuth.login();
       await axios.post(
-        `/api/v1/user/${user?.id}/settings/linked-accounts/plex`,
+        apiUrl(`/user/${user?.id}/settings/linked-accounts/plex`),
         {
           authToken,
         }
@@ -143,7 +144,7 @@ const UserLinkedAccountsSettings = () => {
   const deleteRequest = async (account: string) => {
     try {
       await axios.delete(
-        `/api/v1/user/${user?.id}/settings/linked-accounts/${account}`
+        apiUrl(`/user/${user?.id}/settings/linked-accounts/${account}`)
       );
     } catch {
       setError(intl.formatMessage(messages.deleteFailed));

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsDiscord.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsDiscord.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
 import type { UserSettingsNotificationsResponse } from '@server/interfaces/api/userSettingsInterfaces';
@@ -37,7 +38,7 @@ const UserNotificationsDiscord = () => {
     error,
     mutate: revalidate,
   } = useSWR<UserSettingsNotificationsResponse>(
-    user ? `/api/v1/user/${user?.id}/settings/notifications` : null
+    user ? apiUrl(`/user/${user?.id}/settings/notifications`) : null
   );
 
   const UserNotificationsDiscordSchema = Yup.object().shape({
@@ -68,7 +69,7 @@ const UserNotificationsDiscord = () => {
       enableReinitialize
       onSubmit={async (values) => {
         try {
-          await axios.post(`/api/v1/user/${user?.id}/settings/notifications`, {
+          await axios.post(apiUrl(`/user/${user?.id}/settings/notifications`), {
             pgpKey: data?.pgpKey,
             discordId: values.discordId,
             pushbulletAccessToken: data?.pushbulletAccessToken,

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsEmail.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsEmail.tsx
@@ -8,6 +8,7 @@ import { OpenPgpLink } from '@app/components/Settings/Notifications/Notification
 import SettingsBadge from '@app/components/Settings/SettingsBadge';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
 import type { UserSettingsNotificationsResponse } from '@server/interfaces/api/userSettingsInterfaces';
@@ -41,7 +42,7 @@ const UserEmailSettings = () => {
     error,
     mutate: revalidate,
   } = useSWR<UserSettingsNotificationsResponse>(
-    user ? `/api/v1/user/${user?.id}/settings/notifications` : null
+    user ? apiUrl(`/user/${user?.id}/settings/notifications`) : null
   );
 
   const UserNotificationsEmailSchema = Yup.object().shape({
@@ -67,7 +68,7 @@ const UserEmailSettings = () => {
       enableReinitialize
       onSubmit={async (values) => {
         try {
-          await axios.post(`/api/v1/user/${user?.id}/settings/notifications`, {
+          await axios.post(apiUrl(`/user/${user?.id}/settings/notifications`), {
             pgpKey: values.pgpKey,
             discordId: data?.discordId,
             pushbulletAccessToken: data?.pushbulletAccessToken,

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsPushbullet.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsPushbullet.tsx
@@ -4,6 +4,7 @@ import SensitiveInput from '@app/components/Common/SensitiveInput';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { UserSettingsNotificationsResponse } from '@server/interfaces/api/userSettingsInterfaces';
 import axios from 'axios';
@@ -38,7 +39,7 @@ const UserPushbulletSettings = () => {
     error,
     mutate: revalidate,
   } = useSWR<UserSettingsNotificationsResponse>(
-    user ? `/api/v1/user/${user?.id}/settings/notifications` : null
+    user ? apiUrl(`/user/${user?.id}/settings/notifications`) : null
   );
 
   const UserNotificationsPushbulletSchema = Yup.object().shape({
@@ -65,7 +66,7 @@ const UserPushbulletSettings = () => {
       enableReinitialize
       onSubmit={async (values) => {
         try {
-          await axios.post(`/api/v1/user/${user?.id}/settings/notifications`, {
+          await axios.post(apiUrl(`/user/${user?.id}/settings/notifications`), {
             pgpKey: data?.pgpKey,
             discordId: data?.discordId,
             pushbulletAccessToken: values.pushbulletAccessToken,

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsPushover.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsPushover.tsx
@@ -4,6 +4,7 @@ import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { PushoverSound } from '@server/api/pushover';
 import type { UserSettingsNotificationsResponse } from '@server/interfaces/api/userSettingsInterfaces';
@@ -45,11 +46,13 @@ const UserPushoverSettings = () => {
     error,
     mutate: revalidate,
   } = useSWR<UserSettingsNotificationsResponse>(
-    user ? `/api/v1/user/${user?.id}/settings/notifications` : null
+    user ? apiUrl(`/user/${user?.id}/settings/notifications`) : null
   );
   const { data: soundsData } = useSWR<PushoverSound[]>(
     data?.pushoverApplicationToken
-      ? `/api/v1/settings/notifications/pushover/sounds?token=${data.pushoverApplicationToken}`
+      ? apiUrl(
+          `/settings/notifications/pushover/sounds?token=${data.pushoverApplicationToken}`
+        )
       : null
   );
 
@@ -97,7 +100,7 @@ const UserPushoverSettings = () => {
       enableReinitialize
       onSubmit={async (values) => {
         try {
-          await axios.post(`/api/v1/user/${user?.id}/settings/notifications`, {
+          await axios.post(apiUrl(`/user/${user?.id}/settings/notifications`), {
             pgpKey: data?.pgpKey,
             discordId: data?.discordId,
             pushbulletAccessToken: data?.pushbulletAccessToken,

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsTelegram.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsTelegram.tsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
 import type { UserSettingsNotificationsResponse } from '@server/interfaces/api/userSettingsInterfaces';
@@ -43,7 +44,7 @@ const UserTelegramSettings = () => {
     error,
     mutate: revalidate,
   } = useSWR<UserSettingsNotificationsResponse>(
-    user ? `/api/v1/user/${user?.id}/settings/notifications` : null
+    user ? apiUrl(`/user/${user?.id}/settings/notifications`) : null
   );
 
   const UserNotificationsTelegramSchema = Yup.object().shape({
@@ -91,7 +92,7 @@ const UserTelegramSettings = () => {
       enableReinitialize
       onSubmit={async (values) => {
         try {
-          await axios.post(`/api/v1/user/${user?.id}/settings/notifications`, {
+          await axios.post(apiUrl(`/user/${user?.id}/settings/notifications`), {
             pgpKey: data?.pgpKey,
             discordId: data?.discordId,
             pushbulletAccessToken: data?.pushbulletAccessToken,

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
@@ -8,6 +8,7 @@ import DeviceItem from '@app/components/UserProfile/UserSettings/UserNotificatio
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import {
   getPushSubscription,
@@ -64,7 +65,7 @@ const UserWebPushSettings = () => {
     error,
     mutate: revalidate,
   } = useSWR<UserSettingsNotificationsResponse>(
-    user ? `/api/v1/user/${user?.id}/settings/notifications` : null
+    user ? apiUrl(`/user/${user?.id}/settings/notifications`) : null
   );
   const { data: dataDevices, mutate: revalidateDevices } = useSWR<
     {
@@ -74,7 +75,7 @@ const UserWebPushSettings = () => {
       userAgent: string;
       createdAt: Date;
     }[]
-  >(`/api/v1/user/${user?.id}/pushSubscriptions`, { revalidateOnMount: true });
+  >(apiUrl(`/user/${user?.id}/pushSubscriptions`), { revalidateOnMount: true });
 
   // Subscribes to the push manager
   // Will only add to the database if subscribing for the first time
@@ -122,9 +123,11 @@ const UserWebPushSettings = () => {
       if (endpointToDelete) {
         try {
           await axios.delete(
-            `/api/v1/user/${user?.id}/pushSubscription/${encodeURIComponent(
-              endpointToDelete
-            )}`
+            apiUrl(
+              `/user/${user?.id}/pushSubscription/${encodeURIComponent(
+                endpointToDelete
+              )}`
+            )
           );
         } catch {
           // Ignore deletion failures - backend cleanup is best effort
@@ -148,9 +151,9 @@ const UserWebPushSettings = () => {
   const deletePushSubscriptionFromBackend = async (endpoint: string) => {
     try {
       await axios.delete(
-        `/api/v1/user/${user?.id}/pushSubscription/${encodeURIComponent(
-          endpoint
-        )}`
+        apiUrl(
+          `/user/${user?.id}/pushSubscription/${encodeURIComponent(endpoint)}`
+        )
       );
 
       addToast(intl.formatMessage(messages.subscriptiondeleted), {
@@ -253,7 +256,7 @@ const UserWebPushSettings = () => {
         onSubmit={async (values) => {
           try {
             await axios.post(
-              `/api/v1/user/${user?.id}/settings/notifications`,
+              apiUrl(`/user/${user?.id}/settings/notifications`),
               {
                 pgpKey: data?.pgpKey,
                 discordId: data?.discordId,
@@ -267,7 +270,7 @@ const UserWebPushSettings = () => {
                 },
               }
             );
-            mutate('/api/v1/settings/public');
+            mutate(apiUrl('/settings/public'));
             addToast(intl.formatMessage(messages.webpushsettingssaved), {
               appearance: 'success',
               autoDismiss: true,

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/index.tsx
@@ -9,6 +9,7 @@ import SettingsTabs from '@app/components/Common/SettingsTabs';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { CloudIcon, EnvelopeIcon } from '@heroicons/react/24/solid';
 import type { UserSettingsNotificationsResponse } from '@server/interfaces/api/userSettingsInterfaces';
@@ -37,7 +38,7 @@ const UserNotificationSettings = ({
   const router = useRouter();
   const { user } = useUser({ id: Number(router.query.userId) });
   const { data, error } = useSWR<UserSettingsNotificationsResponse>(
-    user ? `/api/v1/user/${user?.id}/settings/notifications` : null
+    user ? apiUrl(`/user/${user?.id}/settings/notifications`) : null
   );
 
   const settingsRoutes: SettingsRoute[] = [

--- a/src/components/UserProfile/UserSettings/UserPasswordChange/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserPasswordChange/index.tsx
@@ -6,6 +6,7 @@ import SensitiveInput from '@app/components/Common/SensitiveInput';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
@@ -53,7 +54,7 @@ const UserPasswordChange = () => {
     error,
     mutate: revalidate,
   } = useSWR<{ hasPassword: boolean }>(
-    user ? `/api/v1/user/${user?.id}/settings/password` : null
+    user ? apiUrl(`/user/${user?.id}/settings/password`) : null
   );
 
   const PasswordChangeSchema = Yup.object().shape({
@@ -123,7 +124,7 @@ const UserPasswordChange = () => {
         enableReinitialize
         onSubmit={async (values, { resetForm }) => {
           try {
-            await axios.post(`/api/v1/user/${user?.id}/settings/password`, {
+            await axios.post(apiUrl(`/user/${user?.id}/settings/password`), {
               currentPassword: values.currentPassword,
               newPassword: values.newPassword,
               confirmPassword: values.confirmPassword,

--- a/src/components/UserProfile/UserSettings/UserPermissions/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserPermissions/index.tsx
@@ -6,6 +6,7 @@ import PermissionEdit from '@app/components/PermissionEdit';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
@@ -38,7 +39,7 @@ const UserPermissions = () => {
     error,
     mutate: revalidate,
   } = useSWR<{ permissions?: number }>(
-    user ? `/api/v1/user/${user?.id}/settings/permissions` : null
+    user ? apiUrl(`/user/${user?.id}/settings/permissions`) : null
   );
 
   if (!data && !error) {
@@ -84,7 +85,7 @@ const UserPermissions = () => {
         enableReinitialize
         onSubmit={async (values) => {
           try {
-            await axios.post(`/api/v1/user/${user?.id}/settings/permissions`, {
+            await axios.post(apiUrl(`/user/${user?.id}/settings/permissions`), {
               permissions: values.currentPermissions ?? 0,
             });
 

--- a/src/components/UserProfile/UserSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/index.tsx
@@ -8,6 +8,7 @@ import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import type { UserSettingsNotificationsResponse } from '@server/interfaces/api/userSettingsInterfaces';
 import { hasPermission, Permission } from '@server/lib/permissions';
@@ -36,7 +37,7 @@ const UserSettings = ({ children }: UserSettingsProps) => {
   const { user, error } = useUser({ id: Number(router.query.userId) });
   const intl = useIntl();
   const { data } = useSWR<UserSettingsNotificationsResponse>(
-    user ? `/api/v1/user/${user?.id}/settings/notifications` : null
+    user ? apiUrl(`/user/${user?.id}/settings/notifications`) : null
   );
 
   if (!user && !error) {

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -8,6 +8,7 @@ import TmdbTitleCard from '@app/components/TitleCard/TmdbTitleCard';
 import ProfileHeader from '@app/components/UserProfile/ProfileHeader';
 import { Permission, UserType, useUser } from '@app/hooks/useUser';
 import ErrorPage from '@app/pages/_error';
+import { apiUrl } from '@app/utils/apiUrl';
 import defineMessages from '@app/utils/defineMessages';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/outline';
 import type { WatchlistResponse } from '@server/interfaces/api/discoverInterfaces';
@@ -60,7 +61,7 @@ const UserProfile = () => {
           [Permission.MANAGE_REQUESTS, Permission.REQUEST_VIEW],
           { type: 'or' }
         ))
-      ? `/api/v1/user/${user?.id}/requests?take=10&skip=0`
+      ? apiUrl(`/user/${user?.id}/requests?take=10&skip=0`)
       : null
   );
   const { data: quota } = useSWR<QuotaResponse>(
@@ -70,14 +71,14 @@ const UserProfile = () => {
           [Permission.MANAGE_USERS, Permission.MANAGE_REQUESTS],
           { type: 'and' }
         ))
-      ? `/api/v1/user/${user.id}/quota`
+      ? apiUrl(`/user/${user.id}/quota`)
       : null
   );
   const { data: watchData, error: watchDataError } =
     useSWR<UserWatchDataResponse>(
       user?.userType === UserType.PLEX &&
         (user.id === currentUser?.id || currentHasPermission(Permission.ADMIN))
-        ? `/api/v1/user/${user.id}/watch_data`
+        ? apiUrl(`/user/${user.id}/watch_data`)
         : null
     );
 
@@ -90,7 +91,7 @@ const UserProfile = () => {
             type: 'or',
           }
         )
-        ? `/api/v1/user/${user?.id}/watchlist`
+        ? apiUrl(`/user/${user?.id}/watchlist`)
         : null,
       {
         revalidateOnMount: true,

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,3 +1,4 @@
+import { apiUrl } from '@app/utils/apiUrl';
 import { MediaServerType } from '@server/constants/server';
 import type { PublicSettingsResponse } from '@server/interfaces/api/settingsInterfaces';
 import React from 'react';
@@ -42,7 +43,7 @@ export const SettingsProvider = ({
   currentSettings,
 }: SettingsContextProps) => {
   const { data, error } = useSWR<PublicSettingsResponse>(
-    '/api/v1/settings/public',
+    apiUrl('/settings/public'),
     { fallbackData: currentSettings }
   );
 

--- a/src/hooks/useRequestOverride.ts
+++ b/src/hooks/useRequestOverride.ts
@@ -1,3 +1,4 @@
+import { apiUrl } from '@app/utils/apiUrl';
 import type { MediaRequest } from '@server/entity/MediaRequest';
 import type {
   ServiceCommonServer,
@@ -14,13 +15,15 @@ interface OverrideStatus {
 
 const useRequestOverride = (request: MediaRequest): OverrideStatus => {
   const { data: allServers } = useSWR<ServiceCommonServer[]>(
-    `/api/v1/service/${request.type === 'movie' ? 'radarr' : 'sonarr'}`
+    apiUrl(`/service/${request.type === 'movie' ? 'radarr' : 'sonarr'}`)
   );
 
   const { data } = useSWR<ServiceCommonServerWithDetails>(
-    `/api/v1/service/${request.type === 'movie' ? 'radarr' : 'sonarr'}/${
-      request.serverId
-    }`
+    apiUrl(
+      `/service/${request.type === 'movie' ? 'radarr' : 'sonarr'}/${
+        request.serverId
+      }`
+    )
   );
 
   if (!data || !allServers) {

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,3 +1,4 @@
+import { apiUrl } from '@app/utils/apiUrl';
 import { UserType } from '@server/constants/user';
 import type { PermissionCheckOptions } from '@server/lib/permissions';
 import { hasPermission, Permission } from '@server/lib/permissions';
@@ -66,7 +67,7 @@ export const useUser = ({
     data,
     error,
     mutate: revalidate,
-  } = useSWR<User>(id ? `/api/v1/user/${id}` : `/api/v1/auth/me`, {
+  } = useSWR<User>(id ? apiUrl(`/user/${id}`) : apiUrl('/auth/me'), {
     fallbackData: initialData,
     refreshInterval: !isAuthPage ? 30000 : 0,
     revalidateOnFocus: !isAuthPage,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import { UserContext } from '@app/context/UserContext';
 import type { User } from '@app/hooks/useUser';
 import { Permission, useUser } from '@app/hooks/useUser';
 import '@app/styles/globals.css';
+import { apiUrl } from '@app/utils/apiUrl';
 import { polyfillIntl } from '@app/utils/polyfillIntl';
 import '@fontsource-variable/inter';
 import { MediaServerType } from '@server/constants/server';
@@ -140,7 +141,7 @@ const CoreApp: Omit<NextAppComponentType, 'origGetInitialProps'> = ({
 
   useEffect(() => {
     const requestsCount = async () => {
-      const response = await axios.get('/api/v1/request/count');
+      const response = await axios.get(apiUrl('/request/count'));
       return response.data;
     };
 
@@ -194,7 +195,7 @@ const CoreApp: Omit<NextAppComponentType, 'origGetInitialProps'> = ({
       value={{
         fetcher: (url) => axios.get(url).then((res) => res.data),
         fallback: {
-          '/api/v1/auth/me': user,
+          [apiUrl('/auth/me')]: user,
         },
       }}
     >
@@ -263,7 +264,7 @@ CoreApp.getInitialProps = async (initialProps) => {
     const response = await axios.get<PublicSettingsResponse>(
       `http://${process.env.HOST || 'localhost'}:${
         process.env.PORT || 5055
-      }/api/v1/settings/public`
+      }${apiUrl('/settings/public')}`
     );
 
     currentSettings = response.data;
@@ -283,7 +284,7 @@ CoreApp.getInitialProps = async (initialProps) => {
         const response = await axios.get<User>(
           `http://${process.env.HOST || 'localhost'}:${
             process.env.PORT || 5055
-          }/api/v1/auth/me`,
+          }${apiUrl('/auth/me')}`,
           {
             headers:
               ctx.req && ctx.req.headers.cookie

--- a/src/pages/collection/[collectionId]/index.tsx
+++ b/src/pages/collection/[collectionId]/index.tsx
@@ -1,4 +1,5 @@
 import CollectionDetails from '@app/components/CollectionDetails';
+import { apiUrl } from '@app/utils/apiUrl';
 import type { Collection } from '@server/models/Collection';
 import axios from 'axios';
 import type { GetServerSideProps, NextPage } from 'next';
@@ -17,7 +18,7 @@ export const getServerSideProps: GetServerSideProps<
   const response = await axios.get<Collection>(
     `http://${process.env.HOST || 'localhost'}:${
       process.env.PORT || 5055
-    }/api/v1/collection/${ctx.query.collectionId}`,
+    }${apiUrl(`/collection/${ctx.query.collectionId}`)}`,
     {
       headers: ctx.req?.headers?.cookie
         ? { cookie: ctx.req.headers.cookie }

--- a/src/pages/movie/[movieId]/index.tsx
+++ b/src/pages/movie/[movieId]/index.tsx
@@ -1,4 +1,5 @@
 import MovieDetails from '@app/components/MovieDetails';
+import { apiUrl } from '@app/utils/apiUrl';
 import type { MovieDetails as MovieDetailsType } from '@server/models/Movie';
 import axios from 'axios';
 import type { GetServerSideProps, NextPage } from 'next';
@@ -17,7 +18,7 @@ export const getServerSideProps: GetServerSideProps<MoviePageProps> = async (
   const response = await axios.get<MovieDetailsType>(
     `http://${process.env.HOST || 'localhost'}:${
       process.env.PORT || 5055
-    }/api/v1/movie/${ctx.query.movieId}`,
+    }${apiUrl(`/movie/${ctx.query.movieId}`)}`,
     {
       headers: ctx.req?.headers?.cookie
         ? { cookie: ctx.req.headers.cookie }

--- a/src/pages/tv/[tvId]/index.tsx
+++ b/src/pages/tv/[tvId]/index.tsx
@@ -1,4 +1,5 @@
 import TvDetails from '@app/components/TvDetails';
+import { apiUrl } from '@app/utils/apiUrl';
 import type { TvDetails as TvDetailsType } from '@server/models/Tv';
 import axios from 'axios';
 import type { GetServerSideProps, NextPage } from 'next';
@@ -17,7 +18,7 @@ export const getServerSideProps: GetServerSideProps<TvPageProps> = async (
   const response = await axios.get<TvDetailsType>(
     `http://${process.env.HOST || 'localhost'}:${
       process.env.PORT || 5055
-    }/api/v1/tv/${ctx.query.tvId}`,
+    }${apiUrl(`/tv/${ctx.query.tvId}`)}`,
     {
       headers: ctx.req?.headers?.cookie
         ? { cookie: ctx.req.headers.cookie }

--- a/src/utils/apiUrl.ts
+++ b/src/utils/apiUrl.ts
@@ -1,0 +1,5 @@
+const API_BASE = '/api/v1';
+
+export function apiUrl(path: string): string {
+  return `${API_BASE}${path}`;
+}

--- a/src/utils/pushSubscriptionHelpers.ts
+++ b/src/utils/pushSubscriptionHelpers.ts
@@ -1,3 +1,4 @@
+import { apiUrl } from '@app/utils/apiUrl';
 import type { UserPushSubscription } from '@server/entity/UserPushSubscription';
 import type { PublicSettingsResponse } from '@server/interfaces/api/settingsInterfaces';
 import axios from 'axios';
@@ -56,7 +57,7 @@ export const verifyPushSubscription = async (
     const endpoint = subscription.endpoint;
 
     const { data } = await axios.get<UserPushSubscription>(
-      `/api/v1/user/${userId}/pushSubscription/${encodeURIComponent(endpoint)}`
+      apiUrl(`/user/${userId}/pushSubscription/${encodeURIComponent(endpoint)}`)
     );
 
     return data.endpoint === endpoint;
@@ -93,9 +94,11 @@ export const verifyAndResubscribePushSubscription = async (
       if (oldEndpoint) {
         try {
           await axios.delete(
-            `/api/v1/user/${userId}/pushSubscription/${encodeURIComponent(
-              oldEndpoint
-            )}`
+            apiUrl(
+              `/user/${userId}/pushSubscription/${encodeURIComponent(
+                oldEndpoint
+              )}`
+            )
           );
         } catch {
           // Ignore errors when deleting old endpoint (it might not exist)
@@ -140,7 +143,7 @@ export const subscribeToPushNotifications = async (
     const { endpoint, keys } = subscription.toJSON();
 
     if (keys?.p256dh && keys?.auth) {
-      await axios.post('/api/v1/user/registerPushSubscription', {
+      await axios.post(apiUrl('/user/registerPushSubscription'), {
         endpoint,
         p256dh: keys.p256dh,
         auth: keys.auth,


### PR DESCRIPTION
## Description

Replace all hardcoded API and proxy path strings (`/api/v1`, `/api-docs`, `/imageproxy`, `/avatarproxy`) with centralized constants and a helper function. No behavior changes, pure mechanical refactor.

### Why

There are 201 occurrences of `/api/v1` scattered across 73 client files, plus hardcoded mounts in the server. That's 201 places where a single path is repeated as a raw string literal. If any of these paths ever need to change, every occurrence has to be found and updated manually. That's error-prone and hard to verify.

Extracting these into shared constants is a well-established refactoring pattern:
- The DRY principle from [*The Pragmatic Programmer*](https://pragprog.com/tips/) (Tip #15) - "Every piece of knowledge must have a single, unambiguous, authoritative representation within a system." When a path is duplicated 201 times, changing it means hunting down every copy and hoping you didn't miss one.
- Martin Fowler's ["Replace Magic Literal"](https://refactoring.com/catalog/replaceMagicLiteral.html) (*Refactoring*, 2nd Ed.) - replace repeated literals with a single named constant
- Robert C. Martin's *Clean Code* (Ch. 17, G25) - raw literals should be hidden behind well-named constants

After this change, `/api/v1` is defined in exactly 2 places (one server constant, one client constant). Everything else references them. This makes the codebase easier to maintain and opens the door for things like API versioning, base path configuration, or reverse proxy flexibility without having to touch every file again.

- Related to #97

### What changed

- **New file: `server/constants/routes.ts`** - exports `API_BASE_PATH`, `API_DOCS_PATH`, `IMAGE_PROXY_PATH`, `AVATAR_PROXY_PATH`
- **New file: `src/utils/apiUrl.ts`** - helper function that prepends the API base to a path
- **`server/index.ts`** - route mounts now reference constants
- **`server/routes/index.ts`** - deprecated route paths reference constants
- **`src/components/Common/CachedImage/index.tsx`** - image proxy paths reference constants
- **135 client files** - all `/api/v1` string literals replaced with `apiUrl()` calls

## How Has This Been Tested?

- TypeScript compiles with zero errors
- ESLint + Prettier pass on all 140 files (via pre-commit hooks)
- Ran an independent full-codebase review checking for broken references, missing imports, and malformed template literals. All clean
- Running live on a personal server with existing Overseerr data migrated to Seerr. Login, search, requests, Plex/Sonarr/Radarr/Tautulli integration all working
- `pnpm build` succeeds
- `pnpm i18n:extract` produced no changes (expected, no user-facing text was modified)

## Screenshots / Logs (if applicable)

N/A. No visual changes, this is a pure code refactor.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

**AI Disclosure:** This PR was developed with Claude Code as a pair programming tool. I directed the approach, defined the constants/helper pattern, reviewed all 140 file changes, and ran an independent review pass to catch issues. I'm the author, Claude is my editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized API route and URL construction across the app, including API base, docs, and image/avatar proxy paths.
  * Frontend network requests and cache keys now use the unified URL builder for consistency.
  * No visible UI or behavioral changes for end users; routing and network target resolution were standardized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->