### PR TITLE
fix(generate-password): await setPassword to fix race condition

### DIFF
--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -194,7 +194,7 @@ export class User {
 
   public async generatePassword(): Promise<void> {
     const password = generatePassword.randomPassword({ length: 16 });
-    this.setPassword(password);
+    await this.setPassword(password);
 
     const { applicationTitle, applicationUrl } = getSettings().main;
     try {


### PR DESCRIPTION
## Description

`generatePassword()` calls `setPassword()` without awaiting it. Since `setPassword` hashes the password asynchronously with `bcrypt`, the user entity can be saved before the hash completes, resulting in a `null` password. This is a race condition that's usually masked by the subsequent email send taking long enough, but isn't guaranteed. This PR adds the missing await to ensure the password is always set before proceeding.

- Fixes #2844

## How Has This Been Tested?

(It's a one-word fix, and reliably reproducing a race condition while testing would be way more effort than the fix itself. The bug is self-evidently correct from reading the code.)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where password operations executed in an incorrect sequence, ensuring password generation and associated notifications complete reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->