### PR TITLE
fix(login): resolve stuck transition when switching login forms

### DIFF
--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -201,24 +201,17 @@ const Login = () => {
                 <CSSTransition
                   key={mediaServerLogin ? 'ms' : 'local'}
                   nodeRef={loginRef}
-                  addEndListener={(done) => {
-                    loginRef.current?.addEventListener(
-                      'transitionend',
-                      done,
-                      false
-                    );
-                  }}
+                  timeout={{ enter: 300, exit: 150 }}
                   onEntered={() => {
                     document
                       .querySelector<HTMLInputElement>('#email, #username')
                       ?.focus();
                   }}
                   classNames={{
-                    appear: 'opacity-0',
-                    appearActive: 'transition-opacity duration-500 opacity-100',
                     enter: 'opacity-0',
-                    enterActive: 'transition-opacity duration-500 opacity-100',
-                    exitActive: 'transition-opacity duration-0 opacity-0',
+                    enterActive: 'transition-opacity duration-300 opacity-100',
+                    exit: 'opacity-100',
+                    exitActive: 'transition-opacity duration-150 opacity-0',
                   }}
                 >
                   <div ref={loginRef} className="button-container">


### PR DESCRIPTION
## Description
Fixes an issue where switching between login forms (Jellyfin/Seerr toggle for example) would sometimes result in the incoming form being invisible until the user interacted with the page. 

This was caused by `CSSTransition` using `addEndListener` with a `transitionend` event that could fail to fire due to a zero-duration exit transition and a `nodeRef` that swapped to the new component's ref before the old one finished exiting. This PR replaces `addEndListener` with explicit timeout values and I also gave both enter/exit phases matching non-zero CSS durations to ensure smoother transitions.

## How Has This Been Tested?

- Pressed the login switch buttons

## Screenshots / Logs (if applicable)
Before:

https://github.com/user-attachments/assets/c96c3e3b-ed66-42fa-8d24-568726c55760

After:

https://github.com/user-attachments/assets/e3e9b1a9-8683-4491-960c-1c3aeceaa1fd

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized login form animation transitions with adjusted timing for improved visual consistency and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->