### PR TITLE
fix(emby): use static version in auth header for emby only

### DIFF
--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -138,11 +138,14 @@ class JellyfinAPI extends ExternalAPI {
         ? deviceId
         : Buffer.from('BOT_seerr').toString('base64');
 
-    let authHeaderVal: string;
+    const version =
+      settings.main.mediaServerType === MediaServerType.EMBY
+        ? '1.0.0'
+        : getAppVersion();
+
+    let authHeaderVal = `MediaBrowser Client="Seerr", Device="Seerr", DeviceId="${safeDeviceId}", Version="${version}"`;
     if (authToken) {
-      authHeaderVal = `MediaBrowser Client="Seerr", Device="Seerr", DeviceId="${safeDeviceId}", Version="${getAppVersion()}", Token="${authToken}"`;
-    } else {
-      authHeaderVal = `MediaBrowser Client="Seerr", Device="Seerr", DeviceId="${safeDeviceId}", Version="${getAppVersion()}"`;
+      authHeaderVal += `, Token="${authToken}"`;
     }
 
     super(

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -671,9 +671,11 @@ authRoutes.post('/logout', async (req, res, next) => {
             await axios.delete(`${baseUrl}/Devices`, {
               params: { Id: user.jellyfinDeviceId },
               headers: {
-                'X-Emby-Authorization': `MediaBrowser Client="Seerr", Device="Seerr", DeviceId="seerr", Version="${getAppVersion()}", Token="${
-                  settings.jellyfin.apiKey
-                }"`,
+                'X-Emby-Authorization': `MediaBrowser Client="Seerr", Device="Seerr", DeviceId="seerr", Version="${
+                  settings.main.mediaServerType === MediaServerType.EMBY
+                    ? '1.0.0'
+                    : getAppVersion()
+                }", Token="${settings.jellyfin.apiKey}"`,
               },
             });
           } catch (error) {

--- a/server/routes/avatarproxy.ts
+++ b/server/routes/avatarproxy.ts
@@ -27,7 +27,11 @@ async function initAvatarImageProxy() {
     const authToken = getSettings().jellyfin.apiKey;
     _avatarImageProxy = new ImageProxy('avatar', '', {
       headers: {
-        'X-Emby-Authorization': `MediaBrowser Client="Seerr", Device="Seerr", DeviceId="${deviceId}", Version="${getAppVersion()}", Token="${authToken}"`,
+        'X-Emby-Authorization': `MediaBrowser Client="Seerr", Device="Seerr", DeviceId="${deviceId}", Version="${
+          getSettings().main.mediaServerType === MediaServerType.EMBY
+            ? '1.0.0'
+            : getAppVersion()
+        }", Token="${authToken}"`,
       },
     });
   }


### PR DESCRIPTION
## Description

Emby seems to use the combination of Client, Device, DeviceId, and Version in the auth header to identify a device. Since Seerr was using `getAppVersion()` dynamically, every update caused Emby to see it as a new device, breaking per-user device access restrictions and requiring manual re-approval by admins. This changes the Version field to a static value so the device identity remains stable across updates. 

- Fixes #2739

## How Has This Been Tested?

(Did not test, but its a simple change no need to)

## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized authorization header behavior so client version is set consistently, improving compatibility with Jellyfin/Emby servers.
  * Unified header formatting for logout and avatar proxy requests to ensure auth tokens are included when available, reducing authorization failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->