### PR TITLE
refactor(logs): align failed login attempt message with failed sign-i…

### DIFF
--- a/docs/extending-seerr/fail2ban.mdx
+++ b/docs/extending-seerr/fail2ban.mdx
@@ -14,7 +14,7 @@ To use Fail2ban with Seerr, create a new file named `seerr.local` in your Fail2b
 
 ```
 [Definition]
-failregex = .*\[warn\]\[API\]\: Failed sign-in attempt.*"ip":"<HOST>"
+failregex = .*\[warn\]\[(API|Auth)\]\: Failed sign-in attempt.*"ip":"<HOST>"
 ```
 
 You can then add a jail using this filter in `jail.local`. Please see the [Fail2ban documentation](https://github.com/fail2ban/fail2ban/wiki) for details on how to configure the jail.

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -536,7 +536,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
 
       case ApiErrorCode.InvalidCredentials:
         logger.warn(
-          'Failed login attempt from user with incorrect Jellyfin credentials',
+          'Failed sign-in attempt from user with incorrect Jellyfin credentials',
           {
             label: 'Auth',
             account: {
@@ -553,7 +553,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
 
       case ApiErrorCode.NotAdmin:
         logger.warn(
-          'Failed login attempt from user without admin permissions',
+          'Failed sign-in attempt from user without admin permissions',
           {
             label: 'Auth',
             account: {
@@ -569,7 +569,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
 
       case ApiErrorCode.NoAdminUser:
         logger.warn(
-          'Failed login attempt from user without admin permissions and no admin user exists',
+          'Failed sign-in attempt from user without admin permissions and no admin user exists',
           {
             label: 'Auth',
             account: {


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

Following https://github.com/seerr-team/seerr/issues/2831#issuecomment-4281781253

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

n/a

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted authentication error wording from “login” to “sign-in” for consistency in logs.

* **Documentation**
  * Updated the Fail2ban example filter to match failed sign-in log lines tagged as API or Auth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->