### PR TITLE
test(user-list): deflake sorting assertions

### DIFF
--- a/cypress/e2e/user/user-list.cy.ts
+++ b/cypress/e2e/user/user-list.cy.ts
@@ -92,6 +92,17 @@ describe('User List', () => {
     });
 
     cy.get('[data-testid=column-header-created]').click();
-    cy.get('[data-testid=user-list-row]').should('have.length.greaterThan', 0);
+
+    cy.window().then((win) => {
+      const rawSettings = win.localStorage.getItem('ul-filter-settings');
+      expect(
+        rawSettings,
+        'ul-filter-settings should be stored in localStorage'
+      ).to.be.a('string');
+
+      const settings = JSON.parse(rawSettings as string);
+      expect(settings.currentSort).to.equal('created');
+      expect(settings.sortDirection).to.equal('asc');
+    });
   });
 });

--- a/cypress/e2e/user/user-list.cy.ts
+++ b/cypress/e2e/user/user-list.cy.ts
@@ -92,12 +92,6 @@ describe('User List', () => {
     });
 
     cy.get('[data-testid=column-header-created]').click();
-    cy.wait('@userListFetch').then((interception) => {
-      const url = interception.request.url;
-      expect(url).to.include('sort=created');
-      expect(url).to.include('sortDirection=desc');
-    });
-
     cy.get('[data-testid=user-list-row]').should('have.length.greaterThan', 0);
   });
 });


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A cypress oversight introduced here : #1615

The user list cypress test was expecting an extra `/api/v1/user` request after clicking the "created" column. However, because of SWR and the persisted sort state, the data can sometimes be served from cache, meaning that request isn't always triggered.

- Fixes #XXXX

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`pnpm exec cypress run --spec "cypress/e2e/user/user-list.cy.ts"`

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified user-list sorting test to verify client-side persisted sort settings after clicking the Created column, rather than inspecting outbound request parameters.
  * Removed the previous assertion that the list contained at least one row after sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->