### PR TITLE
fix(jellyfin/emby): handle unprobed media as non-4k by default

### DIFF
--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -143,11 +143,13 @@ class JellyfinScanner
         });
       });
 
+      const hasUnknownResolution = !metadata.MediaSources || metadata.MediaSources.length === 0;
+      
       const mediaAddedAt = metadata.DateCreated
         ? new Date(metadata.DateCreated)
         : undefined;
 
-      if (hasOtherResolution || (!this.enable4kMovie && has4k)) {
+      if (hasOtherResolution || hasUnknownResolution || (!this.enable4kMovie && has4k)) {  
         await this.processMovie(tmdbId, {
           is4k: false,
           mediaAddedAt,


### PR DESCRIPTION
Allow import of unprobed media as non-4k by default.

<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

Resolves silent failure to add Movies in an Emby/Jellyfin library that were added via .strm files.  By default these platforms do not probe the media so the API calls fail to return any MediaStreams.  This patch allows these items to be added to the Seerr library as non-4k media by default instead of being silently skipped. 

Fixes https://github.com/seerr-team/seerr/issues/2917

## How Has This Been Tested?

I don't have a testing environment to recompile the code and run the patched version.  However, I tracked down the issue by hand to understand the failure.  I used Claude Opus 4.7 to analyze/verify my finding, wrote the patch, validated with with Claude and cross checked it with GPT-5.4. 

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [X] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.  
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of movies with missing or unavailable resolution metadata to ensure proper content processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->