### PR TITLE
test(usersettings): add integration tests for notification settings route

### DIFF
--- a/server/routes/user/usersettings.test.ts
+++ b/server/routes/user/usersettings.test.ts
@@ -23,6 +23,8 @@ function createApp() {
       secret: 'test-secret',
       resave: false,
       saveUninitialized: false,
+      // secure: false is intentional -- supertest uses HTTP, not HTTPS
+      cookie: { secure: false },
     })
   );
   app.use(checkUser);
@@ -56,11 +58,15 @@ setupTestDb();
 async function authenticatedAgent(email: string, password: string) {
   const agent = request.agent(app);
   const settings = getSettings();
+  const prevLocalLogin = settings.main.localLogin;
   settings.main.localLogin = true;
-
-  const res = await agent.post('/auth/local').send({ email, password });
-  assert.strictEqual(res.status, 200);
-  return agent;
+  try {
+    const res = await agent.post('/auth/local').send({ email, password });
+    assert.strictEqual(res.status, 200);
+    return agent;
+  } finally {
+    settings.main.localLogin = prevLocalLogin;
+  }
 }
 
 describe('POST /user/:id/settings/notifications', () => {

--- a/server/routes/user/usersettings.test.ts
+++ b/server/routes/user/usersettings.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+
+import { getRepository } from '@server/datasource';
+import { User } from '@server/entity/User';
+import { getSettings } from '@server/lib/settings';
+import { checkUser } from '@server/middleware/auth';
+import authRoutes from '@server/routes/auth';
+import { setupTestDb } from '@server/test/db';
+import type { Express } from 'express';
+import express from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import userRoutes from './index';
+
+let app: Express;
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+  app.use(checkUser);
+  app.use('/auth', authRoutes);
+  app.use('/user', userRoutes);
+  // Error handler matching how next({ status, message }) calls are handled
+  app.use(
+    (
+      err: { status?: number; message?: string },
+      _req: express.Request,
+      res: express.Response,
+      // We must provide a next function for the function signature here even though its not used
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      _next: express.NextFunction
+    ) => {
+      res
+        .status(err.status ?? 500)
+        .json({ status: err.status ?? 500, message: err.message });
+    }
+  );
+  return app;
+}
+
+before(async () => {
+  app = createApp();
+});
+
+setupTestDb();
+
+/** Create a supertest agent that is logged in as the given user. */
+async function authenticatedAgent(email: string, password: string) {
+  const agent = request.agent(app);
+  const settings = getSettings();
+  settings.main.localLogin = true;
+
+  const res = await agent.post('/auth/local').send({ email, password });
+  assert.strictEqual(res.status, 200);
+  return agent;
+}
+
+describe('POST /user/:id/settings/notifications', () => {
+  it('persists notification settings to the database', async () => {
+    const agent = await authenticatedAgent('admin@seerr.dev', 'test1234');
+
+    const adminUser = await getRepository(User).findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    const res = await agent
+      .post(`/user/${adminUser.id}/settings/notifications`)
+      .send({
+        discordId: 'test-discord-123',
+        telegramChatId: 'test-telegram-456',
+      });
+
+    assert.strictEqual(res.status, 200);
+
+    const updatedUser = await getRepository(User).findOne({
+      where: { id: adminUser.id },
+      relations: { settings: true },
+    });
+
+    assert.ok(updatedUser?.settings, 'User settings should exist');
+    assert.strictEqual(updatedUser.settings.discordId, 'test-discord-123');
+    assert.strictEqual(
+      updatedUser.settings.telegramChatId,
+      'test-telegram-456'
+    );
+  });
+
+  it('returns the updated values in the response', async () => {
+    const agent = await authenticatedAgent('admin@seerr.dev', 'test1234');
+
+    const adminUser = await getRepository(User).findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    const res = await agent
+      .post(`/user/${adminUser.id}/settings/notifications`)
+      .send({
+        discordId: 'discord-response-check',
+        telegramChatId: 'telegram-response-check',
+      });
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.discordId, 'discord-response-check');
+    assert.strictEqual(res.body.telegramChatId, 'telegram-response-check');
+  });
+
+  it('returns 404 for a non-existent user', async () => {
+    const agent = await authenticatedAgent('admin@seerr.dev', 'test1234');
+
+    const res = await agent
+      .post('/user/99999/settings/notifications')
+      .send({ discordId: 'test' });
+
+    assert.strictEqual(res.status, 404);
+  });
+
+  it('returns 403 for a non-owner non-admin trying to update another user settings', async () => {
+    const agent = await authenticatedAgent('friend@seerr.dev', 'test1234');
+
+    const adminUser = await getRepository(User).findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    const res = await agent
+      .post(`/user/${adminUser.id}/settings/notifications`)
+      .send({ discordId: 'should-not-work' });
+
+    assert.strictEqual(res.status, 403);
+  });
+});


### PR DESCRIPTION
## Description

Adds integration tests for the `POST /user/:id/settings/notifications` route to provide regression coverage for the unawaited `userRepository.save()` fixed in #2760.

Prior to #2760, the handler returned `200` before the database write completed. There were no tests asserting the settings were actually persisted to the database, so the race condition went undetected. This suite locks in the expected behavior: changes must be readable from the database after the response returns.

**AI Disclosure:** I used Claude Code to help write the tests. I reviewed and understood all generated code before submitting.

## How Has This Been Tested?

New test suite at `server/routes/user/usersettings.test.ts` using the real SQLite test database via `setupTestDb()`, following the same pattern as `server/routes/auth.test.ts`:

- `persists notification settings to the database` -- the core regression guard: re-fetches the user from the DB with `relations: { settings: true }` after the POST and asserts the saved values match what was sent. This test would have caught the unawaited save.
- `returns the updated values in the response` -- asserts the response body reflects the values that were sent.
- `returns 404 for a non-existent user` -- asserts the correct error response for a missing user ID.
- `returns 403 for a non-owner non-admin trying to update another user settings` -- asserts the authorization guard is enforced.

All 4 tests pass.

## Screenshots / Logs (if applicable)

N/A -- test-only change with no runtime behaviour change.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. (no documentation changes required for a test-only PR)
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` (no new UI strings added)
- [x] Database migration (if required) (no schema changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an integration test suite for the user notification settings endpoint. Verifies updates persist, response payload reflects changes, returns 404 for missing users, and enforces authorization (403) for non-owners. Includes test setup for authenticated agents and coverage for error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->