### PR TITLE
feat(helm): add subPath for volumeMount

### DIFF
--- a/charts/seerr-chart/Chart.yaml
+++ b/charts/seerr-chart/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: '>=1.23.0-0'
 name: seerr-chart
 description: Seerr helm chart for Kubernetes
 type: application
-version: 3.3.1
+version: 3.3.2
 # renovate: image=ghcr.io/seerr-team/seerr
 appVersion: 'v3.1.0'
 maintainers:

--- a/charts/seerr-chart/Chart.yaml
+++ b/charts/seerr-chart/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: '>=1.23.0-0'
 name: seerr-chart
 description: Seerr helm chart for Kubernetes
 type: application
-version: 3.3.2
+version: 3.4.0
 # renovate: image=ghcr.io/seerr-team/seerr
 appVersion: 'v3.1.0'
 maintainers:

--- a/charts/seerr-chart/README.md
+++ b/charts/seerr-chart/README.md
@@ -44,12 +44,13 @@ If `replicaCount` value was used - remove it. Helm update should work fine after
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| config | object | `{"persistence":{"accessModes":["ReadWriteOnce"],"annotations":{},"existingClaim":"","name":"","size":"5Gi","volumeName":""}}` | Creating PVC to store configuration |
+| config | object | `{"persistence":{"accessModes":["ReadWriteOnce"],"annotations":{},"existingClaim":"","name":"","size":"5Gi","subPath":"","volumeName":""}}` | Creating PVC to store configuration |
 | config.persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes of persistent disk |
 | config.persistence.annotations | object | `{}` | Annotations for PVCs |
 | config.persistence.existingClaim | string | `""` | Specify an existing `PersistentVolumeClaim` to use. If this value is provided, the default PVC will not be created |
 | config.persistence.name | string | `""` | Config name |
 | config.persistence.size | string | `"5Gi"` | Size of persistent disk |
+| config.persistence.subPath | string | `""` | Subpath of the pvc which should be mounted |
 | config.persistence.volumeName | string | `""` | Name of the permanent volume to reference in the claim. Can be used to bind to existing volumes. |
 | extraEnv | list | `[]` | Environment variables to add to the seerr pods |
 | extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the seerr pods |

--- a/charts/seerr-chart/templates/statefulset.yaml
+++ b/charts/seerr-chart/templates/statefulset.yaml
@@ -97,7 +97,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /app/config
-              subPath: {{ or .Values.config.persistence.subPath "" }}
+              subPath: {{ .Values.config.persistence.subPath }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/seerr-chart/templates/statefulset.yaml
+++ b/charts/seerr-chart/templates/statefulset.yaml
@@ -97,6 +97,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /app/config
+              subPath: {{ or .Values.config.persistence.subPath "" }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/seerr-chart/values.yaml
+++ b/charts/seerr-chart/values.yaml
@@ -88,6 +88,8 @@ config:
     volumeName: ''
     # -- Specify an existing `PersistentVolumeClaim` to use. If this value is provided, the default PVC will not be created
     existingClaim: ''
+    # -- Subpath of the pvc which should be mounted
+    subPath: ''
 
 ingress:
   enabled: false


### PR DESCRIPTION

## Description
Add the option to specify the `subPath` of a volume which will be mounted into the container.

- Fixes #2628 

## How Has This Been Tested?
I tested it with no value and `seerr`.  I inspected the PVC to ensure the correct behavior.
*Env:* kind cluster k8s v1.33.4


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
If the `subPath`is not specified the Default `""` is taken

## Screenshots / Logs (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added config.persistence.subPath option to allow mounting a specific subpath from a PVC.

* **Documentation**
  * Updated chart README to document the new persistence subPath setting and its default.

* **Chores**
  * Bumped Helm chart version to 3.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->