### PR TITLE
feat: AdvancedRequestModal preselects the calculated routing rule on create

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -6356,6 +6356,65 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MediaRequest'
+  /request/resolved-route:
+    get:
+      summary: Get the default resolved route for a request
+      description: |
+        Returns the first route used when a new request, for this media, would be inserted.
+      tags:
+        - request
+      parameters:
+        - in: query
+          name: userId
+          schema:
+            type: integer # Changed from number to integer
+            nullable: true
+            example: 20
+        - in: query
+          name: is4k
+          schema:
+            type: boolean
+            nullable: true
+            example: true
+        - in: query
+          name: mediaType
+          schema:
+            type: string
+            enum: [movie, tv]
+            nullable: true
+            default: all
+        - in: query
+          name: mediaId
+          schema:
+            type: integer # Changed from number to integer
+            nullable: false
+            example: 20
+      responses:
+        '200':
+          description: Resolved route
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  serviceId:
+                    type: integer
+                  profileId:
+                    type: integer
+                    nullable: true
+                  rootFolder:
+                    type: string
+                    nullable: true
+                  seriesType:
+                    type: string
+                    nullable: true
+                  tags:
+                    type: array
+                    items:
+                      type: integer
+                  minimumAvailability:
+                    type: string
+                    nullable: true
   /request/count:
     get:
       summary: Gets request counts

--- a/server/interfaces/api/routeInterfaces.ts
+++ b/server/interfaces/api/routeInterfaces.ts
@@ -1,0 +1,3 @@
+import type { ResolvedRoute } from '@server/lib/routingResolver';
+
+export interface RouteResponse extends ResolvedRoute {}

--- a/server/interfaces/api/serviceInterfaces.ts
+++ b/server/interfaces/api/serviceInterfaces.ts
@@ -6,14 +6,7 @@ export interface ServiceCommonServer {
   name: string;
   is4k: boolean;
   isDefault: boolean;
-  activeProfileId: number;
-  activeDirectory: string;
-  activeLanguageProfileId?: number;
-  activeAnimeProfileId?: number;
-  activeAnimeDirectory?: string;
-  activeAnimeLanguageProfileId?: number;
   activeTags: number[];
-  activeAnimeTags?: number[];
 }
 
 export interface ServiceCommonServerWithDetails {

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -66,9 +66,6 @@ export interface DVRSettings {
   apiKey: string;
   useSsl: boolean;
   baseUrl?: string;
-  activeProfileId: number;
-  activeProfileName: string;
-  activeDirectory: string;
   tags: number[];
   is4k: boolean;
   isDefault: boolean;
@@ -86,12 +83,6 @@ export interface RadarrSettings extends DVRSettings {
 export interface SonarrSettings extends DVRSettings {
   seriesType: 'standard' | 'daily' | 'anime';
   animeSeriesType: 'standard' | 'daily' | 'anime';
-  activeAnimeProfileId?: number;
-  activeAnimeProfileName?: string;
-  activeAnimeDirectory?: string;
-  activeAnimeLanguageProfileId?: number;
-  activeLanguageProfileId?: number;
-  animeTags?: number[];
   enableSeasonFolders: boolean;
 }
 

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -1,5 +1,7 @@
 import RadarrAPI from '@server/api/servarr/radarr';
 import SonarrAPI from '@server/api/servarr/sonarr';
+import TheMovieDb from '@server/api/themoviedb';
+import type { TmdbKeyword } from '@server/api/themoviedb/interfaces';
 import {
   MediaRequestStatus,
   MediaStatus,
@@ -21,7 +23,9 @@ import type {
   MediaRequestBody,
   RequestResultsResponse,
 } from '@server/interfaces/api/requestInterfaces';
+import type { RouteResponse } from '@server/interfaces/api/routeInterfaces';
 import { Permission } from '@server/lib/permissions';
+import { resolveRoute } from '@server/lib/routingResolver';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { isAuthenticated } from '@server/middleware/auth';
@@ -294,6 +298,73 @@ requestRoutes.get<Record<string, unknown>, RequestResultsResponse>(
             })),
         },
       });
