### PR TITLE
fix(override-rules): use find() instead of index lookup for service resolution

### DIFF
--- a/src/components/Settings/OverrideRule/OverrideRuleModal.tsx
+++ b/src/components/Settings/OverrideRule/OverrideRuleModal.tsx
@@ -118,20 +118,15 @@ const OverrideRuleModal = ({
   );
 
   useEffect(() => {
-    if (
-      rule?.radarrServiceId !== null &&
-      rule?.radarrServiceId !== undefined &&
-      radarrServices[rule?.radarrServiceId]
-    ) {
-      getServiceInfos(radarrServices[rule?.radarrServiceId], 'radarr');
-    }
-    if (
-      rule?.sonarrServiceId !== null &&
-      rule?.sonarrServiceId !== undefined &&
-      sonarrServices[rule?.sonarrServiceId]
-    ) {
-      getServiceInfos(sonarrServices[rule?.sonarrServiceId], 'sonarr');
-    }
+    const radarrMatch = radarrServices.find(
+      (s) => s.id === rule?.radarrServiceId
+    );
+    if (radarrMatch) getServiceInfos(radarrMatch, 'radarr');
+
+    const sonarrMatch = sonarrServices.find(
+      (s) => s.id === rule?.sonarrServiceId
+    );
+    if (sonarrMatch) getServiceInfos(sonarrMatch, 'sonarr');
   }, [
     getServiceInfos,
     radarrServices,
@@ -258,14 +253,20 @@ const OverrideRuleModal = ({
                           if (e.target.value.startsWith('radarr-')) {
                             setFieldValue('radarrServiceId', id);
                             setFieldValue('sonarrServiceId', null);
-                            if (radarrServices[id]) {
-                              getServiceInfos(radarrServices[id], 'radarr');
+                            const match = radarrServices.find(
+                              (s) => s.id === id
+                            );
+                            if (match) {
+                              getServiceInfos(match, 'radarr');
                             }
                           } else if (e.target.value.startsWith('sonarr-')) {
                             setFieldValue('radarrServiceId', null);
                             setFieldValue('sonarrServiceId', id);
-                            if (sonarrServices[id]) {
-                              getServiceInfos(sonarrServices[id], 'sonarr');
+                            const match = sonarrServices.find(
+                              (s) => s.id === id
+                            );
+                            if (match) {
+                              getServiceInfos(match, 'sonarr');
                             }
                           } else {
                             setFieldValue('radarrServiceId', null);


### PR DESCRIPTION
## Description
This PR is fixes a bug in the Override Rules modal where dropdowns (Root Folder, Quality Profile, Tags) would remain greyed out when editing an existing rule or selecting a service. The root cause was that `radarrServices` and `sonarrServices` were being looked up by array index using the service ID, which only worked by coincidence when the ID matched the index and most commonly broken after a user deletes and re-adds a service, causing the ID to increment while the array index stays at 0. Replaced the index lookups with `.find()` to correctly resolve services by their ID. 

## How Has This Been Tested?
- This has been tested by the reported user and they have confirmed that it works:
<img width="901" height="691" alt="image" src="https://github.com/user-attachments/assets/26630735-ea61-4206-bd10-76dcbb25fff3" />

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved service lookup mechanism in settings to enhance reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->