### PR TITLE
fix(overseerr-merge): sanitise corrupt quota values during overseerr migration

### DIFF
--- a/server/lib/overseerrMerge.ts
+++ b/server/lib/overseerrMerge.ts
@@ -89,6 +89,27 @@ const checkOverseerrMerge = async (): Promise<boolean> => {
     await dbConnection.query('PRAGMA foreign_keys=ON');
   }
 
+  // Fix corrupted quota values carried over from Overseerr
+  try {
+    await dbConnection.query(
+      `UPDATE user SET movieQuotaLimit = NULL WHERE typeof(movieQuotaLimit) = 'text'`
+    );
+    await dbConnection.query(
+      `UPDATE user SET movieQuotaDays = NULL WHERE typeof(movieQuotaDays) = 'text'`
+    );
+    await dbConnection.query(
+      `UPDATE user SET tvQuotaLimit = NULL WHERE typeof(tvQuotaLimit) = 'text'`
+    );
+    await dbConnection.query(
+      `UPDATE user SET tvQuotaDays = NULL WHERE typeof(tvQuotaDays) = 'text'`
+    );
+  } catch (error) {
+    logger.error('Failed to clean up corrupted quota values', {
+      label: 'Seerr Migration',
+      error: error.message,
+    });
+  }
+
   // MediaStatus.Blacklisted was added before MediaStatus.Deleted in Jellyseerr
   try {
     const mediaRepository = getRepository(Media);


### PR DESCRIPTION
## Description

Some users migrating from Overseerr have quota fields stored as literal strings (e.g. "movieQuotaLimit") instead of integers. The root cause is unknown but is likely related to Overseerr's older TypeORM version, a past API bug, or a schema sync issue. This adds a cleanup step to the Overseerr migration flow that nulls out any corrupted values from the Overseerr database, letting affected users fall back to the global defaults correctly.

- Re #2852

## How Has This Been Tested?

(Not tested but should work in theory).

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quota data is now validated and cleaned during Overseerr migration, preventing data integrity issues and ensuring migration stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->