### PR TITLE
feat: add MANAGE_MEDIA permission for non-admin users

### DIFF
--- a/server/lib/permissions.ts
+++ b/server/lib/permissions.ts
@@ -29,6 +29,7 @@ export enum Permission {
   WATCHLIST_VIEW = 134217728,
   MANAGE_BLOCKLIST = 268435456,
   VIEW_BLOCKLIST = 1073741824,
+  MANAGE_MEDIA = 2147483648,
 }
 
 export interface PermissionCheckOptions {

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -169,7 +169,7 @@ mediaRoutes.post<
 
 mediaRoutes.delete(
   '/:id',
-  isAuthenticated(Permission.MANAGE_REQUESTS),
+  isAuthenticated([Permission.ADMIN, Permission.MANAGE_MEDIA], { type: 'or' }),
   async (req, res, next) => {
     try {
       const mediaRepository = getRepository(Media);
@@ -198,7 +198,7 @@ mediaRoutes.delete(
 
 mediaRoutes.delete(
   '/:id/file',
-  isAuthenticated(Permission.MANAGE_REQUESTS),
+  isAuthenticated([Permission.ADMIN, Permission.MANAGE_MEDIA], { type: 'or' }),
   async (req, res, next) => {
     try {
       const settings = getSettings();

--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -116,10 +116,14 @@ const ManageSlideOver = ({
       : null
   );
   const { data: radarrData } = useSWR<RadarrSettings[]>(
-    hasPermission(Permission.ADMIN) ? '/api/v1/settings/radarr' : null
+    hasPermission([Permission.ADMIN, Permission.MANAGE_MEDIA], { type: 'or' })
+      ? '/api/v1/settings/radarr'
+      : null
   );
   const { data: sonarrData } = useSWR<SonarrSettings[]>(
-    hasPermission(Permission.ADMIN) ? '/api/v1/settings/sonarr' : null
+    hasPermission([Permission.ADMIN, Permission.MANAGE_MEDIA], { type: 'or' })
+      ? '/api/v1/settings/sonarr'
+      : null
   );
 
   const deleteMedia = async () => {
@@ -329,7 +333,9 @@ const ManageSlideOver = ({
             </div>
           </div>
         )}
-        {hasPermission(Permission.ADMIN) &&
+        {hasPermission([Permission.ADMIN, Permission.MANAGE_MEDIA], {
+          type: 'or',
+        }) &&
           (data.mediaInfo?.serviceUrl ||
             data.mediaInfo?.tautulliUrl ||
             watchData?.data) && (
@@ -453,7 +459,9 @@ const ManageSlideOver = ({
                   </a>
                 )}
 
-                {hasPermission(Permission.ADMIN) &&
+                {hasPermission([Permission.ADMIN, Permission.MANAGE_MEDIA], {
+                  type: 'or',
+                }) &&
                   data?.mediaInfo?.serviceUrl &&
                   isDefaultService() && (
                     <div>
@@ -489,7 +497,9 @@ const ManageSlideOver = ({
               </div>
             </div>
           )}
-        {hasPermission(Permission.ADMIN) &&
+        {hasPermission([Permission.ADMIN, Permission.MANAGE_MEDIA], {
+          type: 'or',
+        }) &&
           (data.mediaInfo?.serviceUrl4k ||
             data.mediaInfo?.tautulliUrl4k ||
             watchData?.data4k) && (
@@ -650,7 +660,9 @@ const ManageSlideOver = ({
               </div>
             </div>
           )}
-        {hasPermission(Permission.ADMIN) &&
+        {hasPermission([Permission.ADMIN, Permission.MANAGE_MEDIA], {
+          type: 'or',
+        }) &&
           data?.mediaInfo &&
           data.mediaInfo.status !== MediaStatus.BLOCKLISTED && (
             <div>

--- a/src/components/PermissionEdit/index.tsx
+++ b/src/components/PermissionEdit/index.tsx
@@ -85,6 +85,9 @@ export const messages = defineMessages('components.PermissionEdit', {
   viewblocklistedItems: 'View blocklisted media.',
   viewblocklistedItemsDescription:
     'Grant permission to view blocklisted media.',
+  managemedia: 'Manage Media',
+  managemediaDescription:
+    'Grant permission to manage media. Users with this permission can delete media from Radarr/Sonarr and mark media as available.',
 });
 
 interface PermissionEditProps {
@@ -115,6 +118,12 @@ export const PermissionEdit = ({
       name: intl.formatMessage(messages.users),
       description: intl.formatMessage(messages.usersDescription),
       permission: Permission.MANAGE_USERS,
+    },
+    {
+      id: 'managemedia',
+      name: intl.formatMessage(messages.managemedia),
+      description: intl.formatMessage(messages.managemediaDescription),
+      permission: Permission.MANAGE_MEDIA,
     },
     {
       id: 'managerequest',


### PR DESCRIPTION
  ## Summary
  Adds a new `MANAGE_MEDIA` permission that allows non-admin users to manage media (delete from Radarr/Sonarr,
  mark as available) without requiring full admin access.

  ## Changes
  - Added `MANAGE_MEDIA` permission to the permissions enum
  - Updated `ManageSlideOver` component to check for `MANAGE_MEDIA` permission (in addition to `ADMIN`)
  - Updated backend API endpoints (`DELETE /api/v1/media/:id` and `DELETE /api/v1/media/:id/file`) to enforce the
  new permission
  - Added "Manage Media" option to the permission settings UI so admins can grant this permission to users

  ## What users with MANAGE_MEDIA can now do:
  - Delete media from Radarr/Sonarr
  - Mark media as available (including 4K)
  - Clear media data
  - Access the media management sections in the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Manage Media" permission level, allowing administrators to grant media management capabilities separately from full admin access.
  * Updated media deletion endpoints to recognize the new permission type.
  * Permission management interface now includes the option to assign "Manage Media" permissions to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->