### PR TITLE
ci(create-tag): add gh token to avoid api rate limit in tag version retrieval

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Get tag version
         id: git-cliff
+        env:
+          # In order to avoid hitting the GitHub API rate limit
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag_version=$(git-cliff -c .github/cliff.toml --bumped-version --unreleased)
           echo "Next tag version is ${tag_version}"


### PR DESCRIPTION
## Description

Prevents getting rate limited when retrieving tag version when creating tag.

## How Has This Been Tested?
(not needed)

## Screenshots / Logs (if applicable)
<img width="1026" height="477" alt="image" src="https://github.com/user-attachments/assets/51cb142c-5d00-4754-a3e2-de892cb9ff2a" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the automated tag creation process with enhanced GitHub authentication handling in CI/CD workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->