### PR TITLE
chore: bump minimum required node version to 22.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "typescript-eslint": "^8.56.1"
   },
   "engines": {
-    "node": "^22.0.0",
+    "node": "^22.19.0",
     "pnpm": "^10.0.0"
   },
   "config": {


### PR DESCRIPTION
Upgrades the minimum required Node version to support the require(ESM) feature and newer versions of `undici`. See https://nodejs.org/en/blog/release/v22.12.0.

## Description

Upgrades the minimum required Node version to support the require(ESM) feature. See https://nodejs.org/en/blog/release/v22.12.0. This is required for some upcoming features, which depend on libraries that only ship an ESM build.

## How Has This Been Tested?

This does not require testing.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js version requirement to 22.19.0. Ensure your Node.js installation meets this updated requirement before upgrading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->