+    } catch (e) {
+      next({ status: 500, message: e.message });
+    }
+  }
+);
+
+requestRoutes.get<Record<string, unknown>, RouteResponse>(
+  '/resolved-route',
+  async (req, res, next) => {
+    if (!req.user) {
+      return next({
+        status: 401,
+        message: 'You must be logged in to request the default routing rule.',
+      });
+    }
+
+    try {
+      const userId = req.query.userId ? Number(req.query.userId) : null;
+      const is4k = req.query.is4k ? Boolean(req.query.is4k) : false;
+      const mediaId = req.query.mediaId ? Number(req.query.mediaId) : null;
+      const mediaType =
+        (req.query.mediaType as MediaType | MediaType.MOVIE) || MediaType.MOVIE;
+
+      if (!mediaId)
+        return next({
+          status: 404,
+          message: 'MediaId is missing.',
+        });
+
+      const tmdb = new TheMovieDb();
+      const userRepository = getRepository(User);
+
+      if (userId) {
+        req.user = await userRepository.findOneOrFail({
+          where: { id: userId },
+        });
+      }
+
+      if (!req.user) {
+        throw new Error('User missing from request context.');
+      }
+
+      const tmdbMedia =
+        mediaType === MediaType.MOVIE
+          ? await tmdb.getMovie({ movieId: mediaId })
+          : await tmdb.getTvShow({ tvId: mediaId });
+
+      // apply routing rules to determine request settings (server/profile/folder/tags)
+      let tmdbKeywords: number[] = [];
+      if ('keywords' in tmdbMedia.keywords) {
+        tmdbKeywords = tmdbMedia.keywords.keywords.map(
+          (k: TmdbKeyword) => k.id
+        );
+      } else if ('results' in tmdbMedia.keywords) {
+        tmdbKeywords = tmdbMedia.keywords.results.map((k: TmdbKeyword) => k.id);
+      }
+
+      const route = await resolveRoute({
+        serviceType: mediaType === MediaType.MOVIE ? 'radarr' : 'sonarr',
+        is4k: is4k ?? false,
+        userId: req.user.id,
+        genres: tmdbMedia.genres.map((g) => g.id),
+        language: tmdbMedia.original_language,
+        keywords: tmdbKeywords,
+      });
+
+      return res.status(200).json(route);
     } catch (e) {
       next({ status: 500, message: e.message });
     }

--- a/server/routes/service.ts
+++ b/server/routes/service.ts
@@ -20,8 +20,6 @@ serviceRoutes.get('/radarr', async (req, res) => {
       name: radarr.name,
       is4k: radarr.is4k,
       isDefault: radarr.isDefault,
-      activeDirectory: radarr.activeDirectory,
-      activeProfileId: radarr.activeProfileId,
       activeTags: radarr.tags ?? [],
     })
   );
@@ -60,8 +58,6 @@ serviceRoutes.get<{ radarrId: string }>(
         name: radarrSettings.name,
         is4k: radarrSettings.is4k,
         isDefault: radarrSettings.isDefault,
-        activeDirectory: radarrSettings.activeDirectory,
-        activeProfileId: radarrSettings.activeProfileId,
         activeTags: radarrSettings.tags,
       },
       profiles: profiles.map((profile) => ({
@@ -88,12 +84,6 @@ serviceRoutes.get('/sonarr', async (req, res) => {
       name: sonarr.name,
       is4k: sonarr.is4k,
       isDefault: sonarr.isDefault,
-      activeDirectory: sonarr.activeDirectory,
-      activeProfileId: sonarr.activeProfileId,
-      activeAnimeProfileId: sonarr.activeAnimeProfileId,
-      activeAnimeDirectory: sonarr.activeAnimeDirectory,
-      activeLanguageProfileId: sonarr.activeLanguageProfileId,
-      activeAnimeLanguageProfileId: sonarr.activeAnimeLanguageProfileId,
       activeTags: [],
     })
   );
@@ -138,15 +128,7 @@ serviceRoutes.get<{ sonarrId: string }>(
           name: sonarrSettings.name,
           is4k: sonarrSettings.is4k,
           isDefault: sonarrSettings.isDefault,
-          activeDirectory: sonarrSettings.activeDirectory,
-          activeProfileId: sonarrSettings.activeProfileId,
-          activeAnimeProfileId: sonarrSettings.activeAnimeProfileId,
-          activeAnimeDirectory: sonarrSettings.activeAnimeDirectory,
-          activeLanguageProfileId: sonarrSettings.activeLanguageProfileId,
-          activeAnimeLanguageProfileId:
-            sonarrSettings.activeAnimeLanguageProfileId,
           activeTags: sonarrSettings.tags,
-          activeAnimeTags: sonarrSettings.animeTags,
         },
         profiles: profiles.map((profile) => ({
           id: profile.id,

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -238,15 +238,11 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           return;
         }
 
-        let rootFolder = radarrSettings.activeDirectory;
-        let qualityProfile = radarrSettings.activeProfileId;
+        let rootFolder = '';
+        let qualityProfile = -1;
         let tags = radarrSettings.tags ? [...radarrSettings.tags] : [];
 
-        if (
-          entity.rootFolder &&
-          entity.rootFolder !== '' &&
-          entity.rootFolder !== radarrSettings.activeDirectory
-        ) {
+        if (entity.rootFolder && entity.rootFolder !== '') {
           rootFolder = entity.rootFolder;
           logger.info(`Request has an override root folder: ${rootFolder}`, {
             label: 'Media Request',
@@ -255,10 +251,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           });
         }
 
-        if (
-          entity.profileId &&
-          entity.profileId !== radarrSettings.activeProfileId
-        ) {
+        if (entity.profileId) {
           qualityProfile = entity.profileId;
           logger.info(
             `Request has an override quality profile ID: ${qualityProfile}`,
@@ -566,26 +559,10 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           seriesType = sonarrSettings.animeSeriesType ?? 'anime';
         }
 
-        let rootFolder =
-          seriesType === 'anime' && sonarrSettings.activeAnimeDirectory
-            ? sonarrSettings.activeAnimeDirectory
-            : sonarrSettings.activeDirectory;
-        let qualityProfile =
-          seriesType === 'anime' && sonarrSettings.activeAnimeProfileId
-            ? sonarrSettings.activeAnimeProfileId
-            : sonarrSettings.activeProfileId;
-        let languageProfile =
-          seriesType === 'anime' && sonarrSettings.activeAnimeLanguageProfileId
-            ? sonarrSettings.activeAnimeLanguageProfileId
-            : sonarrSettings.activeLanguageProfileId;
-        let tags =
-          seriesType === 'anime'
-            ? sonarrSettings.animeTags
-              ? [...sonarrSettings.animeTags]
-              : []
-            : sonarrSettings.tags
-              ? [...sonarrSettings.tags]
-              : [];
+        let rootFolder = '';
+        let qualityProfile = -1;
+        let languageProfile = -1;
+        let tags = sonarrSettings.tags ? [...sonarrSettings.tags] : [];
 
         if (
           entity.rootFolder &&

--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -8,6 +8,7 @@ import defineMessages from '@app/utils/defineMessages';
 import { formatBytes } from '@app/utils/numberHelpers';
 import { Listbox, Transition } from '@headlessui/react';
 import { CheckIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
+import type { RouteResponse } from '@server/interfaces/api/routeInterfaces';
 import type {
   ServiceCommonServer,
   ServiceCommonServerWithDetails,
@@ -51,6 +52,7 @@ export type RequestOverrides = {
 
 interface AdvancedRequesterProps {
   type: 'movie' | 'tv';
+  mediaId?: number | null | undefined;
   is4k: boolean;
   isAnime?: boolean;
   defaultOverrides?: RequestOverrides;
@@ -60,6 +62,7 @@ interface AdvancedRequesterProps {
 
 const AdvancedRequester = ({
   type,
+  mediaId,
   is4k = false,
   isAnime = false,
   defaultOverrides,
@@ -77,6 +80,16 @@ const AdvancedRequester = ({
       revalidateOnMount: true,
     }
   );
+  const { data: resolvedRoute } = useSWR<RouteResponse>(
+    `/api/v1/request/resolved-route?userId=${currentUser?.id}&mediaId=${mediaId}&mediaType=${type}&is4k=${is4k}`,
+    {
+      refreshInterval: 0,
+      refreshWhenHidden: false,
+      revalidateOnFocus: false,
+      revalidateOnMount: true,
+    }
+  );
+
   const [selectedServer, setSelectedServer] = useState<number | null>(
     defaultOverrides?.server !== undefined && defaultOverrides?.server >= 0
       ? defaultOverrides?.server
@@ -120,6 +133,7 @@ const AdvancedRequester = ({
       ? '/api/v1/user?take=1000&sort=displayname'
       : null
   );
+
   const filteredUserData = useMemo(
     () =>
       userData?.results.filter((user) =>
@@ -153,9 +167,9 @@ const AdvancedRequester = ({
   }, [filteredUserData]);
 
   useEffect(() => {
-    let defaultServer = data?.find(
-      (server) => server.isDefault && is4k === server.is4k
-    );
+    let defaultServer =
+      data?.find((x) => x.id === resolvedRoute?.serviceId) ??
+      data?.find((server) => server.isDefault && is4k === server.is4k);
 
     if (!defaultServer && (data ?? []).length > 0) {
       defaultServer = data?.[0];
@@ -168,34 +182,26 @@ const AdvancedRequester = ({
     ) {
       setSelectedServer(defaultServer.id);
     }
-  }, [data]);
+  }, [data, resolvedRoute]);
 
   useEffect(() => {
     if (serverData) {
-      const defaultProfile = serverData.profiles.find(
-        (profile) =>
-          profile.id ===
-          (isAnime && serverData.server.activeAnimeProfileId
-            ? serverData.server.activeAnimeProfileId
-            : serverData.server.activeProfileId)
-      );
-      const defaultFolder = serverData.rootFolders.find(
-        (folder) =>
-          folder.path ===
-          (isAnime && serverData.server.activeAnimeDirectory
-            ? serverData.server.activeAnimeDirectory
-            : serverData.server.activeDirectory)
-      );
-      const defaultLanguage = serverData.languageProfiles?.find(
-        (language) =>
-          language.id ===
-          (isAnime && serverData.server.activeAnimeLanguageProfileId
-            ? serverData.server.activeAnimeLanguageProfileId
-            : serverData.server.activeLanguageProfileId)
-      );
-      const defaultTags = isAnime
-        ? serverData.server.activeAnimeTags
-        : serverData.server.activeTags;
+      const defaultProfile =
+        serverData.profiles.find((x) => x.id === resolvedRoute?.profileId) ??
+        serverData.profiles.find((profile) => profile.id === selectedProfile) ??
+        serverData.profiles.find(() => true);
+
+      const defaultFolder =
+        serverData.rootFolders.find(
+          (folder) => folder.path === selectedFolder
+        ) ?? serverData.rootFolders.find(() => true);
+
+      const defaultLanguage =
+        serverData.languageProfiles?.find(
+          (language) => language.id === selectedLanguage
+        ) ?? serverData.languageProfiles?.find(() => true);
+
+      const defaultTags = serverData.server.activeTags;
 
       const applyOverrides =
         defaultOverrides &&
@@ -234,7 +240,7 @@ const AdvancedRequester = ({
         setSelectedTags(defaultTags);
       }
     }
-  }, [serverData]);
+  }, [serverData, resolvedRoute]);
 
   useEffect(() => {
     if (defaultOverrides && defaultOverrides.server != null) {

--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -378,17 +378,7 @@ const AdvancedRequester = ({
                         key={`profile-list${profile.id}`}
                         value={profile.id}
                       >
-                        {isAnime &&
-                        serverData.server.activeAnimeProfileId === profile.id
-                          ? intl.formatMessage(messages.default, {
-                              name: profile.name,
-                            })
-                          : !isAnime &&
-                              serverData.server.activeProfileId === profile.id
-                            ? intl.formatMessage(messages.default, {
-                                name: profile.name,
-                              })
-                            : profile.name}
+                        {profile.name}
                       </option>
                     ))}
                 </select>
@@ -422,26 +412,10 @@ const AdvancedRequester = ({
                         key={`folder-list${folder.id}`}
                         value={folder.path}
                       >
-                        {isAnime &&
-                        serverData.server.activeAnimeDirectory === folder.path
-                          ? intl.formatMessage(messages.default, {
-                              name: intl.formatMessage(messages.folder, {
-                                path: folder.path,
-                                space: formatBytes(folder.freeSpace ?? 0),
-                              }),
-                            })
-                          : !isAnime &&
-                              serverData.server.activeDirectory === folder.path
-                            ? intl.formatMessage(messages.default, {
-                                name: intl.formatMessage(messages.folder, {
-                                  path: folder.path,
-                                  space: formatBytes(folder.freeSpace ?? 0),
-                                }),
-                              })
-                            : intl.formatMessage(messages.folder, {
-                                path: folder.path,
-                                space: formatBytes(folder.freeSpace ?? 0),
-                              })}
+                        {intl.formatMessage(messages.folder, {
+                          path: folder.path,
+                          space: formatBytes(folder.freeSpace ?? 0),
+                        })}
                       </option>
                     ))}
                 </select>
@@ -480,19 +454,7 @@ const AdvancedRequester = ({
                           key={`folder-list${language.id}`}
                           value={language.id}
                         >
-                          {isAnime &&
-                          serverData.server.activeAnimeLanguageProfileId ===
-                            language.id
-                            ? intl.formatMessage(messages.default, {
-                                name: language.name,
-                              })
-                            : !isAnime &&
-                                serverData.server.activeLanguageProfileId ===
-                                  language.id
-                              ? intl.formatMessage(messages.default, {
-                                  name: language.name,
-                                })
-                              : language.name}
+                          {language.name}
                         </option>
                       ))}
                   </select>

--- a/src/components/RequestModal/CollectionRequestModal.tsx
+++ b/src/components/RequestModal/CollectionRequestModal.tsx
@@ -521,6 +521,9 @@ const CollectionRequestModal = ({
         hasPermission(Permission.MANAGE_REQUESTS)) && (
         <AdvancedRequester
           type="movie"
+          mediaId={
+            data?.parts.find((part) => selectedParts.includes(part.id))?.id
+          }
           is4k={is4k}
           onChange={(overrides) => {
             setRequestOverrides(overrides);

--- a/src/components/RequestModal/MovieRequestModal.tsx
+++ b/src/components/RequestModal/MovieRequestModal.tsx
@@ -288,6 +288,7 @@ const MovieRequestModal = ({
           hasPermission(Permission.MANAGE_REQUESTS)) && (
           <AdvancedRequester
             type="movie"
+            mediaId={data?.id}
             is4k={is4k}
             requestUser={editRequest.requestedBy}
             defaultOverrides={{
@@ -358,6 +359,7 @@ const MovieRequestModal = ({
         hasPermission(Permission.MANAGE_REQUESTS)) && (
         <AdvancedRequester
           type="movie"
+          mediaId={data?.id}
           is4k={is4k}
           onChange={(overrides) => {
             setRequestOverrides(overrides);

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -727,6 +727,7 @@ const TvRequestModal = ({
         hasPermission(Permission.MANAGE_REQUESTS)) && (
         <AdvancedRequester
           type="tv"
+          mediaId={data?.id}
           is4k={is4k}
           isAnime={data?.keywords.some(
             (keyword) => keyword.id === ANIME_KEYWORD_ID

--- a/src/hooks/useRequestOverride.ts
+++ b/src/hooks/useRequestOverride.ts
@@ -40,18 +40,11 @@ const useRequestOverride = (request: MediaRequest): OverrideStatus => {
       activeServer && request.serverId !== defaultServer?.id
         ? activeServer.name
         : undefined,
-    profile:
-      defaultServer?.activeProfileId !== request.profileId
-        ? data.profiles.find((profile) => profile.id === request.profileId)
-            ?.name
-        : undefined,
-    rootFolder:
-      defaultServer?.activeDirectory !== request.rootFolder
-        ? request.rootFolder
-        : undefined,
+    profile: data.profiles.find((profile) => profile.id === request.profileId)
+      ?.name,
+    rootFolder: request.rootFolder,
     languageProfile:
-      request.type === 'tv' &&
-      defaultServer?.activeLanguageProfileId !== request.languageProfileId
+      request.type === 'tv'
         ? data.languageProfiles?.find(
             (profile) => profile.id === request.languageProfileId
           )?.name


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description
### Reasoning
I discovered that there was an PR open which would solve most of the issues i have with assigning the correct service / profile automatically.
Testing this feature i saw that for non admin users, restricted to making only requests, this worked perfectly.
The rules were calculated correctly and the request could get approved by an admin.

But when using an administrative user, the advanced request modal would always fallback to the initial settings.
In other words, it did not use the calculation functionality introduced by the rules routing feature.
As this was a major letdown, i decided to implement a feature that would allow an admin user to also have the calculated default preselected, but still granting him the option to change the reasoning of the automation.

### Detail
Implemented a new route GET /api/v1/request/resolved-route which returns the calculated output of
the routing rule using the same logic as the post request route.
This route then is used by the request modal to determine the correct
initial setting for a newly created request.
This grants admin users the same quality of life feature as a non admin one has.

This PR is a follow-up to PR #2452. 
It adds preselection for advanced requests which depends on the changes introduced there.

## How Has This Been Tested?
Tests were performed manually by performing the request creation action with both admin and non admin user.
Test instance was connected to my local running Sonarr / Radarr instances and ran against both of them.

Each new request created through my test instance landed on the correct Instance either chosen by the auto calculated rules or by the manual override performed by an admin user.

No affect was noticed on any other component throughout testing

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
        Ran cypress and all seemed fine
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
