### PR TITLE
fix(entity): set the default value of UpdateDateColumn to CURRENT_TIMESTAMP

### DIFF
--- a/server/entity/DiscoverSlider.ts
+++ b/server/entity/DiscoverSlider.ts
@@ -58,7 +58,10 @@ class DiscoverSlider {
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   public createdAt: Date;
 
-  @UpdateDateColumn({ type: resolveDbType('datetime') })
+  @UpdateDateColumn({
+    type: resolveDbType('datetime'),
+    default: () => 'CURRENT_TIMESTAMP',
+  })
   public updatedAt: Date;
 
   constructor(init?: Partial<DiscoverSlider>) {

--- a/server/entity/Issue.ts
+++ b/server/entity/Issue.ts
@@ -64,7 +64,10 @@ class Issue {
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   public createdAt: Date;
 
-  @UpdateDateColumn({ type: resolveDbType('datetime') })
+  @UpdateDateColumn({
+    type: resolveDbType('datetime'),
+    default: () => 'CURRENT_TIMESTAMP',
+  })
   public updatedAt: Date;
 
   @AfterLoad()

--- a/server/entity/IssueComment.ts
+++ b/server/entity/IssueComment.ts
@@ -34,7 +34,10 @@ class IssueComment {
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   public createdAt: Date;
 
-  @UpdateDateColumn({ type: resolveDbType('datetime') })
+  @UpdateDateColumn({
+    type: resolveDbType('datetime'),
+    default: () => 'CURRENT_TIMESTAMP',
+  })
   public updatedAt: Date;
 
   constructor(init?: Partial<IssueComment>) {

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -130,7 +130,10 @@ class Media {
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   public createdAt: Date;
 
-  @UpdateDateColumn({ type: resolveDbType('datetime') })
+  @UpdateDateColumn({
+    type: resolveDbType('datetime'),
+    default: () => 'CURRENT_TIMESTAMP',
+  })
   public updatedAt: Date;
 
   /**

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -543,7 +543,10 @@ export class MediaRequest {
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   public createdAt: Date;
 
-  @UpdateDateColumn({ type: resolveDbType('datetime') })
+  @UpdateDateColumn({
+    type: resolveDbType('datetime'),
+    default: () => 'CURRENT_TIMESTAMP',
+  })
   public updatedAt: Date;
 
   @Column({ type: 'varchar' })

--- a/server/entity/OverrideRule.ts
+++ b/server/entity/OverrideRule.ts
@@ -41,7 +41,10 @@ class OverrideRule {
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   public createdAt: Date;
 
-  @UpdateDateColumn({ type: resolveDbType('datetime') })
+  @UpdateDateColumn({
+    type: resolveDbType('datetime'),
+    default: () => 'CURRENT_TIMESTAMP',
+  })
   public updatedAt: Date;
 
   constructor(init?: Partial<OverrideRule>) {

--- a/server/entity/Season.ts
+++ b/server/entity/Season.ts
@@ -33,7 +33,10 @@ class Season {
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   public createdAt: Date;
 
-  @UpdateDateColumn({ type: resolveDbType('datetime') })
+  @UpdateDateColumn({
+    type: resolveDbType('datetime'),
+    default: () => 'CURRENT_TIMESTAMP',
+  })
   public updatedAt: Date;
 
   constructor(init?: Partial<Season>) {

--- a/server/entity/SeasonRequest.ts
+++ b/server/entity/SeasonRequest.ts
@@ -30,7 +30,10 @@ class SeasonRequest {
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   public createdAt: Date;
 
-  @UpdateDateColumn({ type: resolveDbType('datetime') })
+  @UpdateDateColumn({
+    type: resolveDbType('datetime'),
+    default: () => 'CURRENT_TIMESTAMP',
+  })
   public updatedAt: Date;
 
   constructor(init?: Partial<SeasonRequest>) {

--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -150,7 +150,10 @@ export class User {
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   public createdAt: Date;
 
-  @UpdateDateColumn({ type: resolveDbType('datetime') })
+  @UpdateDateColumn({
+    type: resolveDbType('datetime'),
+    default: () => 'CURRENT_TIMESTAMP',
+  })
   public updatedAt: Date;
 
   public warnings: string[] = [];

--- a/server/entity/Watchlist.ts
+++ b/server/entity/Watchlist.ts
@@ -61,7 +61,10 @@ export class Watchlist implements WatchlistItem {
   @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   public createdAt: Date;
 
-  @UpdateDateColumn({ type: resolveDbType('datetime') })
+  @UpdateDateColumn({
+    type: resolveDbType('datetime'),
+    default: () => 'CURRENT_TIMESTAMP',
+  })
   public updatedAt: Date;
 
   constructor(init?: Partial<Watchlist>) {


### PR DESCRIPTION
## Description

Fix future TypeORM migrations by explicitly setting the default value for `@UpdateDateColumn` to `CURRENT_TIMESTAMP` across all entities. This prevents migrations from incorrectly generating with `datetime('now')`.

- Re #2823

## How Has This Been Tested?

Try to generate a TypeORM migration before/after with:
`pnpm migration:generate test`

The migration after this change doesn't contain all the changes on the `updatedAt` columns.

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database timestamp field configurations across core entities to include explicit default values, ensuring consistent initialization behavior when records are created and modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->