### PR TITLE
fix: send availability notification if media is available before approval

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -668,10 +668,18 @@ export class MediaRequest {
         return;
       }
 
-      if (media[this.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE) {
-        logger.warn(
-          'Media became available before request was approved. Skipping approval notification',
+      if (
+        this.status === MediaRequestStatus.APPROVED &&
+        media[this.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
+      ) {
+        logger.info(
+          'Media is already available. Sending availability notification instead of approval.',
           { label: 'Media Request', requestId: this.id, mediaId: this.media.id }
+        );
+        MediaRequest.sendNotification(
+          this,
+          media,
+          Notification.MEDIA_AVAILABLE
         );
         return;
       }
@@ -728,6 +736,10 @@ export class MediaRequest {
       let notifySystem = true;
 
       switch (type) {
+        case Notification.MEDIA_AVAILABLE:
+          event = `${entity.is4k ? '4K ' : ''}${mediaType} Now Available`;
+          notifyAdmin = false;
+          break;
         case Notification.MEDIA_APPROVED:
           event = `${entity.is4k ? '4K ' : ''}${mediaType} Request Approved`;
           notifyAdmin = false;


### PR DESCRIPTION
## Description
When users don't use Sonarr/Radarr and manually fulfill requests, the request stays in `PENDING` state until the media scanner detects the media. At that point, the scanner auto-approves the request, but `notifyApprovedOrDeclined()` sees the media is already AVAILABLE and early-returns without sending any notification that is neither approval nor availability.

This changes the early-return guard to send an availability notification instead of silently suppressing all notifications. This should ensure requesters are still informed when their media is ready.

- Fixes #2809

## How Has This Been Tested?

(not tested but should work anyways)

## Screenshots / Logs (if applicable)

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Users now receive a "Now Available" notification when a request is already approved and the media is available.
  * Notification messaging is more consistent and admin alerts are suppressed for these availability notices to reduce unnecessary admin noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->