### PR TITLE
fix(media-request): remove cascade from modifiedBy to prevent user column wipe

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -534,7 +534,6 @@ export class MediaRequest {
 
   @ManyToOne(() => User, {
     nullable: true,
-    cascade: true,
     eager: true,
     onDelete: 'SET NULL',
   })


### PR DESCRIPTION
## Description
This PR removes `cascade: true` from the `MediaRequest.modifiedBy` column decorator. The option has been load-bearing for nothing since the day it was added, but under a specific combination of circumstances it wipes `select: false` columns on the User row (particularly the `password` field used for local logins).

When TypeORM walks the cascade graph while saving a MediaRequest, it treats the attached User as a subject that needs syncing. The change-detection step reads property values off the in-memory instance; any column whose property reads as `undefined` gets NULLed. The `select: false` columns are exactly in that shape as the properties exist on the entity instance (hydrated via `RawSqlResultsToEntityTransformer`) but hold `undefined` because they weren't SELECTed. So every `select: false` column gets NULLed when the cascade fires, while `plexToken` which was loaded via `addSelect` matches its snapshot and is excluded from the UPDATE.

The caller that reaches this bug in production is the Plex Watchlist Sync. [It loads users with createQueryBuilder + addSelect('user.plexToken')](https://github.com/seerr-team/seerr/blob/develop/server/lib/watchlistsync.ts#L20-L26), then iterates the watchlist and calls `MediaRequest.request(...)` for each item. For admins with `MANAGE_REQUESTS` or `AUTO_APPROVE*`, that method assigns `modifiedBy: user`, triggering the cascade. When 2 or more items are added via the sync simultaneously, the first iteration saves cleanly but from the second iteration onward, the cascade subject builder emits an UPDATE whose SET clause contains exactly the five `select: false` columns. This was caught by a `pgaudit` capture (thanks @kenlasko!):
```
{"level":"info","ts":"2026-04-18T22:03:01.898220818Z","logger":"pgaudit","msg":"record","logging_pod":"home-2","record":{"log_time":"2026-04-18 22:03:01.898 UTC","user_name":"seerr","database_name":"seerr","process_id":"357046","connection_from":"10.244.6.78:36240","session_id":"69e3ff95.572b6","session_line_num":"1","command_tag":"UPDATE","session_start_time":"2026-04-18 22:03:01 UTC","virtual_transaction_id":"98/9812","transaction_id":"19990572","error_severity":"LOG","sql_state_code":"00000","backend_type":"client backend","query_id":"0","audit":{"audit_type":"OBJECT","statement_id":"1","substatement_id":"1","class":"WRITE","command":"UPDATE","object_type":"TABLE","object_name":"public.\"user\"","statement":"UPDATE \"user\" SET \"password\" = $1, \"resetPasswordGuid\" = $2, \"jellyfinDeviceId\" = $3, \"jellyfinAuthToken\" = $4, \"plexToken\" = $5, \"updatedAt\" = CURRENT_TIMESTAMP WHERE \"id\" IN ($6) RETURNING \"updatedAt\"","parameter":",,,,eVK1MWsMfCRVnpaX1XBD,1"}}}
```

The bug has been latent for ~3.5 years and went unreported because the trigger conditions are a tiny intersection, and because the symptom is invisible for the vast majority of users who hit it. The cascade option was added in [236c4e5](https://github.com/sct/overseerr/commit/236c4e5e6126d2424a4badc08b7f7e6d1d70f401) (Nov 2020) but reached nothing until [301f2bf](https://github.com/sct/overseerr/commit/301f2bf7ab0c5e7c5aef9d78a58d6449df0f55b8) shipped watchlist sync in Aug 2022, and even then was safe by accident until [ef41102](https://github.com/sct/overseerr/commit/ef41102) rewrote the loader the same day to fix an unrelated displayName bug.

Trigger conditions are narrow (and probably why it took this long to surface):
- The user must have `MANAGE_REQUESTS` or `AUTO_APPROVE*` (so `modifiedBy: user` is assigned).
- Plex Watchlist Sync must be enabled.
- The watchlist must have 2+ unavailable items when sync runs (the first save is clean and only subsequent ones wipe).
- The user must have a local password set. `jellyfinAuthToken` / `jellyfinDeviceId` are always NULL for users who reach watchlist sync since it's Plex-only, and `resetPasswordGuid` is only set during an active 24h reset window. So in practice the only observable symptom is "admin had a local password, now it's gone" which is a rare intersection since most Plex admins who uses the plex watchlist sync integration mainly relies of Plex Oauth.

The fix in this PR matches `Issue.modifiedBy` which has worked correctly with this shape since 2021.

- Fixes #2841

## How Has This Been Tested?
The bug was reproduced by testing manually and the fix was also verified by testing manually using the following steps:
1. Set a local password on the admin account
2. Go to plex and add **multiple** movies to watchlist (2+) before the next watchlist sync triggers
3. Trigger or wait for watchlist sync to trigger

I also wrote a small test case to test this which also verified the fix though not sure if worth adding it.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data integrity handling for media request modifications by adjusting relationship management to prevent unintended data cascading while preserving proper cleanup and null handling when references are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->