### PR TITLE
feat: adds a /health endpoint for a lightweight server ready check

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -47,6 +47,12 @@ const router = Router();
 
 router.use(checkUser);
 
+router.get('/health', (_req, res) => {
+  return res.status(200).json({
+    status: 'ok',
+  });
+});
+
 router.get<unknown, StatusResponse>('/status', async (req, res) => {
   const githubApi = new GithubAPI();
 


### PR DESCRIPTION
## Description

Adds an alternative /health checkpoint that is lightweight which should allow for liveness and readiness probes on  helm chart

- Related #2796

## How Has This Been Tested?


## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/health` endpoint for checking server status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->