### PR TITLE
ci: enforce route constants via ESLint and CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+reviews:
+  path_instructions:
+    - path: 'src/**'
+      instructions: |
+        Flag any hardcoded '/api/v1' string literals in client code.
+        All API paths should use the apiUrl() helper from src/utils/apiUrl.ts.
+        Example: apiUrl('/discover/movies') instead of '/api/v1/discover/movies'.
+    - path: 'server/index.ts'
+      instructions: |
+        Flag any hardcoded '/api/v1', '/api-docs', '/imageproxy', or '/avatarproxy'
+        string literals in route mounts. All route paths should reference constants
+        from server/constants/routes.ts.
+    - path: 'server/routes/**'
+      instructions: |
+        Flag any hardcoded '/api/v1', '/api-docs', '/imageproxy', or '/avatarproxy'
+        string literals. Route paths should reference constants from
+        server/constants/routes.ts.

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -86,6 +86,38 @@ export default defineConfig(
       ],
     },
   },
+  // Enforce route constants in client code (src/)
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/utils/apiUrl.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "Literal[value=/^\\/api\\/v1/], TemplateLiteral[quasis.0.value.raw=/^\\/api\\/v1/]",
+          message:
+            'Use apiUrl() from @app/utils/apiUrl instead of hardcoded /api/v1 paths.',
+        },
+      ],
+    },
+  },
+  // Enforce route constants in server code (excluding the constants definition)
+  {
+    files: ['server/**/*.ts'],
+    ignores: ['server/constants/routes.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "Literal[value=/^\\/api\\/v1/], TemplateLiteral[quasis.0.value.raw=/^\\/api\\/v1/]",
+          message:
+            'Use API_BASE_PATH from @server/constants/routes instead of hardcoded /api/v1 paths.',
+        },
+      ],
+    },
+  },
   prettier,
   {
     linterOptions: {


### PR DESCRIPTION
## Summary  - Adds an ESLint `no-restricted-syntax` rule that flags hardcoded `/api/v1` string literals in `src/` and `server/` (excluding the constant definition files) - Adds `.coderabbit.yaml` with path instructions so CodeRabbit flags hardcoded route paths during review  This is a companion to #2762 (route constants refactor). Once that PR lands, these guardrails prevent the hardcoded paths from being reintroduced.  ### Why  PR #2762 replaces 201 hardcoded `/api/v1` occurrences across 73 files with centralized constants. Without enforcement, new code will inevitably reintroduce hardcoded paths. These two lightweight checks catch it at dev time (ESLint, pre-commit hook) and at review time (CodeRabbit).  ### What changed  - **`eslint.config.mts`** — Two new config blocks with `no-restricted-syntax`:   - `src/**/*.{ts,tsx}` (excludes `src/utils/apiUrl.ts`): "Use apiUrl() from @app/utils/apiUrl"   - `server/**/*.ts` (excludes `server/constants/routes.ts`): "Use API_BASE_PATH from @server/constants/routes" - **`.coderabbit.yaml`** — Path instructions for `src/`, `server/index.ts`, and `server/routes/`  ### Notes  - Zero new dependencies. Uses built-in ESLint `no-restricted-syntax` rule - The ESLint rule will flag existing hardcoded paths on `develop`. This is intentional and expected... those are the same paths #2762 converts. This PR should be merged after #2762 - Tested locally: rule correctly flags `/api/v1` literals, does not flag the constant definition files  ## Test plan  - [x] `npx eslint src/components/TitleCard/index.tsx` flags all 8 hardcoded `/api/v1` paths - [x] ESLint config loads without errors - [x] Constant definition files (`src/utils/apiUrl.ts`, `server/constants/routes.ts`) are excluded - [ ] Verify CodeRabbit picks up `.coderabbit.yaml` instructions on future PRs  ## Checklist:  - [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md). - [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice)) - [ ] I have updated the documentation accordingly. - [x] All new and existing tests passed. - [x] Successful build `pnpm build` - [ ] Translation keys `pnpm i18n:extract` - [ ] Database migration (if required)  **AI Disclosure:** This PR was developed with Claude Code as a pair programming tool. I directed the approach, reviewed the config changes, and verified the ESLint rule behavior. I'm the author, Claude is my editor.  🤖 Generated with [Claude Code](https://claude.com/claude-code)  <!-- This is an auto-generated comment: release notes by coderabbit.ai --> ## Summary by CodeRabbit  * **Chores**   * Added repository-level checks that flag hardcoded API paths and enforce using shared helpers/constants for route and API base paths, improving consistency and reducing configuration errors. <!-- end of auto-generated comment: release notes by coderabbit.ai -->