### PR TITLE
ci(pr-validation): disable package manager cache in nodejs setup

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -125,6 +125,7 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: 'package.json'
+          package-manager-cache: false
 
       - name: Skip bot PRs
         id: bot-check


### PR DESCRIPTION
## Description

This PR disables package manager cache in nodejs setup in pr validation as its not needed.

## How Has This Been Tested?

(This workflow has not been tested)

## Screenshots / Logs (if applicable)

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to adjust caching behavior during Node.js setup in validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->