### PR TITLE
fix(override-rules): remove users from `useEffect` dependency array

### DIFF
--- a/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
+++ b/src/components/Settings/OverrideRule/OverrideRuleTiles.tsx
@@ -135,7 +135,7 @@ const OverrideRuleTiles = ({
         setUsers(users);
       }
     })();
-  }, [rules, users]);
+  }, [rules]);
 
   return (
     <>


### PR DESCRIPTION
## Description

Navigating to `Settings > Services` triggers an infinite request loop to `/api/v1/user` when override rules with user conditions exist. The `useEffect` in `OverrideRuleTiles` that fetches user data includes `users` in its dependency array, but also calls `setUsers` within the effect body thus creating a state update → re-run → state update cycle.

This PR removes users from the dependency array so the effect only re-runs when rules change resolves the loop.

- Fixes #2769

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance in the Override Rule settings by optimizing update behavior for rule handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->