### PR TITLE
fix(ntfy): remove undefined fields from ntfy payload

### DIFF
--- a/server/lib/notifications/agents/ntfy.ts
+++ b/server/lib/notifications/agents/ntfy.ts
@@ -95,15 +95,21 @@ class NtfyAgent
       click = `${applicationUrl}/${payload.media.mediaType}/${payload.media.tmdbId}`;
     }
 
-    return {
+    const ntfyPayload: Record<string, unknown> = {
       topic,
       priority,
       title,
       message,
       markdown: true,
-      attach,
-      click,
     };
+    if (attach) {
+      ntfyPayload.attach = attach;
+    }
+    if (click) {
+      ntfyPayload.click = click;
+    }
+
+    return ntfyPayload;
   }
 
   public shouldSend(): boolean {


### PR DESCRIPTION
## Description

Ntfy is returning HTTP 400 when we include `undefined` fields in the JSON payload. This PRs add those fields to the payload only when they are not empty.

- Fixes #2929

## How Has This Been Tested?

Try to send a test notification on ntfy:latest.

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized notification system's payload construction to ensure cleaner data structures and better handling of optional fields in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->