### PR TITLE
fix(settings): persist new settings defaults to disk on startup

### DIFF
--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -811,16 +811,22 @@ class Settings {
       await this.save();
     }
 
+    let change = false;
     if (data && !raw) {
       const parsedJson = JSON.parse(data);
       const migratedData = await runMigrations(parsedJson, SETTINGS_PATH);
-      this.data = mergeSettings(this.data, migratedData);
+      const merged = mergeSettings(this.data, migratedData);
+
+      if (JSON.stringify(merged) !== JSON.stringify(migratedData)) {
+        change = true;
+      }
+
+      this.data = merged;
     } else if (data) {
       this.data = JSON.parse(data);
     }
 
     // generate keys and ids if it's missing
-    let change = false;
     if (!this.data.main.apiKey) {
       this.data.main.apiKey = this.generateApiKey();
       change = true;


### PR DESCRIPTION
## Description

Previously, when new default values were added to the Settings constructor, `mergeSettings` would correctly backfill them into memory at runtime, but `save()` was only triggered when `apiKey`, `clientId`, or `vapidKeys` were missing. This meant the file on disk would never be updated with the new defaults and every restart would silently re-merge the same missing keys, and the settings file would stay stale indefinitely.

This adds a check that compares the merged result against the file data after loading. If new keys were introduced from defaults, the file now gets written once on the first startup after an upgrade. Subsequent startups see no difference and skip the write.

This is the root cause behind several long-standing issues where settings appeared to not save properly, including series type not reflecting correctly, media server type not persisting, and other cases where newly introduced defaults were available in memory but never written to disk.

## How Has This Been Tested?

(tested on #2731)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced settings migration handling to ensure configuration changes are properly tracked and persisted during data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->