### PR TITLE
fix(request): record modifiedBy on retry and add route tests 

### DIFF
--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -212,3 +212,56 @@ describe('PUT /request/:requestId (movie)', () => {
     assert.strictEqual(saved.rootFolder, '/updated/movies');
   });
 });
+
+describe('POST /request/:requestId/:status', () => {
+  const cases = [
+    { action: 'approve', expected: MediaRequestStatus.APPROVED },
+    { action: 'decline', expected: MediaRequestStatus.DECLINED },
+  ] as const;
+
+  for (const { action, expected } of cases) {
+    it(`transitions to ${action}d and records the acting user`, async () => {
+      const repo = getRepository(MediaRequest);
+      const pending = await seedRequest();
+      const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+      const res = await admin.post(`/request/${pending.id}/${action}`);
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.body.status, expected);
+      assert.strictEqual(res.body.modifiedBy.email, 'admin@seerr.dev');
+
+      const persisted = await repo.findOneOrFail({
+        where: { id: pending.id },
+        relations: { modifiedBy: true },
+      });
+
+      assert.strictEqual(persisted.status, expected);
+      assert.strictEqual(persisted.modifiedBy?.email, 'admin@seerr.dev');
+      assert.ok(persisted.updatedAt > pending.updatedAt);
+    });
+  }
+});
+
+describe('POST /request/:requestId/retry', () => {
+  it('re-approves a failed request and records the acting user', async () => {
+    const repo = getRepository(MediaRequest);
+    const failed = await seedRequest(MediaRequestStatus.FAILED);
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.post(`/request/${failed.id}/retry`);
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.status, MediaRequestStatus.APPROVED);
+    assert.strictEqual(res.body.modifiedBy.email, 'admin@seerr.dev');
+
+    const persisted = await repo.findOneOrFail({
+      where: { id: failed.id },
+      relations: { modifiedBy: true },
+    });
+
+    assert.strictEqual(persisted.status, MediaRequestStatus.APPROVED);
+    assert.strictEqual(persisted.modifiedBy?.email, 'admin@seerr.dev');
+    assert.ok(persisted.updatedAt > failed.updatedAt);
+  });
+});

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -646,6 +646,7 @@ requestRoutes.post<{
 
       // this also triggers updating the parent media's status & sending to *arr
       request.status = MediaRequestStatus.APPROVED;
+      request.modifiedBy = req.user;
       await requestRepository.save(request);
 
       return res.status(200).json(request);


### PR DESCRIPTION
## Description

The retry route (`POST /request/:requestId/retry`) was not setting `modifiedBy` on the request, unlike the [approve/decline route](https://github.com/seerr-team/seerr/blob/dc40ca413c9c82baea0cc9a1fbf2b28b907b036e/server/routes/request.ts#L692) which records the acting user. This means there was no audit trail of who re-approved a failed request. Originally flagged by CodeRabbit in https://github.com/seerr-team/seerr/pull/2729#pullrequestreview-3995918759.

This PR also adds route tests for the approve, decline, and retry flows covering status transitions, `modifiedBy` attribution, and `updatedAt` advancement.

> **Note:** This PR should be merged after #2823 since it depends on `@UpdateDateColumn` being in place for the `updatedAt` assertions.

## How Has This Been Tested?
- Tested by running the unit test with #2823 merged locally.
```
▶ POST /request/:requestId/:status
  ✔ transitions to approved and records the acting user (605.417486ms)
  ✔ transitions to declined and records the acting user (540.404394ms)
✔ POST /request/:requestId/:status (1667.346427ms)
▶ POST /request/:requestId/retry
  ✔ re-approves a failed request and records the acting user (453.960331ms)
✔ POST /request/:requestId/retry (454.44532ms)
ℹ tests 3
ℹ suites 2
ℹ pass 3
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 7937.442868
```

## Screenshots / Logs (if applicable)

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests covering request status transitions (approve, decline) and retry behavior, asserting responses and persisted status, modifier, and updated timestamps.

* **Bug Fixes**
  * Fixed retry flow to correctly record the user who performed the retry so modifications show the proper modifier and updated timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->