### PR TITLE
docs: add self-signed certificate guide

### DIFF
--- a/docs/using-seerr/advanced/self-signed-certificates.mdx
+++ b/docs/using-seerr/advanced/self-signed-certificates.mdx
@@ -12,11 +12,9 @@ import TabItem from '@theme/TabItem';
 
 If your media server or services (Radarr, Sonarr, etc.) use self-signed SSL certificates, Seerr will reject the connection because it does not trust them by default. The recommended fix is to add your CA certificate to Node.js.
 
----
+## Add Your CA Certificate
 
-## Recommended: Add Your CA Certificate
-
-The `NODE_EXTRA_CA_CERTS` environment variable tells Node.js to trust additional Certificate Authority (CA) certificates. This is the recommended approach because it keeps certificate validation active while trusting your specific certificate.
+The `NODE_EXTRA_CA_CERTS` environment variable tells Node.js to trust additional Certificate Authority (CA) certificates. This approach keeps certificate validation active while trusting your specific certificate.
 
 You will need to mount your certificate file (in PEM format) into the container and set the environment variable to point to it.
 

--- a/docs/using-seerr/advanced/self-signed-certificates.mdx
+++ b/docs/using-seerr/advanced/self-signed-certificates.mdx
@@ -1,0 +1,100 @@
+---
+id: self-signed-certificates
+title: Self-Signed Certificates
+sidebar_label: Self-Signed Certificates
+description: How to configure Seerr to work with services that use self-signed SSL certificates.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Self-Signed Certificates
+
+If your media server or services (Radarr, Sonarr, etc.) use self-signed SSL certificates, Seerr will reject the connection because it does not trust them by default. The recommended fix is to add your CA certificate to Node.js. As a last resort, you can disable certificate validation entirely.
+
+---
+
+## Recommended: Add Your CA Certificate
+
+The `NODE_EXTRA_CA_CERTS` environment variable tells Node.js to trust additional Certificate Authority (CA) certificates. This is the recommended approach because it keeps certificate validation active while trusting your specific certificate.
+
+You will need to mount your certificate file (in PEM format) into the container and set the environment variable to point to it.
+
+:::note
+These examples show only the certificate-related configuration. For a complete setup, see the [Docker installation guide](/getting-started/docker).
+:::
+
+<Tabs>
+<TabItem value="docker-cli" label="Docker CLI">
+
+```bash
+docker run -d \
+  --name seerr \
+  -e NODE_EXTRA_CA_CERTS=/certs/my-ca.pem \
+  -v /path/to/my-ca.pem:/certs/my-ca.pem:ro \
+  -p 5055:5055 \
+  ghcr.io/seerr-team/seerr:latest
+```
+
+</TabItem>
+<TabItem value="docker-compose" label="Docker Compose">
+
+```yaml
+services:
+  seerr:
+    image: ghcr.io/seerr-team/seerr:latest
+    environment:
+      - NODE_EXTRA_CA_CERTS=/certs/my-ca.pem
+    volumes:
+      - /path/to/my-ca.pem:/certs/my-ca.pem:ro
+    ports:
+      - 5055:5055
+```
+
+</TabItem>
+</Tabs>
+
+Replace `/path/to/my-ca.pem` with the actual path to your CA certificate on the host. The path after the colon (`/certs/my-ca.pem`) is where it will be available inside the container.
+
+:::tip
+The certificate must be in PEM format. Open it in a text editor — if it starts with `-----BEGIN CERTIFICATE-----`, it is PEM. If it contains binary data, convert it with `openssl x509 -inform DER -in cert.cer -out cert.pem`.
+:::
+
+For more details, see the [Node.js documentation on adding CA certificates](https://nodejs.org/en/learn/http/enterprise-network-configuration#adding-additional-ca-certificates).
+
+---
+
+## Alternative: Disable Certificate Validation
+
+If you cannot get `NODE_EXTRA_CA_CERTS` working, you can disable certificate validation entirely by setting `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+
+<Tabs>
+<TabItem value="docker-cli" label="Docker CLI">
+
+```bash
+docker run -d \
+  --name seerr \
+  -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
+  -p 5055:5055 \
+  ghcr.io/seerr-team/seerr:latest
+```
+
+</TabItem>
+<TabItem value="docker-compose" label="Docker Compose">
+
+```yaml
+services:
+  seerr:
+    image: ghcr.io/seerr-team/seerr:latest
+    environment:
+      - NODE_TLS_REJECT_UNAUTHORIZED=0
+    ports:
+      - 5055:5055
+```
+
+</TabItem>
+</Tabs>
+
+:::warning
+This disables **all** certificate validation for every outgoing HTTPS connection from Seerr, including connections to external APIs like TMDb. Prefer the `NODE_EXTRA_CA_CERTS` approach whenever possible.
+:::

--- a/docs/using-seerr/advanced/self-signed-certificates.mdx
+++ b/docs/using-seerr/advanced/self-signed-certificates.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 # Self-Signed Certificates
 
-If your media server or services (Radarr, Sonarr, etc.) use self-signed SSL certificates, Seerr will reject the connection because it does not trust them by default. The recommended fix is to add your CA certificate to Node.js. As a last resort, you can disable certificate validation entirely.
+If your media server or services (Radarr, Sonarr, etc.) use self-signed SSL certificates, Seerr will reject the connection because it does not trust them by default. The recommended fix is to add your CA certificate to Node.js.
 
 ---
 
@@ -21,7 +21,7 @@ The `NODE_EXTRA_CA_CERTS` environment variable tells Node.js to trust additional
 You will need to mount your certificate file (in PEM format) into the container and set the environment variable to point to it.
 
 :::note
-These examples show only the certificate-related configuration. For a complete setup, see the [Docker installation guide](/getting-started/docker).
+These examples show only the certificate-related configuration. For a complete setup, see the [Getting Started](/getting-started) guide.
 :::
 
 <Tabs>
@@ -61,40 +61,3 @@ The certificate must be in PEM format. Open it in a text editor — if it starts
 :::
 
 For more details, see the [Node.js documentation on adding CA certificates](https://nodejs.org/en/learn/http/enterprise-network-configuration#adding-additional-ca-certificates).
-
----
-
-## Alternative: Disable Certificate Validation
-
-If you cannot get `NODE_EXTRA_CA_CERTS` working, you can disable certificate validation entirely by setting `NODE_TLS_REJECT_UNAUTHORIZED=0`.
-
-<Tabs>
-<TabItem value="docker-cli" label="Docker CLI">
-
-```bash
-docker run -d \
-  --name seerr \
-  -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
-  -p 5055:5055 \
-  ghcr.io/seerr-team/seerr:latest
-```
-
-</TabItem>
-<TabItem value="docker-compose" label="Docker Compose">
-
-```yaml
-services:
-  seerr:
-    image: ghcr.io/seerr-team/seerr:latest
-    environment:
-      - NODE_TLS_REJECT_UNAUTHORIZED=0
-    ports:
-      - 5055:5055
-```
-
-</TabItem>
-</Tabs>
-
-:::warning
-This disables **all** certificate validation for every outgoing HTTPS connection from Seerr, including connections to external APIs like TMDb. Prefer the `NODE_EXTRA_CA_CERTS` approach whenever possible.
-:::

--- a/docs/using-seerr/advanced/self-signed-certificates.mdx
+++ b/docs/using-seerr/advanced/self-signed-certificates.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 # Self-Signed Certificates
 
-If your media server or services (Radarr, Sonarr, etc.) use self-signed SSL certificates, Seerr will reject the connection because it does not trust them by default. The recommended fix is to add your CA certificate to Node.js.
+If your media server or services (Radarr, Sonarr, etc.) use self-signed SSL certificates, Seerr will reject the connection because it does not trust them by default. The fix is to add your CA certificate to Node.js.
 
 ## Add Your CA Certificate
 

--- a/docs/using-seerr/settings/mediaserver.mdx
+++ b/docs/using-seerr/settings/mediaserver.mdx
@@ -84,7 +84,7 @@ This value should be set to the port that your Jellyfin server listens on. The d
 
 #### Use SSL
 
-Enable this setting to connect to Jellyfin via HTTPS rather than HTTP. Note that self-signed certificates are **not** officially supported.
+Enable this setting to connect to Jellyfin via HTTPS rather than HTTP. Self-signed certificates are not trusted by default, but you can configure Seerr to accept them. See [Self-Signed Certificates](/using-seerr/advanced/self-signed-certificates) for details.
 
 #### External URL
 
@@ -178,7 +178,7 @@ This value should be set to the port that your Emby server listens on. The defau
 
 #### Use SSL
 
-Enable this setting to connect to Emby via HTTPS rather than HTTP. Note that self-signed certificates are **not** officially supported.
+Enable this setting to connect to Emby via HTTPS rather than HTTP. Self-signed certificates are not trusted by default, but you can configure Seerr to accept them. See [Self-Signed Certificates](/using-seerr/advanced/self-signed-certificates) for details.
 
 #### External URL
 
@@ -218,7 +218,7 @@ This value should be set to the port that your Plex server listens on. The defau
 
 #### Use SSL
 
-Enable this setting to connect to Plex via HTTPS rather than HTTP. Note that self-signed certificates are _not_ supported.
+Enable this setting to connect to Plex via HTTPS rather than HTTP. Self-signed certificates are not trusted by default, but you can configure Seerr to accept them. See [Self-Signed Certificates](/using-seerr/advanced/self-signed-certificates) for details.
 
 #### Web App URL (optional)
 

--- a/docs/using-seerr/settings/services.md
+++ b/docs/using-seerr/settings/services.md
@@ -44,7 +44,7 @@ This value should be set to the port that your Radarr/Sonarr server listens on. 
 
 #### Use SSL
 
-Enable this setting to connect to Radarr/Sonarr via HTTPS rather than HTTP. Note that self-signed certificates are _not_ supported.
+Enable this setting to connect to Radarr/Sonarr via HTTPS rather than HTTP. Self-signed certificates are not trusted by default, but you can configure Seerr to accept them. See [Self-Signed Certificates](/using-seerr/advanced/self-signed-certificates) for details.
 
 #### API Key
 


### PR DESCRIPTION
## Description

Add a new docs page covering how to use self-signed certificates with Seerr. Documents the `NODE_EXTRA_CA_CERTS` approach with Docker CLI and Docker Compose examples. Updates the four "Use SSL" sections in services.md and mediaserver.mdx to link to the new guide instead of saying certificates are "not supported."

- Fixes #2578

## How Has This Been Tested?

- Verified the documentation renders correctly with `pnpm start` in the docs directory
- Confirmed all internal links resolve to valid pages
- Tested the Docker CLI and Docker Compose examples against the Node.js documentation

## Screenshots / Logs (if applicable)

N/A — documentation-only change.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

## AI Disclosure

AI tools were used to assist with drafting and reviewing this documentation. All content was verified for technical accuracy against the Node.js documentation and the Seerr codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide explaining how to configure acceptance of self-signed SSL certificates for upstream services.
  * Clarified media server and services pages to note self-signed certs are untrusted by default and link to the new guide.
  * Included concrete Docker CLI/Compose examples, PEM conversion instructions, and a link to Node.js docs for adding CA certificates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
