### PR TITLE
fix: remove orphaned media entries when all requests are deleted

### DIFF
--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -42,6 +42,11 @@ const sanitizeDisplayName = (displayName: string): string => {
 
 @EventSubscriber()
 export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRequest> {
+  private static readonly ACTIVE_STATUSES = new Set([
+    MediaStatus.AVAILABLE,
+    MediaStatus.PARTIALLY_AVAILABLE,
+    MediaStatus.PROCESSING,
+  ]);
   private async notifyAvailableMovie(
     entity: MediaRequest,
     event?: UpdateEvent<MediaRequest>
@@ -952,13 +957,29 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       relations: { requests: true },
     });
 
+    const hasStandardRequests = fullMedia.requests.some((r) => !r.is4k);
+    const has4kRequests = fullMedia.requests.some((r) => r.is4k);
+
+    // If no requests remain at all and the media isn't actively
+    // available or being processed, delete the orphaned entry so
+    // users can submit a fresh request for this title.
+    if (
+      !hasStandardRequests &&
+      !has4kRequests &&
+      !MediaRequestSubscriber.ACTIVE_STATUSES.has(fullMedia.status) &&
+      !MediaRequestSubscriber.ACTIVE_STATUSES.has(fullMedia.status4k)
+    ) {
+      await manager.remove(fullMedia);
+      return;
+    }
+
     const needsStatusUpdate =
-      !fullMedia.requests.some((request) => !request.is4k) &&
-      fullMedia.status !== MediaStatus.AVAILABLE;
+      !hasStandardRequests &&
+      !MediaRequestSubscriber.ACTIVE_STATUSES.has(fullMedia.status);
 
     const needs4kStatusUpdate =
-      !fullMedia.requests.some((request) => request.is4k) &&
-      fullMedia.status4k !== MediaStatus.AVAILABLE;
+      !has4kRequests &&
+      !MediaRequestSubscriber.ACTIVE_STATUSES.has(fullMedia.status4k);
 
     if (needsStatusUpdate || needs4kStatusUpdate) {
       // Re-fetch WITHOUT requests to avoid cascade issues on save


### PR DESCRIPTION
## Description

When a user deletes the last request associated with a media entry, the media record is left orphaned in the database with status `UNKNOWN`. This prevents users from submitting a new request for the same title since Seerr still treats it as an existing item.

`handleRemoveParentUpdate()` now removes the media entry entirely when no requests remain and the media is not in an active state (`AVAILABLE`, `PARTIALLY_AVAILABLE`, or `PROCESSING`). Media that is already available on disk is never removed.

Also aligns the status-reset branch with the same `ACTIVE_STATUSES` set to avoid resetting `PROCESSING` or `PARTIALLY_AVAILABLE` media to `UNKNOWN`.

## How Has This Been Tested?

Manual testing on a self-hosted instance with orphaned media entries. Verified:
- Deleting the last request on non-available media removes the media entry
- Re-requesting the same title works after deletion
- Media with status AVAILABLE is preserved
- Media with remaining requests (standard or 4k) is not affected

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

> This pull request was authored with AI assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of orphaned media by implementing proper cleanup when no active requests remain.

* **Refactor**
  * Optimized request status checking to reduce redundant scans.
  * Enhanced status tracking logic for media items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->