### PR TITLE
refactor(watchlistsync): log media request creation after success instead of before

### DIFF
--- a/server/lib/watchlistsync.ts
+++ b/server/lib/watchlistsync.ts
@@ -115,12 +115,6 @@ class WatchlistSync {
 
     for (const mediaItem of unavailableItems) {
       try {
-        logger.info("Creating media request from user's Plex Watchlist", {
-          label: 'Watchlist Sync',
-          userId: user.id,
-          mediaTitle: mediaItem.title,
-        });
-
         if (mediaItem.type === 'show' && !mediaItem.tvdbId) {
           throw new Error('Missing TVDB ID from Plex Metadata');
         }
@@ -156,6 +150,12 @@ class WatchlistSync {
           user,
           { isAutoRequest: true }
         );
+
+        logger.info("Created media request from user's Plex Watchlist", {
+          label: 'Watchlist Sync',
+          userId: user.id,
+          mediaTitle: mediaItem.title,
+        });
       } catch (e) {
         if (!(e instanceof Error)) {
           continue;


### PR DESCRIPTION
## Description

The "Creating media request" log message fired before `MediaRequest.request()` was called, so it would appear even when the request was subsequently rejected (e.g. duplicate, quota, no seasons available). This made it look like duplicate requests were being created when they weren't. Moves the log after the successful request call and changes the message to past tense to accurately reflect what happened.

- Fixes #2787

## How Has This Been Tested?

(Not required)

## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal logging for media request synchronization from Plex watchlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->