### PR TITLE
fix(helm): healthcheck endpoint to avoid github rate limit

### DIFF
--- a/charts/seerr-chart/Chart.yaml
+++ b/charts/seerr-chart/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: '>=1.23.0-0'
 name: seerr-chart
 description: Seerr helm chart for Kubernetes
 type: application
-version: 3.4.0
+version: 3.4.1
 # renovate: image=ghcr.io/seerr-team/seerr
 appVersion: 'v3.1.0'
 maintainers:

--- a/charts/seerr-chart/README.md
+++ b/charts/seerr-chart/README.md
@@ -1,6 +1,6 @@
 # seerr-chart
 
-![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.1.0](https://img.shields.io/badge/AppVersion-v3.1.0-informational?style=flat-square)
+![Version: 3.4.1](https://img.shields.io/badge/Version-3.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.1.0](https://img.shields.io/badge/AppVersion-v3.1.0-informational?style=flat-square)
 
 Seerr helm chart for Kubernetes
 

--- a/charts/seerr-chart/templates/statefulset.yaml
+++ b/charts/seerr-chart/templates/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /api/v1/status
+              path: /api/v1/settings/public
               port: http
             {{- if .Values.probes.livenessProbe.initialDelaySeconds }}
             initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
@@ -63,7 +63,7 @@ spec:
             {{- end }}
           readinessProbe:
             httpGet:
-              path: /api/v1/status
+              path: /api/v1/settings/public
               port: http
             {{- if .Values.probes.readinessProbe.initialDelaySeconds }}
             initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}

--- a/docs/extending-seerr/reverse-proxy.mdx
+++ b/docs/extending-seerr/reverse-proxy.mdx
@@ -293,7 +293,7 @@ This is a third-party documentation maintained by the community. We can't provid
       log global
       option httplog
       http-response set-header Strict-Transport-Security max-age=15552000
-      option httpchk GET /api/v1/status
+      option httpchk GET /api/v1/settings/public
       timeout connect 30000
       timeout server 30000
       retries 3

--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -61,7 +61,7 @@ docker run -d \
   -p 5055:5055 \
   -v /path/to/appdata/config:/app/config \
   --restart unless-stopped \
-  --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/status || exit 1" \
+  --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/settings/public || exit 1" \
   --health-start-period 20s \
   --health-timeout 3s \
   --health-interval 15s \
@@ -116,7 +116,7 @@ services:
     volumes:
       - /path/to/appdata/config:/app/config
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/status || exit 1
+      test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/settings/public || exit 1
       start_period: 20s
       timeout: 3s
       interval: 15s
@@ -179,7 +179,7 @@ docker run -d `
   -p 5055:5055 `
   -v seerr-data:/app/config `
   --restart unless-stopped `
-  --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/status || exit 1" `
+  --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/settings/public || exit 1" `
   --health-start-period 20s `
   --health-timeout 3s `
   --health-interval 15s `
@@ -217,7 +217,7 @@ docker run -d ^
   -p 5055:5055 ^
   -v seerr-data:/app/config ^
   --restart unless-stopped ^
-  --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/status || exit 1" ^
+  --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/settings/public || exit 1" ^
   --health-start-period 20s ^
   --health-timeout 3s ^
   --health-interval 15s ^
@@ -260,7 +260,7 @@ services:
     volumes:
       - seerr-data:/app/config
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/status || exit 1
+      test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/settings/public || exit 1
       start_period: 20s
       timeout: 3s
       interval: 15s

--- a/docs/migration-guide.mdx
+++ b/docs/migration-guide.mdx
@@ -82,7 +82,7 @@ Summary of changes :
       volumes:
         - /path/to/appdata/config:/app/config
       healthcheck:
-        test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/status || exit 1
+        test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/settings/public || exit 1
         start_period: 20s
         timeout: 3s
         interval: 15s
@@ -126,7 +126,7 @@ Summary of changes :
       volumes:
         - seerr-data:/app/config
       healthcheck:
-        test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/status || exit 1
+        test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/settings/public || exit 1
         start_period: 20s
         timeout: 3s
         interval: 15s


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

Improve the health check by using an endpoint that does not depend on external resources.

linked to https://github.com/seerr-team/seerr/issues/2796

## How Has This Been Tested?

n/a
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart version to 3.4.1

* **Documentation**
  * Updated Docker health-check examples (Linux/macOS/Windows) to use the current endpoint
  * Updated reverse-proxy (HAProxy) health-check example to use the current endpoint
  * Updated migration guide with revised health-check examples
  * Refreshed Helm chart README version badge
<!-- end of auto-generated comment: release notes by coderabbit.ai -->