### PR TITLE
ci(docker): release alias for major and minor version series

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,9 @@ jobs:
             ${{ env.DOCKER_HUB }}
             ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=${{ env.VERSION }}
+            type=semver,pattern={{raw}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
           labels: |
             org.opencontainers.image.created=${{ steps.ts.outputs.TIMESTAMP }}
 

--- a/docs/getting-started/docker.mdx
+++ b/docs/getting-started/docker.mdx
@@ -18,6 +18,8 @@ Our Docker images are available with the following tags:
 
 - `latest`: Always points to the most recent stable release.
 - Version tags (e.g., `v3.0.0`): For specific stable versions.
+- Major version aliases (e.g., `v3`): Alias for the latest stable release in the respective major version series.
+- Minor version aliases (e.g., `v3.0`): Alias for the latest stable release in the respective minor version series.
 - `develop`: Rolling release/nightly builds for using the latest changes (use with caution).
 :::
 

--- a/docs/migration-guide.mdx
+++ b/docs/migration-guide.mdx
@@ -39,6 +39,8 @@ Our Docker images are available with the following tags:
 
 - `latest`: Always points to the most recent stable release.
 - Version tags (e.g., `v3.0.0`): For specific stable versions.
+- Major version aliases (e.g., `v3`): Alias for the latest stable release in the respective major version series.
+- Minor version aliases (e.g., `v3.0`): Alias for the latest stable release in the respective minor version series.
 - `develop`: Rolling release/nightly builds for using the latest changes (use with caution).
 :::
 


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Fixes #2875

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

not tested

https://github.com/docker/metadata-action?tab=readme-ov-file#typesemver

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker image now includes semantic version tag aliases (`v<major>` and `v<major>.<minor>`) alongside full version tags for easier version pinning.

* **Documentation**
  * Updated Docker image tag documentation to reflect new tag alias options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->