### PR TITLE
fix(imdbRadarrProxy): pass headers and nodeCache as options instead of params

### DIFF
--- a/server/api/rating/imdbRadarrProxy.ts
+++ b/server/api/rating/imdbRadarrProxy.ts
@@ -156,13 +156,17 @@ export interface IMDBRating {
  */
 class IMDBRadarrProxy extends ExternalAPI {
   constructor() {
-    super('https://api.radarr.video/v1', {
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      nodeCache: cacheManager.getCache('imdb').data,
-    });
+    super(
+      'https://api.radarr.video/v1',
+      {},
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        nodeCache: cacheManager.getCache('imdb').data,
+      }
+    );
   }
 
   /**


### PR DESCRIPTION
## Description
The `IMDBRadarrProxy` constructor was passing `{ headers, nodeCache }` as the second argument to `super()`, which `ExternalAPI` treats as axios default query parameters rather than options. This meant that our internal IMDB cache was silently dead (never populated, every request hit the network), and every outbound request to api.radarr.video carried `?headers[...]&nodeCache=[object+Object]` tacked on. Since that query string is identical across every Seerr instance everywhere, we were all hitting the same mangled URL on Radarr's CDN and getting back whatever stale response had been cached against that key, which is why ratings could drift out of sync with the canonical endpoint for extended periods.

- Fixes #2899

## How Has This Been Tested?
Before the fix, every request from Seerr to api.radarr.video hits a URL with garbage query params appended. You can reproduce the stale response by curling the mangled URL directly:

**Mangled URL (what Seerr currently hits) which returns stale cached rating**:
```bash
curl -s "https://api.radarr.video/v1/movie/imdb/tt36647890?headers%5BContent-Type%5D=application%2Fjson&headers%5BAccept%5D=application%2Fjson&nodeCache=%5Bobject+Object%5D" \
  -H "Accept: application/json" | jq '.[0].MovieRatings.Imdb'
```
```json
{
  "Count": 203,
  "Value": 4.1,
  "Type": "User"
}
```
**Canonical URL (what we'll hit after the fix) which returns current rating**:
```bash
curl -s "https://api.radarr.video/v1/movie/imdb/tt36647890" \
  -H "Accept: application/json" | jq '.[0].MovieRatings.Imdb'
```
```json
{
  "Count": 1683,
  "Value": 3.9,
  "Type": "User"
}
```

After the fix, hit `/api/v1/movie/1470130/ratingscombined` on a running instance and confirm `imdb.criticsScore` matches the canonical curl output (on ui too).

## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to code organization for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->