### PR TITLE
refactor(imageproxy): reduce noisy image cache logging

### DIFF
--- a/server/lib/imageproxy.ts
+++ b/server/lib/imageproxy.ts
@@ -55,16 +55,12 @@ class ImageProxy {
       }
     } catch (e) {
       if (e.code === 'ENOENT') {
-        logger.error('Directory not found', {
-          label: 'Image Cache',
-          message: e.message,
-        });
-      } else {
-        logger.error('Failed to read directory', {
-          label: 'Image Cache',
-          message: e.message,
-        });
+        return;
       }
+      logger.error('Failed to read directory', {
+        label: 'Image Cache',
+        message: e.message,
+      });
     }
 
     logger.info(`Cleared ${deletedImages} stale image(s) from cache '${key}'`, {

--- a/server/routes/avatarproxy.ts
+++ b/server/routes/avatarproxy.ts
@@ -141,13 +141,16 @@ router.get('/:jellyfinUserId', async (req, res) => {
 
     const jellyfinAvatarUrl = getJellyfinAvatarUrl(req.params.jellyfinUserId);
 
-    let imageData = await avatarImageCache.getImage(
-      jellyfinAvatarUrl,
-      fallbackUrl
-    );
-
-    if (imageData.meta.extension === 'json') {
-      // this is a 404
+    let imageData;
+    if (user?.avatarVersion) {
+      imageData = await avatarImageCache.getImage(
+        jellyfinAvatarUrl,
+        fallbackUrl
+      );
+      if (imageData.meta.extension === 'json') {
+        imageData = await avatarImageCache.getImage(fallbackUrl);
+      }
+    } else {
       imageData = await avatarImageCache.getImage(fallbackUrl);
     }
 


### PR DESCRIPTION
## Description
Users without a Jellyfin avatar (where `avatarVersion` is null) were still triggering a fetch to the Jellyfin server on every `avatarproxy` request, resulting in unnecessary 404s and noisy debug logs. This skips the Jellyfin request entirely for those users and serves the gravatar fallback directly. Also downgrades the `ENOENT` error log in `clearCache` to a silent early return, since the cache directory not existing yet is expected behavior, not an error.

- Fixes https://github.com/seerr-team/seerr/issues/2786

## How Has This Been Tested?
- Just log out and log back in when you have recent requests slider with users with no jellyfin avatars and observe no noisy logs

## Screenshots / Logs (if applicable)

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avatar loading now skips unnecessary primary fetches when a user lacks an avatar version, reducing failed requests and improving reliability.
  * Cache-cleanup failures for missing directories no longer produce error logs, reducing noise while preserving logging for other errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->